### PR TITLE
Add variadic arguments to commands and options. see #53

### DIFF
--- a/lib/commander.js
+++ b/lib/commander.js
@@ -44,6 +44,7 @@ function Option(flags, description) {
   this.flags = flags;
   this.required = ~flags.indexOf('<');
   this.optional = ~flags.indexOf('[');
+  this.variadic = ~flags.indexOf('...');
   this.bool = !~flags.indexOf('-no-');
   flags = flags.split(/[ ,|]+/);
   if (flags.length > 1 && !/^[[<]/.test(flags[1])) this.short = flags.shift();
@@ -116,28 +117,35 @@ Command.prototype.__proto__ = EventEmitter.prototype;
  *        .option('-C, --chdir <path>', 'change the working directory')
  *        .option('-c, --config <path>', 'set config path. defaults to ./deploy.conf')
  *        .option('-T, --no-tests', 'ignore test hook')
- *     
+ *
  *      program
  *        .command('setup')
  *        .description('run remote setup commands')
  *        .action(function(){
  *          console.log('setup');
  *        });
- *     
+ *
  *      program
  *        .command('exec <cmd>')
  *        .description('run the given remote command')
  *        .action(function(cmd){
  *          console.log('exec "%s"', cmd);
  *        });
- *     
+ *
+ *      program
+ *        .command('cat <files...>')
+ *        .description('concat given files')
+ *        .action(function(files){
+ *          console.log('cat "%s"', files.join(', '));
+ *        });
+ *
  *      program
  *        .command('*')
  *        .description('deploy the given env')
  *        .action(function(env){
  *          console.log('deploying "%s"', env);
  *        });
- *     
+ *
  *      program.parse(process.argv);
   *
  * @param {String} name
@@ -157,7 +165,8 @@ Command.prototype.command = function(name){
 /**
  * Parse expected `args`.
  *
- * For example `["[type]"]` becomes `[{ required: false, name: 'type' }]`.
+ * For example `["[type]"]` becomes `[{ required: false, name: 'type',
+ * variadic: false }]`.
  *
  * @param {Array} args
  * @return {Command} for chaining
@@ -166,19 +175,16 @@ Command.prototype.command = function(name){
 
 Command.prototype.parseExpectedArgs = function(args){
   if (!args.length) return;
-  var self = this;
-  args.forEach(function(arg){
-    switch (arg[0]) {
-      case '<':
-        self.args.push({ required: true, name: arg.slice(1, -1) });
-        break;
-      case '[':
-        self.args.push({ required: false, name: arg.slice(1, -1) });
-        break;
-    }
+  this.args = args.map(function(arg){
+    return {
+      variadic : arg.indexOf('...') != -1,
+      required : arg[0] == '<',
+      name : arg.replace(/^<|\[/, '').replace(/>|\]$/, '').replace(/\.\.\.$/, '')
+    };
   });
   return this;
 };
+
 
 /**
  * Register callback `fn` for the command.
@@ -217,12 +223,26 @@ Command.prototype.action = function(fn){
     // Leftover arguments need to be pushed back. Fixes issue #56
     if (parsed.args.length) args = parsed.args.concat(args);
     
-    self.args.forEach(function(arg, i){
+    for (var i = 0, n = self.args.length; i < n; ++i) {
+      var arg = self.args[i];
       if (arg.required && null == args[i]) {
         self.missingArgument(arg.name);
       }
-    });
-    
+      // grab all args that aren't options
+      if (arg.variadic) {
+        var argValue = []
+          , startIndex = i;
+        for (var k = i, m = args.length; k < m; ++k) {
+          if (args[k][0] == '-') {
+            break;
+          } else {
+            argValue.push(args[k]);
+          }
+        }
+        args.splice(startIndex, k, argValue);
+      }
+    }
+
     // Always append ourselves to the end of the arguments,
     // to make sure we match the number of arguments the user
     // expects
@@ -474,8 +494,26 @@ Command.prototype.parseOptions = function(argv){
 
     // option is defined
     if (option) {
+
+      // option allows multiple arguments
+      if (option.variadic) {
+        var optionArgs = [];
+        // loop till next option and collect all values in between
+        for (var k = i + 1; k < len; ++k) {
+          var nextArg = argv[k];
+          if (null == nextArg || '-' == nextArg[0]) {
+            break;
+          } else {
+            i += 1;
+            optionArgs.push(nextArg);
+          }
+        }
+        if (option.required && !optionArgs.length) {
+          return this.optionMissingArgument(option);
+        }
+        this.emit(option.name(), optionArgs);
       // requires arg
-      if (option.required) {
+      } else if (option.required) {
         arg = argv[++i];
         if (null == arg) return this.optionMissingArgument(option);
         if ('-' == arg[0]) return this.optionMissingArgument(option, arg);
@@ -611,16 +649,10 @@ Command.prototype.description = function(str){
  */
 
 Command.prototype.usage = function(str){
-  var args = this.args.map(function(arg){
-    return arg.required
-      ? '<' + arg.name + '>'
-      : '[' + arg.name + ']';
-  });
-
   var usage = '[options'
     + (this.commands.length ? '] [command' : '')
     + ']'
-    + (this.args.length ? ' ' + args : '');
+    + (this.args.length ? ' ' + this.getArgsUsage() : '');
   if (0 == arguments.length) return this._usage || usage;
   this._usage = str;
 
@@ -673,22 +705,33 @@ Command.prototype.commandHelp = function(){
     , '  Commands:'
     , ''
     , this.commands.map(function(cmd){
-      var args = cmd.args.map(function(arg){
-        return arg.required
-          ? '<' + arg.name + '>'
-          : '[' + arg.name + ']';
-      }).join(' ');
-
       return cmd._name 
         + (cmd.options.length 
           ? ' [options]'
-          : '') + ' ' + args
+          : '') + ' ' + cmd.getArgsUsage()
         + (cmd.description()
           ? '\n' + cmd.description()
           : '');
     }).join('\n\n').replace(/^/gm, '    ')
     , ''
   ].join('\n');
+};
+
+/**
+ * Return string representation of all the Command arguments.
+ *
+ * @return {String}
+ * @api private
+ */
+
+Command.prototype.getArgsUsage = function(){
+    return this.args.map(function(arg){
+      var name = arg.name;
+      name += arg.variadic? '...' : '';
+      return arg.required
+        ? '<' + name + '>'
+        : '[' + name + ']';
+    }).join(' ');
 };
 
 /**

--- a/test/test.options.args.variadic.js
+++ b/test/test.options.args.variadic.js
@@ -1,0 +1,54 @@
+var program = require('../')
+  , should = require('should');
+
+
+// inspired by "http://cheeseorfont.com/play"
+
+program
+  .version('0.0.1')
+  .option('-c, --cheese <types...>', 'specify the types of cheese')
+  .option('-f, --fonts [families...]', 'specify the font families')
+  .option('-b, --bool', 'boolean flag');
+
+
+program.parse(['node', 'test', '--cheese', 'feta', 'ricotta', 'cheddar']);
+program.cheese.should.eql(['feta', 'ricotta', 'cheddar']);
+
+
+program.parse(['node', 'test', '-f', 'fantezi', 'gallaudet', 'tarocco']);
+program.fonts.should.eql(['fantezi', 'gallaudet', 'tarocco']);
+
+
+// make sure other options doesn't mess with values
+program.parse(['node', 'test', '-f', 'fantezi', 'gallaudet', 'tarocco', '-c', 'feta', '-b']);
+program.fonts.should.eql(['fantezi', 'gallaudet', 'tarocco']);
+program.cheese.should.eql(['feta']);
+program.bool.should.be.true;
+
+
+program.parse(['node', 'test', '-f', 'helvetica']);
+program.fonts.should.eql(['helvetica']);
+
+
+program.parse(['node', 'test', '-f']);
+program.fonts.should.eql([]);
+
+
+// Make sure we still catch errors with required values for options
+var exceptionOccurred = false;
+var oldProcessExit = process.exit;
+var oldConsoleError = console.error;
+process.exit = function() { exceptionOccurred = true; throw new Error('test error'); };
+console.error = function(msg) { };
+
+try {
+  program.parse(['node', 'test', '-c']);
+} catch(err) {
+  err.message.should.equal('test error');
+}
+
+exceptionOccurred.should.be.true;
+
+// restore
+console.error = oldConsoleError;
+process.exit = oldProcessExit;

--- a/test/test.options.commands.js
+++ b/test/test.options.commands.js
@@ -10,9 +10,12 @@ program
   .option('-C, --chdir <path>', 'change the working directory')
   .option('-c, --config <path>', 'set config path. defaults to ./deploy.conf')
   .option('-T, --no-tests', 'ignore test hook')
+  .option('-w, --words <words...>', 'variadic option')
 
 var envValue = "";
 var cmdValue = "";
+var filesValue = "";
+var dirValue = "";
 var customHelp = false;
 
 program
@@ -39,11 +42,21 @@ program
   });
 
 program
+  .command('cat <dir> <files...>')
+  .description('concat files')
+  .option('-s, --silent', 'some boolean flag')
+  .option('-t, --target [path]', 'some other option')
+  .action(function(dir, files){
+    filesValue = files;
+    dirValue = dir;
+  });
+
+program
   .command('*')
   .action(function(env){
     console.log('deploying "%s"', env);
   });
-  
+
 program.parse(['node', 'test', '--config', 'conf']);
 program.config.should.equal("conf");
 program.commands[0].should.not.have.property.setup_mode;
@@ -84,6 +97,13 @@ program.config.should.equal("conf6");
 program.commands[1].exec_mode.should.equal("mode2");
 program.commands[1].target.should.equal("target1");
 cmdValue.should.equal("exec3");
+
+program.parse(['node', 'test', 'cat', '--silent', '-t', 'target1', 'foo', 'lorem.js', 'ipsum.js', 'dolor.js']);
+dirValue.should.equal('foo');
+filesValue.should.eql(['lorem.js', 'ipsum.js', 'dolor.js']);
+program.commands[2].silent.should.be.true;
+program.commands[2].target.should.equal('target1');
+
 
 // Make sure we still catch errors with required values for options
 var exceptionOccurred = false;


### PR DESCRIPTION
Will be easier to handle sub-commands that accepts multiple arguments, like:

```
program
  .command("new <NAME> [FILES...]")
  .action(function(name, files) {
    console.log(files);
  })
  .parse(process.argv);

$ program new cool foo bar bad
>  ["foo", "bar", "baz"]
```

Added same functionality for Options as well:

```
program
  .option('-f, --files <paths...>', 'file paths')
  .parse(process.argv);
console.log( program.files );

$ program -f foo.js bar.js baz.js
>  ["foo.js", "bar.js", "baz.js"]
```

---

based on feature request #53
