### PR TITLE
Implemented 'Mandatory flags' per issue #44

### DIFF
--- a/lib/commander.js
+++ b/lib/commander.js
@@ -41,6 +41,12 @@ exports.Option = Option;
  */
 
 function Option(flags, description) {
+  // `Flags` ending with a '*' are mandatory
+  this.mandatory = flags.slice(-1) === '*';
+  if (this.mandatory) {
+    // Remove the '*' marker
+    flags = flags.slice(0, -1);
+  }
   this.flags = flags;
   this.required = ~flags.indexOf('<');
   this.optional = ~flags.indexOf('[');
@@ -204,12 +210,10 @@ Command.prototype.action = function(fn){
     unknown = unknown || [];
     var parsed = self.parseOptions(unknown);
     
-    // Output help if necessary
+    // Output help and die, if necessary
     outputHelpIfNecessary(self, parsed.unknown);
     
-    // If there are still any unknown options, then we simply 
-    // die, unless someone asked for help, in which case we give it
-    // to them, and then we die.
+    // If there are still any unknown options, then we simply die
     if (parsed.unknown.length > 0) {      
       self.unknownOption(parsed.unknown[0]);
     }
@@ -512,6 +516,14 @@ Command.prototype.parseOptions = function(argv){
     // arg
     args.push(arg);
   }
+
+  // check for missing mandatory options
+  for (var i = 0, len = this.options.length; i < len; ++i) {
+    option = this.options[i];
+    if (option.mandatory && Object.keys(this).indexOf(option.name()) == -1) {
+      this.missingMandatoryOption(option.name());
+    }
+  }
   
   return { args: args, unknown: unknownOptions };
 };
@@ -526,6 +538,19 @@ Command.prototype.parseOptions = function(argv){
 Command.prototype.missingArgument = function(name){
   console.error();
   console.error("  error: missing required argument `%s'", name);
+  console.error();
+  process.exit(1);
+};
+
+/**
+ * A mandatory option is missing. 
+ *
+ * @param {String} name
+ * @api private
+ */
+Command.prototype.missingMandatoryOption = function(name){
+  console.error();
+  console.error("  error: missing mandatory argument `%s'", name);
   console.error();
   process.exit(1);
 };

--- a/test/test.options.mandatory.js
+++ b/test/test.options.mandatory.js
@@ -1,0 +1,14 @@
+var program = require('../')
+	, should = require('should');
+
+program
+	.version('0.0.1')
+	.option('-f, --foo', 'add some foo')
+	.option('-b, --bar*', 'add some bar - mandatory');
+
+var mandatoryOptionName;
+program.Command.prototype.missingMandatoryOption = function(name) {
+	mandatoryOptionName = name;
+};
+program.parse(['node', 'test', '-f', 'aFoo']);
+mandatoryOptionName.should.equal('bar');


### PR DESCRIPTION
Implemented 'Mandatory flags' based on the thread:
https://github.com/visionmedia/commander.js/issues/44.

Similar to the fix from this pull request:
https://github.com/visionmedia/commander.js/pull/70, but is additive
and does not break the existing semantics of 'required' arguments.

If this pull request is accepted I'll also update the docs : )
