### PR TITLE
Add application description to the help msg

### DIFF
--- a/examples/description
+++ b/examples/description
@@ -8,7 +8,7 @@ var program = require('../');
 
 program
   .version('0.0.1')
-  .description('application simple description ')
+  .description('Application simple description')
   .option('-f, --foo', 'enable some foo')
   .option('-b, --bar', 'enable some bar')
   .option('-B, --baz', 'enable some baz')

--- a/index.js
+++ b/index.js
@@ -120,28 +120,28 @@ Command.prototype.__proto__ = EventEmitter.prototype;
  *        .option('-C, --chdir <path>', 'change the working directory')
  *        .option('-c, --config <path>', 'set config path. defaults to ./deploy.conf')
  *        .option('-T, --no-tests', 'ignore test hook')
- *     
+ *
  *      program
  *        .command('setup')
  *        .description('run remote setup commands')
  *        .action(function(){
  *          console.log('setup');
  *        });
- *     
+ *
  *      program
  *        .command('exec <cmd>')
  *        .description('run the given remote command')
  *        .action(function(cmd){
  *          console.log('exec "%s"', cmd);
  *        });
- *     
+ *
  *      program
  *        .command('*')
  *        .description('deploy the given env')
  *        .action(function(env){
  *          console.log('deploying "%s"', env);
  *        });
- *     
+ *
  *      program.parse(process.argv);
   *
  * @param {String} name
@@ -218,30 +218,30 @@ Command.prototype.parseExpectedArgs = function(args){
 
 Command.prototype.action = function(fn){
   var self = this;
-  this.parent.on(this._name, function(args, unknown){    
+  this.parent.on(this._name, function(args, unknown){
     // Parse any so-far unknown options
     unknown = unknown || [];
     var parsed = self.parseOptions(unknown);
-    
+
     // Output help if necessary
     outputHelpIfNecessary(self, parsed.unknown);
-    
-    // If there are still any unknown options, then we simply 
+
+    // If there are still any unknown options, then we simply
     // die, unless someone asked for help, in which case we give it
     // to them, and then we die.
-    if (parsed.unknown.length > 0) {      
+    if (parsed.unknown.length > 0) {
       self.unknownOption(parsed.unknown[0]);
     }
-    
+
     // Leftover arguments need to be pushed back. Fixes issue #56
     if (parsed.args.length) args = parsed.args.concat(args);
-    
+
     self._args.forEach(function(arg, i){
       if (arg.required && null == args[i]) {
         self.missingArgument(arg.name);
       }
     });
-    
+
     // Always append ourselves to the end of the arguments,
     // to make sure we match the number of arguments the user
     // expects
@@ -250,7 +250,7 @@ Command.prototype.action = function(fn){
     } else {
       args.push(self);
     }
-    
+
     fn.apply(this, args);
   });
   return this;
@@ -258,7 +258,7 @@ Command.prototype.action = function(fn){
 
 /**
  * Define option with `flags`, `description` and optional
- * coercion `fn`. 
+ * coercion `fn`.
  *
  * The `flags` string should contain both the short and long flags,
  * separated by comma, a pipe or space. The following are all valid
@@ -371,7 +371,7 @@ Command.prototype.parse = function(argv){
   // process argv
   var parsed = this.parseOptions(this.normalize(argv.slice(2)));
   var args = this.args = parsed.args;
- 
+
   // executable sub-commands, skip .parseArgs()
   if (this.executables) return this.executeSubCommand(argv, args, parsed.unknown);
 
@@ -474,10 +474,10 @@ Command.prototype.parseArgs = function(args, unknown){
     }
   } else {
     outputHelpIfNecessary(this, unknown);
-    
+
     // If there were no args and we have unknown options,
     // then they are extraneous and we need to error.
-    if (unknown.length > 0) {      
+    if (unknown.length > 0) {
       this.unknownOption(unknown[0]);
     }
   }
@@ -560,11 +560,11 @@ Command.prototype.parseOptions = function(argv){
       }
       continue;
     }
-    
+
     // looks like an option
     if (arg.length > 1 && '-' == arg[0]) {
       unknownOptions.push(arg);
-      
+
       // If the next argument looks like it might be
       // an argument for this option, we pass it on.
       // If it isn't, then it'll simply be ignored
@@ -573,11 +573,11 @@ Command.prototype.parseOptions = function(argv){
       }
       continue;
     }
-    
+
     // arg
     args.push(arg);
   }
-  
+
   return { args: args, unknown: unknownOptions };
 };
 
@@ -715,7 +715,7 @@ Command.prototype.largestOptionLength = function(){
 
 Command.prototype.optionHelp = function(){
   var width = this.largestOptionLength();
-  
+
   // Prepend the help information
   return [pad('-h, --help', width) + '  ' + 'output usage information']
     .concat(this.options.map(function(option){
@@ -746,7 +746,7 @@ Command.prototype.commandHelp = function(){
       }).join(' ');
 
       return pad(cmd._name
-        + (cmd.options.length 
+        + (cmd.options.length
           ? ' [options]'
           : '') + ' ' + args, 22)
         + (cmd.description()
@@ -765,23 +765,36 @@ Command.prototype.commandHelp = function(){
  */
 
 Command.prototype.helpInformation = function(){
+
   var desc = [];
   if (this._description) {
     desc = [
-        ''
-      , '  Description: ' + this._description]
+      '  ' + this._description
+      , ''
+    ]
   }
 
-  return desc.concat([
-      ''
-    , '  Usage: ' + this._name + ' ' + this.usage()
-    , '' + this.commandHelp()
-    , '  Options:'
+  var usage = [
+    '  Usage: ' + this._name + ' ' + this.usage()
+    , ''
+  ];
+
+  var cmds = [];
+  var commandHelp = this.commandHelp();
+  if (commandHelp) cmds = [commandHelp];
+
+  var options = [
+    '  Options:'
     , ''
     , '' + this.optionHelp().replace(/^/gm, '    ')
     , ''
-    , ''
-  ]).join('\n');
+  ];
+
+  return usage
+    .concat(cmds)
+    .concat(desc)
+    .concat(options)
+    .join('\n');
 };
 
 /**
@@ -874,7 +887,7 @@ Command.prototype.promptMultiLine = function(str, fn){
  *     program.prompt('Username: ', function(name){
  *       console.log('hi %s', name);
  *     });
- *     
+ *
  *     program.prompt('Description:', function(desc){
  *       console.log('description was "%s"', desc.trim());
  *     });
@@ -1010,7 +1023,7 @@ Command.prototype.confirm = function(str, fn, verbose){
  * Examples:
  *
  *      var list = ['tobi', 'loki', 'jane', 'manny', 'luna'];
- *      
+ *
  *      console.log('Choose the coolest pet:');
  *      program.choose(list, function(i){
  *        console.log('you chose %d "%s"', i, list[i]);


### PR DESCRIPTION
It was there already (?), I just put it in the help msg.

``` javascript
program
  .version('0.0.1')
  .description('simple application description')
  .option('-f, --foo', 'enable some foo')
  .option('-b, --bar', 'enable some bar')
  .option('-B, --baz', 'enable some baz')
  .parse(process.argv);
```

will show:

```
  Description: simple application description 

  Usage: app [options]

  Options:

    -h, --help     output usage information
    -V, --version  output the version number
    -f, --foo      enable some foo
    -b, --bar      enable some bar
    -B, --baz      enable some baz
```
