### PR TITLE
Add outputHelp method to Command object.

### DIFF
--- a/lib/commander.js
+++ b/lib/commander.js
@@ -971,6 +971,18 @@ Command.prototype.choose = function(list, index, fn){
   again();
 };
 
+
+/**
+ * Output help information for this command
+ *
+ * @api public
+ */
+
+Command.prototype.outputHelp = function() {
+  process.stdout.write(this.helpInformation());
+  this.emit('--help');
+}
+
 /**
  * Camel-case the given `flag`
  *
@@ -1023,8 +1035,7 @@ function outputHelpIfNecessary(cmd, options) {
   options = options || [];
   for (var i = 0; i < options.length; i++) {
     if (options[i] == '--help' || options[i] == '-h') {
-      process.stdout.write(cmd.helpInformation());
-      cmd.emit('--help');
+      cmd.outputHelp();
       process.exit(0);
     }
   }


### PR DESCRIPTION
Addresses issue #79 for a public show help feature.
