### PR TITLE
Command.prototype.outputHelpIfNecessary

### DIFF
--- a/index.js
+++ b/index.js
@@ -816,7 +816,7 @@ Command.prototype.outputHelpIfNecessary = function(options) {
   options = options || [];
   for (var i = 0; i < options.length; i++) {
     if (options[i] == '--help' || options[i] == '-h') {
-      cmd.outputHelp();
+      this.outputHelp();
       process.exit(0);
     }
   }


### PR DESCRIPTION
SInce outputHelpIfNecessary depends on Command, it should be part of Command class.
Reason: I want to use commander in shell and have to override all functions with process.exit
