### PR TITLE
Fix issue #56 where options parsing strips off arguments that it shouldn't

### DIFF
--- a/lib/commander.js
+++ b/lib/commander.js
@@ -213,6 +213,12 @@ Command.prototype.action = function(fn){
       self.unknownOption(parsed.unknown[0]);
     }
     
+    // Leftover arguments need to be pushed back onto the args stack
+    // Fixes issue #56
+    if (parsed.args.length > 0) {
+        args = parsed.args.concat(args);
+    }
+    
     self.args.forEach(function(arg, i){
       if (arg.required && null == args[i]) {
         self.missingArgument(arg.name);


### PR DESCRIPTION
Leftover arguments need to be pushed back onto the args stack. Makes
sure that options don't strip of arguments they shouldn't.
