### PR TITLE
fix up errant output & escape codes in make test

### DIFF
--- a/test/run
+++ b/test/run
@@ -5,10 +5,10 @@ export NODE_ENV=test
 echo
 for file in $@; do
   printf "\033[90m   ${file#test/}\033[0m "
-  node $file 2> /tmp/stderr && echo "\033[36m✓\033[0m"
+  node $file 2> /tmp/stderr && printf "\033[36m✓\033[0m\n"
   code=$?
   if test $code -ne 0; then
-    echo "\033[31m✖\033[0m"
+    printf "\033[31m✖\033[0m\n"
     cat /tmp/stderr >&2
     exit $code
   fi

--- a/test/test.options.commands.js
+++ b/test/test.options.commands.js
@@ -90,7 +90,7 @@ var exceptionOccurred = false;
 var oldProcessExit = process.exit;
 var oldConsoleError = console.error;
 process.exit = function() { exceptionOccurred = true; throw new Error(); };
-console.error = function() {};
+console.error = process.stdout.write = function() {};
 
 try {
   program.parse(['node', 'test', '--config', 'conf6', 'exec', '--help']);


### PR DESCRIPTION
* many versions of echo don't support "\033", but printf(1) does
* silence the help output in test.options.commands.js (dangerous?)