### PR TITLE
avoid normalizing arguments after the double dash

### DIFF
--- a/index.js
+++ b/index.js
@@ -434,7 +434,10 @@ Command.prototype.normalize = function(args){
 
   for (var i = 0, len = args.length; i < len; ++i) {
     arg = args[i];
-    if (arg.length > 1 && '-' == arg[0] && '-' != arg[1]) {
+    if ('--' == arg) {
+      ret.push.apply(ret, args.slice(i));
+      break;
+    } else if (arg.length > 1 && '-' == arg[0] && '-' != arg[1]) {
       arg.slice(1).split('').forEach(function(c){
         ret.push('-' + c);
       });

--- a/test/test.literal.args.js
+++ b/test/test.literal.args.js
@@ -10,7 +10,7 @@ program
   .option('-f, --foo', 'add some foo')
   .option('-b, --bar', 'add some bar');
 
-program.parse(['node', 'test', '--foo', '--', '--bar', 'baz']);
+program.parse(['node', 'test', '--foo', '--', '--bar', '-baz', 'quux']);
 program.foo.should.be.true;
 should.equal(undefined, program.bar);
-program.args.should.eql(['--bar', 'baz']);
+program.args.should.eql(['--bar', '-baz', 'quux']);


### PR DESCRIPTION
Previously, `./foo bar -- -baz` was treated as `./foo bar -- -b -a -z`. `Command::normalize` now stops as soon as it encounters the double dash.
