### PR TITLE
allowUnknownOptions() --- dont process.exit(1) when an unknown option is detected.

### DIFF
--- a/index.js
+++ b/index.js
@@ -622,6 +622,9 @@ Command.prototype.optionMissingArgument = function(option, flag){
  */
 
 Command.prototype.unknownOption = function(flag){
+  if(this._allowUnknownOptions)
+    return;
+
   console.error();
   console.error("  error: unknown option `%s'", flag);
   console.error();
@@ -652,6 +655,21 @@ Command.prototype.version = function(str, flags){
   });
   return this;
 };
+
+
+/**
+ * Allows options not registered to be ignored.
+ *
+ * When an unknown option is detected the program does not print an error nor does it exit.
+ *
+ * @return {Command} for chaining
+ * @api public
+ */
+
+Command.prototype.allowUnknownOptions = function(){
+  this._allowUnknownOptions = true;
+  return this;
+}
 
 /**
  * Set the description `str`.


### PR DESCRIPTION
It needed a way to allow unknown options not to fail with process.exit() and added allowUnknownOptions to the chain.

Our program consists of a host which parses some arguments and passes them on to a hosted app. In that case it is necessary to just ignore unknown options.

This affects only 'global' options not 'command' options.
