### PR TITLE
Use empty string for name if parse not called to avoid printing undefine...

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ function Command(name) {
   this.commands = [];
   this.options = [];
   this._args = [];
-  this._name = name;
+  this._name = name || '';
 }
 
 /**

--- a/test/test.options.defaults.js
+++ b/test/test.options.defaults.js
@@ -14,7 +14,10 @@ program
   .option('-r, --crust <type>', 'What kind of crust would you like?', 'hand-tossed')
   .option('-c, --cheese [type]', 'optionally specify the type of cheese', 'mozzarella');
 
+program.should.have.property('_name', '');
+
 program.parse(['node', 'test']);
+program.should.have.property('_name', 'test');
 program.should.not.have.property('anchovies');
 program.should.not.have.property('onions');
 program.should.not.have.property('olives');


### PR DESCRIPTION
...d in help output

Avoid "Usage: undefined [options] [command]"