### PR TITLE
Fix: Long-only flags would not take values

### DIFF
--- a/lib/commander.js
+++ b/lib/commander.js
@@ -45,7 +45,7 @@ function Option(flags, description) {
   this.optional = ~flags.indexOf('[');
   this.bool = !~flags.indexOf('-no-');
   flags = flags.split(/[ ,|]+/);
-  if (flags.length > 1) this.short = flags.shift();
+  if (flags.length > 1 && !/^[[<]/.test(flags[1])) this.short = flags.shift();
   this.long = flags.shift();
   this.description = description;
 }

--- a/test/test.options.large-only-with-value.js
+++ b/test/test.options.large-only-with-value.js
@@ -1,0 +1,13 @@
+/**
+ * Module dependencies.
+ */
+
+var program = require('../')
+  , should = require('should');
+
+program
+  .version('0.0.1')
+  .option('--longflag [value]', 'A long only flag with a value');
+
+program.parse(['node', 'test', '--longflag', 'something']);
+program.longflag.should.equal('something');


### PR DESCRIPTION
For '--longflag [value]', '--longflag' was being mistaken for the
short option, and '[value]' as the long option. This patch fixes
this by checking if the second flag argument starts with [ or <
which indicates a value being expected.
