### PR TITLE
Allow multiple arguments to a command

### DIFF
--- a/lib/commander.js
+++ b/lib/commander.js
@@ -172,9 +172,11 @@ Command.prototype.parseExpectedArgs = function(args){
     switch (arg[0]) {
       case '<':
 		argDef.required = true;
+        //self.args.push({ required: true, name: arg.slice(1, -1) });
         break;
       case '[':
 		argDef.required = false;
+        //self.args.push({ required: false, name: arg.slice(1, -1) });
         break;
     }
 	
@@ -230,16 +232,27 @@ Command.prototype.action = function(fn){
       if (arg.required && null == args[i]) {
         self.missingArgument(arg.name);
       }
+	  
+	  //detect an argument that supports multiple values:
 	  if (arg.multi) multiAllowed = true;
     });
-    
+	
+	//alter final arguments into an array (only if they exist and we are expected multi)
+	if (self.args.length && multiAllowed) {
+		var arrayArg = [];
+		for (var i=self.args.length-1;i<args.length;i++)
+			arrayArg.push(args[i]);
+		
+		args[self.args.length-1] = arrayArg;
+	}
+	
     // Always append ourselves to the end of the arguments,
     // to make sure we match the number of arguments the user
     // expects
-    if (self.args.length && !multiAllowed) {
-      args[self.args.length] = self;
+    if (self.args.length) {
+		args[self.args.length] = self;
     } else {
-      args.push(self);
+		args.push(self);
     }
 
     fn.apply(this, args);
@@ -725,10 +738,9 @@ Command.prototype.helpInformation = function(){
  */
 
 Command.prototype.promptForNumber = function(str, fn){
-  var self = this;
-  this.promptSingleLine(str, function parseNumber(val){
+  this.promptSingleLine(str, function(val){
     val = Number(val);
-    if (isNaN(val)) return self.promptSingleLine(str + '(must be a number) ', parseNumber);
+    if (isNaN(val)) return program.promptForNumber(str + '(must be a number) ', fn);
     fn(val);
   });
 };
@@ -743,9 +755,9 @@ Command.prototype.promptForNumber = function(str, fn){
 
 Command.prototype.promptForDate = function(str, fn){
   var self = this;
-  this.promptSingleLine(str, function parseDate(val){
+  this.promptSingleLine(str, function(val){
     val = new Date(val);
-    if (isNaN(val.getTime())) return self.promptSingleLine(str + '(must be a date) ', parseDate);
+    if (isNaN(val.getTime())) return self.promptForDate(str + '(must be a date) ', fn);
     fn(val);
   });
 };
@@ -779,15 +791,15 @@ Command.prototype.promptSingleLine = function(str, fn){
  */
 
 Command.prototype.promptMultiLine = function(str, fn){
-  var buf = [];
+  var buf = '';
   console.log(str);
   process.stdin.setEncoding('utf8');
   process.stdin.on('data', function(val){
-    if ('\n' == val || '\r\n' == val) {
+    if ('\n' == val) {
       process.stdin.removeAllListeners('data');
-      fn(buf.join('\n'));
+      fn(buf);
     } else {
-      buf.push(val.trimRight());
+      buf += val;
     }
   }).resume();
 };
@@ -855,7 +867,6 @@ Command.prototype.password = function(str, mask, fn){
     mask = '';
   }
 
-  process.stdin.resume();
   tty.setRawMode(true);
   process.stdout.write(str);
 


### PR DESCRIPTION
This change adds support for using "..." on a command parameter to represent it supporting multiple space-separated values.  This allows us to support patterns like `apt-get install package1 package2 package3` .

The parameters are passed as arguments to the action for that command.  For example:

```
program
  .command("install <packages...>")
  .action(function(packages) {
    console.log('We have ' + packages.length + ' packages to install');
  });

```
