### PR TITLE
Add support for equal sign

### DIFF
--- a/lib/commander.js
+++ b/lib/commander.js
@@ -376,7 +376,12 @@ Command.prototype.normalize = function(args){
         ret.push('-' + c);
       });
     } else {
-      ret.push(arg);
+      var index = arg.indexOf('=');
+      if (~index) {
+        ret.push(arg.slice(0, index), arg.slice(index + 1));
+      } else {
+        ret.push(arg);
+      }
     }
   }
 

--- a/test/test.options.equals.js
+++ b/test/test.options.equals.js
@@ -1,0 +1,15 @@
+/**
+ * Module dependencies.
+ */
+
+var program = require('../')
+  , should = require('should');
+
+program
+  .version('0.0.1')
+  .option('--string <n>', 'pass a string')
+  .option('--num <n>', 'pass a number', Number)
+
+program.parse('node test --string=Hello --num=5.5'.split(' '));
+program.string.should.equal('Hello');
+program.num.should.equal(5.5);


### PR DESCRIPTION
This allows you to write

```
node test --string=Hello
```

which behaves the same as:

```
node test --string Hello
```

This is achieved by updating the normalize method.
