### PR TITLE
Add program.opts namespace for all options

### DIFF
--- a/lib/commander.js
+++ b/lib/commander.js
@@ -86,9 +86,9 @@ Option.prototype.is = function(arg){
 
 function Command(name) {
   this.commands = [];
-  this.options = [];
+  this.options = {};
+  this._options = [];
   this.args = [];
-  this.opts = {};
   this.name = name;
 }
 
@@ -303,11 +303,11 @@ Command.prototype.option = function(flags, description, fn, defaultValue){
 
   } else {
     // set opt to false otherwise
-    self.opts[name] = false;
+    self.options[name] = false;
   }
 
   // register the option
-  this.options.push(option);
+  this._options.push(option);
 
   // when it's passed assign the value
   // and conditionally invoke the callback
@@ -343,7 +343,7 @@ Command.prototype.option = function(flags, description, fn, defaultValue){
  * @api private
  */
 Command.prototype.assign = function(key, value) {
-  this.opts[key] = this[key] = value;
+  this.options[key] = this[key] = value;
   return this;
 };
 
@@ -441,9 +441,9 @@ Command.prototype.parseArgs = function(args, unknown){
  */
 
 Command.prototype.optionFor = function(arg){
-  for (var i = 0, len = this.options.length; i < len; ++i) {
-    if (this.options[i].is(arg)) {
-      return this.options[i];
+  for (var i = 0, len = this._options.length; i < len; ++i) {
+    if (this._options[i].is(arg)) {
+      return this._options[i];
     }
   }
 };
@@ -646,7 +646,7 @@ Command.prototype.usage = function(str){
  */
 
 Command.prototype.largestOptionLength = function(){
-  return this.options.reduce(function(max, option){
+  return this._options.reduce(function(max, option){
     return Math.max(max, option.flags.length);
   }, 0);
 };
@@ -663,7 +663,7 @@ Command.prototype.optionHelp = function(){
   
   // Prepend the help information
   return [pad('-h, --help', width) + '  ' + 'output usage information']
-    .concat(this.options.map(function(option){
+    .concat(this._options.map(function(option){
       return pad(option.flags, width)
         + '  ' + option.description;
       }))
@@ -691,7 +691,7 @@ Command.prototype.commandHelp = function(){
       }).join(' ');
 
       return cmd.name 
-        + (cmd.options.length 
+        + (cmd._options.length 
           ? ' [options]'
           : '') + ' ' + args
         + (cmd.description()

--- a/test/test.options.args.optional.given.js
+++ b/test/test.options.args.optional.given.js
@@ -11,4 +11,4 @@ program
 
 program.parse(['node', 'test', '--cheese', 'feta']);
 program.cheese.should.equal('feta');
-program.opts.cheese.should.equal('feta');
+program.options.cheese.should.equal('feta');

--- a/test/test.options.args.optional.js
+++ b/test/test.options.args.optional.js
@@ -11,4 +11,4 @@ program
 
 program.parse(['node', 'test', '--cheese']);
 program.cheese.should.be.true;
-program.opts.cheese.should.be.true;
+program.options.cheese.should.be.true;

--- a/test/test.options.bool.js
+++ b/test/test.options.bool.js
@@ -15,5 +15,5 @@ program.parse(['node', 'test', '--pepper']);
 program.pepper.should.be.true;
 program.cheese.should.be.true;
 
-program.opts.pepper.should.be.true;
-program.opts.cheese.should.be.true;
+program.options.pepper.should.be.true;
+program.options.cheese.should.be.true;

--- a/test/test.options.bool.no.js
+++ b/test/test.options.bool.no.js
@@ -13,4 +13,4 @@ program
 program.parse(['node', 'test', '--no-cheese']);
 should.equal(undefined, program.pepper);
 program.cheese.should.be.false;
-program.opts.cheese.should.be.false;
+program.options.cheese.should.be.false;

--- a/test/test.options.bool.small.combined.js
+++ b/test/test.options.bool.small.combined.js
@@ -14,5 +14,5 @@ program.parse(['node', 'test', '-pc']);
 program.pepper.should.be.true;
 program.cheese.should.be.false;
 
-program.opts.pepper.should.be.true;
-program.opts.cheese.should.be.false;
+program.options.pepper.should.be.true;
+program.options.cheese.should.be.false;

--- a/test/test.options.bool.small.js
+++ b/test/test.options.bool.small.js
@@ -14,5 +14,5 @@ program.parse(['node', 'test', '-p', '-c']);
 program.pepper.should.be.true;
 program.cheese.should.be.false;
 
-program.opts.pepper.should.be.true;
-program.opts.cheese.should.be.false;
+program.options.pepper.should.be.true;
+program.options.cheese.should.be.false;

--- a/test/test.options.camelcase.js
+++ b/test/test.options.camelcase.js
@@ -26,9 +26,9 @@ program.myVeryLongFloat.should.equal(6.5);
 program.myURLCount.should.equal(7.5);
 program.myLongRange.should.eql([1,5]);
 
-program.opts.myInt.should.equal(5);
-program.opts.myNum.should.equal(15.99);
-program.opts.myFLOAT.should.equal(5.5);
-program.opts.myVeryLongFloat.should.equal(6.5);
-program.opts.myURLCount.should.equal(7.5);
-program.opts.myLongRange.should.eql([1,5]);
+program.options.myInt.should.equal(5);
+program.options.myNum.should.equal(15.99);
+program.options.myFLOAT.should.equal(5.5);
+program.options.myVeryLongFloat.should.equal(6.5);
+program.options.myURLCount.should.equal(7.5);
+program.options.myLongRange.should.eql([1,5]);

--- a/test/test.options.coercion.js
+++ b/test/test.options.coercion.js
@@ -22,7 +22,7 @@ program.num.should.equal(15.99);
 program.float.should.equal(5.5);
 program.range.should.eql([1,5]);
 
-program.opts.int.should.equal(5);
-program.opts.num.should.equal(15.99);
-program.opts.float.should.equal(5.5);
-program.opts.range.should.eql([1,5]);
+program.options.int.should.equal(5);
+program.options.num.should.equal(15.99);
+program.options.float.should.equal(5.5);
+program.options.range.should.eql([1,5]);

--- a/test/test.options.defaults.given.js
+++ b/test/test.options.defaults.given.js
@@ -22,9 +22,9 @@ program.should.have.property('sauce', false);
 program.should.have.property('crust', 'thin');
 program.should.have.property('cheese', 'wensleydale');
 
-program.opts.should.have.property('anchovies', true);
-program.opts.should.have.property('onions', true);
-program.opts.should.have.property('olives', 'black');
-program.opts.should.have.property('sauce', false);
-program.opts.should.have.property('crust', 'thin');
-program.opts.should.have.property('cheese', 'wensleydale');
+program.options.should.have.property('anchovies', true);
+program.options.should.have.property('onions', true);
+program.options.should.have.property('olives', 'black');
+program.options.should.have.property('sauce', false);
+program.options.should.have.property('crust', 'thin');
+program.options.should.have.property('cheese', 'wensleydale');

--- a/test/test.options.defaults.js
+++ b/test/test.options.defaults.js
@@ -22,9 +22,9 @@ program.should.have.property('sauce', true);
 program.should.have.property('crust', 'hand-tossed');
 program.should.have.property('cheese', 'mozzarella');
 
-program.opts.should.have.property('anchovies', false);
-program.opts.should.have.property('onions', false);
-program.opts.should.have.property('olives', false);
-program.opts.should.have.property('sauce', true);
-program.opts.should.have.property('crust', 'hand-tossed');
-program.opts.should.have.property('cheese', 'mozzarella');
+program.options.should.have.property('anchovies', false);
+program.options.should.have.property('onions', false);
+program.options.should.have.property('olives', false);
+program.options.should.have.property('sauce', true);
+program.options.should.have.property('crust', 'hand-tossed');
+program.options.should.have.property('cheese', 'mozzarella');

--- a/test/test.options.defaults.not.given.js
+++ b/test/test.options.defaults.not.given.js
@@ -23,9 +23,9 @@ program.should.have.property('sauce', true);
 program.should.have.property('crust', 'hand-tossed');
 program.should.have.property('cheese', 'mozzarella');
 
-program.opts.should.have.property('anchovies', false);
-program.opts.should.have.property('onions', false);
-program.opts.should.have.property('olives', 'black');
-program.opts.should.have.property('sauce', true);
-program.opts.should.have.property('crust', 'hand-tossed');
-program.opts.should.have.property('cheese', 'mozzarella');
+program.options.should.have.property('anchovies', false);
+program.options.should.have.property('onions', false);
+program.options.should.have.property('olives', 'black');
+program.options.should.have.property('sauce', true);
+program.options.should.have.property('crust', 'hand-tossed');
+program.options.should.have.property('cheese', 'mozzarella');

--- a/test/test.options.large-only-with-value.js
+++ b/test/test.options.large-only-with-value.js
@@ -12,4 +12,4 @@ program
 program.parse(['node', 'test', '--longflag', 'something']);
 program.longflag.should.equal('something');
 
-program.opts.longflag.should.equal('something');
+program.options.longflag.should.equal('something');

--- a/test/test.options.large-only.js
+++ b/test/test.options.large-only.js
@@ -12,4 +12,4 @@ program
 program.parse(['node', 'test', '--verbose']);
 program.verbose.should.be.true;
 
-program.opts.verbose.should.be.true;
+program.options.verbose.should.be.true;


### PR DESCRIPTION
Add `opts` namespace, which holds all options and values. Unlike the Commander object itself, it will have values for all options. Addresses open issues #29 and #19.

Includes updates to existing test suite.
