### PR TITLE
Adds an option's default value to the help output

### DIFF
--- a/index.js
+++ b/index.js
@@ -384,7 +384,10 @@ Command.prototype.option = function(flags, description, fn, defaultValue) {
     // when --no-* we make sure default is true
     if (false == option.bool) defaultValue = true;
     // preassign only if we have a default
-    if (undefined !== defaultValue) self[name] = defaultValue;
+    if (undefined !== defaultValue) {
+      self[name] = defaultValue;
+      option.defaultValue = defaultValue;
+    }
   }
 
   // register the option
@@ -948,8 +951,9 @@ Command.prototype.optionHelp = function() {
 
   // Append the help information
   return this.options.map(function(option) {
-      return pad(option.flags, width) + '  ' + option.description;
-    }).concat([pad('-h, --help', width) + '  ' + 'output usage information'])
+      return pad(option.flags, width) + '  ' + option.description
+        + (option.defaultValue !== undefined ? ' (default: ' + option.defaultValue + ')' : '');
+  }).concat([pad('-h, --help', width) + '  ' + 'output usage information'])
     .join('\n');
 };
 


### PR DESCRIPTION
If a default value is supplied to the option, this patch appends a '(Default: value)' message to the end of the help for the option. For example,
option('-f', 'Number of foos', 100)

becomes

-f   Number of foos (Default: 100)
