### PR TITLE
Command.action functions should have the Command as this, not the parent.

### DIFF
--- a/index.js
+++ b/index.js
@@ -246,7 +246,7 @@ Command.prototype.action = function(fn){
       args.push(self);
     }
     
-    fn.apply(this, args);
+    fn.apply(self, args);
   });
   return this;
 };


### PR DESCRIPTION
Without this the current Command is not easily accessible, while the parent (the current this) is still easily accessible as this.parent.  For example trying to command.help() is hard without this.

```
program
    .command("do")
    .action(function (opts) {
        if (!ok(opts.secret))
            this.help();
    })
```
