### PR TITLE
Changed choose method so it can now return a default item if none is spe...

### DIFF
--- a/lib/commander.js
+++ b/lib/commander.js
@@ -910,15 +910,14 @@ Command.prototype.confirm = function(str, fn){
  * @api public
  */
 
-Command.prototype.choose = function(list, fn) {
+Command.prototype.choose = function(list, def, fn) {
   var self = this;
   var def_item = 0;
 
-  list.forEach(function(item, i) {
-    if (item[0] == '>') { 
-      def_item = i;
-      list[i] = item.slice(1);
+  typeof(def)=='function' ? fn = def : def_item = def - 1;
 
+  list.forEach(function(item, i) {
+    if (i == def_item) {
       console.log('> %d) %s', i + 1, list[i]);
     } else {
       console.log('  %d) %s', i + 1, item);
@@ -932,7 +931,7 @@ Command.prototype.choose = function(list, fn) {
       } else {
         val = parseInt(val, 10) - 1;
 
-        if (list[val] !== undefined) {
+	if (list[val] !== undefined) {
 	  fn(val, list[val]);
 	} else {
 	  again();


### PR DESCRIPTION
By default the first item is set as default, but another one can be set by adding ">" as it's prefix.
If is set an index higher than items count than again() is called.

Ex:
items = ['one', 'two', 'three', 'four', 'five']; // will return 'one' if none is specified
items = ['one', 'two', 'three', '>four', 'five']; // will return 'four' as default
