### PR TITLE
Required options can be bypassed

### DIFF
--- a/lib/commander.js
+++ b/lib/commander.js
@@ -458,6 +458,9 @@ Command.prototype.parseOptions = function(argv){
     , option
     , arg;
 
+  outputHelpIfNecessary(this, argv);
+
+
   var unknownOptions = [];
 
   // Ensure our required arguments exist at minimum


### PR DESCRIPTION
This implements a fix where it will ensure that at minimum the required options are enforced. Before, I could omit the required options and it would act like an optional option.

this.required = ~flags.indexOf('<');

these line of code were the initial problem because it will return 0 for index doesn't exist or a negative number if it does exist which isn't correct logic probably so it was changed to return a simple true or false.

Then logic was missing to ensure required options were even provided and that was added and tested
