### PR TITLE
split -abc="def" into -abc def

### DIFF
--- a/index.js
+++ b/index.js
@@ -421,6 +421,7 @@ Command.prototype.executeSubCommand = function(argv, args, unknown) {
 /**
  * Normalize `args`, splitting joined short flags. For example
  * the arg "-abc" is equivalent to "-a -b -c".
+ * and the arg "-abc='def'" can be "--abc def".
  * This also normalizes equal sign and splits "--abc=def" into "--abc def".
  *
  * @param {Array} args
@@ -436,9 +437,13 @@ Command.prototype.normalize = function(args){
   for (var i = 0, len = args.length; i < len; ++i) {
     arg = args[i];
     if (arg.length > 1 && '-' == arg[0] && '-' != arg[1]) {
-      arg.slice(1).split('').forEach(function(c){
-        ret.push('-' + c);
-      });
+	    if (~(index = arg.indexOf('='))) {
+		    ret.push('-' + arg.slice(0, index), arg.slice(index + 1));
+	    }else{
+		    arg.slice(1).split('').forEach(function(c){
+			    ret.push('-' + c);
+		    });
+	    }
     } else if (/^--/.test(arg) && ~(index = arg.indexOf('='))) {
       ret.push(arg.slice(0, index), arg.slice(index + 1));
     } else {


### PR DESCRIPTION
sometime we need to use this:

```
-browsers="chrome"
```

it will be splited into `-b -r -o -w -s -e -r -s -= -" -c -h -r -o -m -e -"`...

It`s **not** what we want

after change. 

```
-browser --> -b -r -o -w -s -e -r
-browser="chrome" --> --browser chorme
```
