### PR TITLE
Commands now work with files ending in .js, and usage information is more pretty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 node_modules
 *.sock
+index.js.orig
+index.js.patch


### PR DESCRIPTION
Commands didn't work with files ending in .js or that were symlinked into node's bin dir. They now do. Also, when printing usage information for a command, the command's filename was printed including the .js extension and the hyphens. These are now removed.