### PR TITLE
Allow for empty [optional] options and actually default them to their default

### DIFF
--- a/lib/commander.js
+++ b/lib/commander.js
@@ -291,7 +291,7 @@ Command.prototype.option = function(flags, description, fn, defaultValue){
         ? (option.bool
             ? defaultValue || true : false
         ) : val;
-    } else {
+    } else if (null !== val) {
         // reassign
         self[name] = val;
     }


### PR DESCRIPTION
This was something I had missed in the last pull request I made. This doesn't break anything, all tests still pass, it just allows for what is described in the title.
