### PR TITLE
Added prompt tests and fixed four issues

### DIFF
--- a/lib/commander.js
+++ b/lib/commander.js
@@ -712,9 +712,10 @@ Command.prototype.helpInformation = function(){
  */
 
 Command.prototype.promptForNumber = function(str, fn){
-  this.promptSingleLine(str, function(val){
+  var self = this;
+  this.promptSingleLine(str, function parseNumber(val){
     val = Number(val);
-    if (isNaN(val)) return program.promptForNumber(str + '(must be a number) ', fn);
+    if (isNaN(val)) return self.promptSingleLine(str + '(must be a number) ', parseNumber);
     fn(val);
   });
 };
@@ -729,9 +730,9 @@ Command.prototype.promptForNumber = function(str, fn){
 
 Command.prototype.promptForDate = function(str, fn){
   var self = this;
-  this.promptSingleLine(str, function(val){
+  this.promptSingleLine(str, function parseDate(val){
     val = new Date(val);
-    if (isNaN(val.getTime())) return self.promptForDate(str + '(must be a date) ', fn);
+    if (isNaN(val.getTime())) return self.promptSingleLine(str + '(must be a date) ', parseDate);
     fn(val);
   });
 };
@@ -765,15 +766,16 @@ Command.prototype.promptSingleLine = function(str, fn){
  */
 
 Command.prototype.promptMultiLine = function(str, fn){
-  var buf = '';
+  var buf = [];
   console.log(str);
   process.stdin.setEncoding('utf8');
   process.stdin.on('data', function(val){
-    if ('\n' == val) {
+    //node on windows returns '\r\n'
+    if ('\n' == val || '\r\n' == val) {
       process.stdin.removeAllListeners('data');
-      fn(buf);
+      fn(buf.join('\n'));
     } else {
-      buf += val;
+      buf.push(val.replace(/\s+$/, ''));
     }
   }).resume();
 };

--- a/test/test.prompt.js
+++ b/test/test.prompt.js
@@ -1,0 +1,121 @@
+/**
+ * Module dependencies.
+ */
+
+var events = require('events')
+ ,  program = require('../')
+ ,  should = require('should');
+
+//mock stdin on process
+var stdin = new events.EventEmitter();
+stdin.setEncoding = stdin.resume = function() {};
+stdin.write = function(data) { stdin.emit('data', data); };
+process.__defineGetter__('stdin', function() { return stdin });
+
+//mock stdout on process
+var stdout = new events.EventEmitter();
+stdout.write = function(data) { this.emit('data', data) };
+stdout.expect = function(expected, fn) {
+  var actual = '';
+  this.once('data', function(data){ actual = data; });
+  fn();
+  actual.should.equal(expected);
+}
+//var realOut = process.stdout;
+process.__defineGetter__('stdout', function() { return stdout });
+
+var count = 0;
+var test = function(expected) {
+  count++;
+  return function(actual) {
+    count--;
+    if(expected instanceof Date) {
+      //need something better :(
+      //using `new Date(date.toString())` round trip
+      //loosing some precision for .getTime()
+      actual.should.be.an.instanceof(Date);
+    } else {
+      actual.should.equal(expected);
+    }
+  }
+}
+
+process.on('exit', function(){
+  count.should.equal(0);
+})
+
+/* Single Line String Prompt Tests */
+var prompt = 'hello '
+ ,  expected = 'world';
+
+// simple single line string 
+stdout.expect(prompt, function(){
+    program.prompt(prompt, test(expected));
+    stdin.write(expected);    
+})
+// with trim
+stdout.expect(prompt, function(){
+    program.prompt(prompt, test(expected));
+    stdin.write('      ' + expected + '      ');    
+})
+// newline
+stdout.expect(prompt, function(){
+    program.prompt(prompt, test(''));
+    stdin.write('\n');    
+})
+
+/* Multiline Tests*/
+var prompt = 'A multiline';
+stdout.expect(prompt + '\n', function() {
+  program.prompt(prompt, test('hello world\n  and what a world\nit could be'));
+  stdin.write('hello world\n');
+  stdin.write('  and what a world\n');
+  stdin.write('it could be\n');
+  stdin.write('\n');
+})
+
+/* Date Prompt Tests */
+var prompt = 'A date '
+ ,  expected = new Date();
+ 
+// simple date
+stdout.expect(prompt, function(){
+    program.prompt(prompt, Date, test(expected));
+    stdin.write(expected.toString());    
+})
+// not a date twice
+stdout.expect(prompt, function() {
+  program.prompt(prompt, Date, test(expected));
+  
+  stdout.expect(prompt + '(must be a date) ', function() {
+    stdin.write('blue');    
+  })
+  stdout.expect(prompt + '(must be a date) ', function() {
+    stdin.write('blue');    
+  })
+  stdin.write(expected.toString());    
+})
+
+/* Number Prompt Tests*/
+var prompt = 'A number '
+ ,  expected = 12;
+ 
+//simple number
+stdout.expect(prompt, function(){
+    program.prompt(prompt, Number, test(expected));
+    stdin.write(expected.toString());    
+})
+
+// not a number twice
+stdout.expect(prompt, function() {
+  program.prompt(prompt, Number, test(expected));
+  
+  stdout.expect(prompt + '(must be a number) ', function() {
+    stdin.write('blue');    
+  })
+  stdout.expect(prompt + '(must be a number) ', function() {
+    stdin.write('blue');    
+  })
+  stdin.write(expected.toString());    
+})
+


### PR DESCRIPTION
Getting started early on my new year's resolution to figure out how to do pull requests on github, so apologies in advance if I don't know what I'm doing.

In the `promptForNumber` method there was the use of undeclared `program` versus `self`. Turned into a bit of a yak shaving to create tests which then also needed stdin and stdout to be mock. Found three other issues along the way:

1) Supplemental prompts for non-dates and numbers kept adding additional "(must be a xxxx)" to the prompt string

2) Node on windows returns `\r\n` so multi-line wasn't working

3) Somewhat more qualitatively I changed multi-line to not return the extra `\n` at the end, but preserved leading whitespace.
