### PR TITLE
allow "-" hyphen as an option argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -543,12 +543,12 @@ Command.prototype.parseOptions = function(argv){
       if (option.required) {
         arg = argv[++i];
         if (null == arg) return this.optionMissingArgument(option);
-        if ('-' == arg[0]) return this.optionMissingArgument(option, arg);
+        if ('-' == arg[0] && '-' != arg) return this.optionMissingArgument(option, arg);
         this.emit(option.name(), arg);
       // optional arg
       } else if (option.optional) {
         arg = argv[i+1];
-        if (null == arg || '-' == arg[0]) {
+        if (null == arg || ('-' == arg[0] && '-' != arg)) {
           arg = null;
         } else {
           ++i;

--- a/test/test.options.hyphen.js
+++ b/test/test.options.hyphen.js
@@ -1,0 +1,23 @@
+/**
+ * Module dependencies.
+ */
+
+var program = require('../')
+  , should = require('should');
+
+function parseRange(str) {
+  return str.split('..').map(Number);
+}
+
+program
+  .version('0.0.1')
+  .option('-a, --alpha <a>', 'hyphen')
+  .option('-b, --bravo <b>', 'hyphen')
+  .option('-c, --charlie <c>', 'hyphen')
+
+program.parse('node test -a - --bravo - --charlie=- - -- -'.split(' '));
+program.alpha.should.equal('-');
+program.bravo.should.equal('-');
+program.charlie.should.equal('-');
+program.args[0].should.equal('-');
+program.args[1].should.equal('-');


### PR DESCRIPTION
An argument which has only one character of "-" hyphen have been not accepted.

ex. node test -a - --bravo - --charlie=- - -- -

STDIN and STDOUT are often named as "-" in most UNIX commands.
This patch will allow to use "-" hyphen arguments.
Test script is included as well.

@kawanet
