### PR TITLE
Incorrectly guessed parameters to boolean options should be arguments to a command.

### DIFF
--- a/lib/commander.js
+++ b/lib/commander.js
@@ -213,6 +213,20 @@ Command.prototype.action = function(fn){
       self.unknownOption(parsed.unknown[0]);
     }
     
+    // Any remaining arguments in parsed.args were originally thought
+    // to be tied to options, but ended up being tied to the original
+    // command.
+    if (parsed.args.length > 0) {
+      parsed.args.forEach(function(arg, index) {
+        // For each argument that is inserted, the insertionIndex gets
+        // offset by one for future arguments. In order to compensate
+        // for this, simply add in the index of this argument in
+        // parsed.args to the insertionIndex, as this represents how
+        // many arguments have been inserted prior to this one.
+        args.splice(arg.insertionIndex + index - 1, 0, arg.value);
+      });
+    }
+    
     self.args.forEach(function(arg, i){
       if (arg.required && null == args[i]) {
         self.missingArgument(arg.name);
@@ -461,7 +475,10 @@ Command.prototype.parseOptions = function(argv){
       continue;
     }
 
-    if (literal) {
+    // Object arguments were parameters that were guessed
+    // to be tied to an option, but actually turned out to
+    // be arguments to the command. Pass them on as such.
+    if (literal || 'object' == typeof arg) {
       args.push(arg);
       continue;
     }
@@ -475,11 +492,16 @@ Command.prototype.parseOptions = function(argv){
       if (option.required) {
         arg = argv[++i];
         if (null == arg) return this.optionMissingArgument(option);
+        if ('object' == typeof arg) arg = arg.value;
         if ('-' == arg[0]) return this.optionMissingArgument(option, arg);
         this.emit(option.name(), arg);
       // optional arg
       } else if (option.optional) {
         arg = argv[i+1];
+        if ('object' == typeof arg) {
+          arg = arg.value;
+        }
+        
         if (null == arg || '-' == arg[0]) {
           arg = null;
         } else {
@@ -501,7 +523,15 @@ Command.prototype.parseOptions = function(argv){
       // an argument for this option, we pass it on.
       // If it isn't, then it'll simply be ignored
       if (argv[i+1] && '-' != argv[i+1][0]) {
-        unknownOptions.push(argv[++i]);
+        // This option could take no parameters, at which point
+        // the next argument is really for the command rather than
+        // the option. Thus, maintain the argument along with the
+        // location to insert it into the args array if necessary
+        // later on.
+        unknownOptions.push({
+          value: argv[++i],
+          insertionIndex: args.length
+        });
       }
       continue;
     }


### PR DESCRIPTION
To illustrate the issue, consider the simple command below that prints the string it is given. Call this file cmd.js:

``` js
#!/usr/bin/env node
var program = require('commander');

program.command('print <str>')
  .option('-e, --example', 'Example boolean option')
  .action(function(str, env) {
    console.log(str);
  });

program.parse(process.argv);
```

When run without any options, it works fine. The problem arises when the `-e` or `--example` boolean option is provided before the input `<str>`, like so:

``` bash
$ ./cmd.js print hello
# => hello

$ ./cmd.js print -e hello
# => error: missing required argument `str'
```

Even though `-e` is a boolean option, "hello" is guessed to be its argument in the `lib/commander.js` on [line 504](https://github.com/visionmedia/commander.js/blob/72344894f09cadaa7cc4bf8ab3fa51a790a72878/lib/commander.js#L504):

``` js
// looks like an option
if (arg.length > 1 && '-' == arg[0]) {
  unknownOptions.push(arg);

  // If the next argument looks like it might be
  // an argument for this option, we pass it on.
  // If it isn't, then it'll simply be ignored
  if (argv[i+1] && '-' != argv[i+1][0]) {
    unknownOptions.push(argv[++i]);
  }
  continue;
}
```

The "hello" argument is then ignored, which makes the command fail.

I have fixed this issue in the latest commit below by reinserting incorrectly guessed option parameters back into the arguments array for a command. Let me know if you have any questions about the code and if there any changes I need to make.

I also noticed that the date test in `test.prompt.js` was failing. It seems to be that this line:

``` js
actual.should.be.an.instanceof(Date);
```

was acting up even though `actual` was indeed an instance of `Date`. In fact, I changed it to:

``` js
(new Date()).should.be.an.instanceof(Date);
```

and it still failed. As a result, I modified the test to use `should.equal(true)` instead, like so:

``` js
(actual instanceof Date).should.equal(true);
```

and it passed.

Update: I've omitted the test fix above to make this pull request focus on just one issue. Let me know if you'd like another pull request for the tests; it's just a minor bug anyway.

I've been using commander.js for one of my personal projects and have been pleased with its robustness. I'd love to fix these issues and give back. Don't hesitate if you have any questions or need me to modify something.
