### PR TITLE
Amend engine version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,5 +9,5 @@
   , "devDependencies": { "should": ">= 0.0.1" }
   , "scripts": { "test": "make test" }
   , "main": "index"
-  , "engines": { "node": ">= 0.6.x" }
+  , "engines": { "node": ">= 0.6.0" }
 }


### PR DESCRIPTION
`man npm-json` says that: "You may not supply a comparator with a
version containing an x.  Any digits after the first "x" are ignored."
