### PR TITLE
Make version flags configurable

### DIFF
--- a/lib/commander.js
+++ b/lib/commander.js
@@ -506,6 +506,7 @@ Command.prototype.unknownOption = function(flag){
  * which will print the version number when passed.
  *
  * @param {String} str
+ * @param {String} flags
  * @return {Command} for chaining
  * @api public
  */


### PR DESCRIPTION
I would like to use '-v' for '--verbose' and only expose version as
'--version'. This change allows me to do this without changing the
defaults for everybody else.
