### PR TITLE
Clean up help screen

### DIFF
--- a/index.js
+++ b/index.js
@@ -734,6 +734,7 @@ Command.prototype.optionHelp = function(){
  */
 
 Command.prototype.commandHelp = function(){
+  var self = this;
   if (!this.commands.length) return '';
   return [
       ''
@@ -749,7 +750,7 @@ Command.prototype.commandHelp = function(){
       return pad(cmd._name
         + (cmd.options.length 
           ? ' [options]'
-          : '') + ' ' + args, 22)
+          : '') + ' ' + args, self.largestOptionLength() + 1)
         + (cmd.description()
           ? ' ' + cmd.description()
           : '');


### PR DESCRIPTION
Quick little fix to get the option and command descriptions starting on the same column. Satisfies my anal retentiveness.
