### PR TITLE
Update lib/commander.js

### DIFF
--- a/lib/commander.js
+++ b/lib/commander.js
@@ -679,7 +679,7 @@ Command.prototype.commandHelp = function(){
           : '[' + arg.name + ']';
       }).join(' ');
 
-      return cmd.name 
+      return cmd._name 
         + (cmd.options.length 
           ? ' [options]'
           : '') + ' ' + args


### PR DESCRIPTION
Usage Information was displaying 'undefined' for command names, apparently because Command's name is store as _name rather than name
