### PR TITLE
Adding parsedOptions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,6 +12,11 @@
 
  Options with commander are defined with the `.option()` method, also serving as documentation for the options. The example below parses args and options from `process.argv`, leaving remaining args as the `program.args` array which were not consumed by options.
 
+In addition, since the program object has a number of other
+properties associated with it, the simple
+list of options that were parsed from the command line can
+be read from program.parsedOptions.
+
 ```js
 #!/usr/bin/env node
 
@@ -33,6 +38,8 @@ console.log('you ordered a pizza with:');
 if (program.peppers) console.log('  - peppers');
 if (program.pineapple) console.log('  - pineappe');
 if (program.bbq) console.log('  - bbq');
+//access via .parsedOptions
+if (program.parsedOptions['bbq']) console.log('  - bbq');
 console.log('  - %s cheese', program.cheese);
 ```
 

--- a/lib/commander.js
+++ b/lib/commander.js
@@ -87,6 +87,7 @@ Option.prototype.is = function(arg){
 function Command(name) {
   this.commands = [];
   this.options = [];
+  this.parsedOptions = {};
   this.args = [];
   this.name = name;
 }
@@ -323,6 +324,7 @@ Command.prototype.option = function(flags, description, fn, defaultValue){
       // reassign
       self[name] = val;
     }
+    self.parsedOptions[name] = self[name];
   });
 
   return this;


### PR DESCRIPTION
Hey,
  Thanks for Commander.  Made adding option parsing to a utility a breeze.

  One issue we've had is that it's difficult to distinguish parsed-options from other-stuff in the program object.  In particular, I want to be able to do _.keys(program.options) in order to get a simple list of options.  e.g. I only want to see that 'keyword' was parsed, but the program object has a bunch of other stuff making it difficult to pick out the :

{ commands: [],
  options: 
   [ { flags: '-V, --version', required: 0, optional: 0, bool: true, short: '-V', long: '--version', description: 'output the version number' },,
  args: [],
  name: 'main.coffee',
  Command: [Function: Command],
  Option: [Function: Option],
  _version: '0.0.1',
  _events:    { version: [ [Function], [Function] ],...},
  rawArgs:    [ 'coffee',...],
  keyword: 'game' }

  This pull request adds a .parsedOptions properties that contains only the options parsed from the command line.  This way, properties can be accessed as program.keyword or program.parsedOptions.keyword, and my _.keys(program.parsedOptions) will work fine.