### PR TITLE
Add support for equal sign

### DIFF
--- a/lib/commander.js
+++ b/lib/commander.js
@@ -359,6 +359,7 @@ Command.prototype.parse = function(argv){
 /**
  * Normalize `args`, splitting joined short flags. For example
  * the arg "-abc" is equivalent to "-a -b -c".
+ * This also normalizes equal sign and splits "--abc=def" into "--abc def".
  *
  * @param {Array} args
  * @return {Array}
@@ -367,7 +368,8 @@ Command.prototype.parse = function(argv){
 
 Command.prototype.normalize = function(args){
   var ret = []
-    , arg;
+    , arg
+    , index;
 
   for (var i = 0, len = args.length; i < len; ++i) {
     arg = args[i];
@@ -375,6 +377,8 @@ Command.prototype.normalize = function(args){
       arg.slice(1).split('').forEach(function(c){
         ret.push('-' + c);
       });
+    } else if (/^--/.test(arg) && ~(index = arg.indexOf('='))) {
+      ret.push(arg.slice(0, index), arg.slice(index + 1));
     } else {
       ret.push(arg);
     }

--- a/test/test.options.equals.js
+++ b/test/test.options.equals.js
@@ -1,0 +1,17 @@
+/**
+ * Module dependencies.
+ */
+
+var program = require('../')
+  , should = require('should');
+
+program
+  .version('0.0.1')
+  .option('--string <n>', 'pass a string')
+  .option('--string2 <n>', 'pass another string')
+  .option('--num <n>', 'pass a number', Number)
+
+program.parse('node test --string=Hello --string2 Hello=World --num=5.5'.split(' '));
+program.string.should.equal('Hello');
+program.string2.should.equal('Hello=World');
+program.num.should.equal(5.5);


### PR DESCRIPTION
This allows you to write

```
node test --string=Hello
```

which behaves the same as:

```
node test --string Hello
```

This is achieved by updating the normalize method.
