### PR TITLE
Use of dot notation to prevent array method name collision - fix error "execvp(): No such file or directory"

### DIFF
--- a/index.js
+++ b/index.js
@@ -371,7 +371,7 @@ Command.prototype.parse = function(argv){
 
   // executable sub-commands
   var name = result.args[0];
-  if (this._execs[name]) return this.executeSubCommand(argv, args, parsed.unknown);
+  if (this._execs.name) return this.executeSubCommand(argv, args, parsed.unknown);
 
   return result;
 };


### PR DESCRIPTION
I have a single use case that is broken. I need to support options and commands, but I'm not using the 'Commands' capability of Commander.
For example, my script can accept the following:

```
myscript.js -a reset
```

I rely on Commander to handle the options, but I'm parsing the commands myself. It works well, except if the command name is an actual array method (push, pop, splice, etc...). In that case (for example if I use 'push'), the following error occurs:

```
myscript.js -a push 
execvp(): No such file or directory
myscript.js-push(1) does not exist, try --help
```

I realized it was because line 374 was interpreting the argument 'name' as an actual method instead of a key:

```
if (this._execs[name]) return this.executeSubCommand(argv, args, parsed.unknown);
```

changing this line into

```
if (this._execs.name) return this.executeSubCommand(argv, args, parsed.unknown);
```

fixed my problem...
This is what this pull request is about.
Let me know if you need anything else!
Thanks
