### PR TITLE
clean up usage argument summary

### DIFF
--- a/index.js
+++ b/index.js
@@ -687,10 +687,9 @@ Command.prototype.usage = function(str){
       : '[' + arg.name + ']';
   });
 
-  var usage = '[options'
-    + (this.commands.length ? '] [command' : '')
-    + ']'
-    + (this._args.length ? ' ' + args : '');
+  var usage = '[options]'
+    + (this.commands.length ? ' [command]' : '')
+    + (this._args.length ? ' ' + args.join(' ') : '');
 
   if (0 == arguments.length) return this._usage || usage;
   this._usage = str;


### PR DESCRIPTION
instead of using implicit array string conversion which includes
confusing commas, use an explicit .join(' ')
