### PR TITLE
Add ability to ignore unknown options

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,6 +91,7 @@ Option.prototype.is = function(arg){
 function Command(name) {
   this.commands = [];
   this.options = [];
+  this._allow_unknown = false;
   this._args = [];
   this._name = name;
 }
@@ -351,6 +352,17 @@ Command.prototype.option = function(flags, description, fn, defaultValue){
 };
 
 /**
+ * Allow unknown options on the command line.
+ *
+ * @param {Boolean} allow
+ * @api public
+ */
+Command.prototype.allowUnknown = function(allow) {
+    this._allow_unknown = allow === undefined ? false : allow;
+    return this;
+}
+
+/**
  * Parse `argv`, settings options and invoking commands when defined.
  *
  * @param {Array} argv
@@ -474,10 +486,10 @@ Command.prototype.parseArgs = function(args, unknown){
     }
   } else {
     outputHelpIfNecessary(this, unknown);
-    
+
     // If there were no args and we have unknown options,
     // then they are extraneous and we need to error.
-    if (unknown.length > 0) {      
+    if (!this._allow_unknown && unknown.length > 0) {
       this.unknownOption(unknown[0]);
     }
   }


### PR DESCRIPTION
Important if change control for live server configuration is different for code rollout. Allows the addition of necessary options before the roll happens so that as soon as the code appears it is already configured properly without risking breaking it before that point.
