### PR TITLE
allow node.js v0.7.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,5 +9,5 @@
   , "devDependencies": { "should": ">= 0.0.1" }
   , "scripts": { "test": "make test" }
   , "main": "index"
-  , "engines": { "node": ">= 0.4.x < 0.7.0" }
+  , "engines": { "node": ">= 0.4.x" }
 }


### PR DESCRIPTION
Is this just a package.json misconfiguration? This is breaking a simple `npm install express`, with node v0.7.x, because `express` specifies `0.6.0` of `commander.js`. Installing commander directly works, but falls back to an older version.
