### PR TITLE
if args is falsy, assume a default collection.

### DIFF
--- a/index.js
+++ b/index.js
@@ -215,7 +215,9 @@ Command.prototype.action = function(fn){
   var self = this;
   this.parent.on(this._name, function(args, unknown){
     // Parse any so-far unknown options
+    args = args || [];
     unknown = unknown || [];
+
     var parsed = self.parseOptions(unknown);
 
     // Output help if necessary


### PR DESCRIPTION
This is kind of an edge case that I coincide if I try to break things hard enough
while using commander at https://github.com/v0lkan/JFDI/

From tracing the code I tend to come to a conclusion that
when the command's option is not required, and the option is not optional, and we follow the

```
program
.command(..)
.description(..)
.action(function(){
});
```

pattern, then after some event chaining, args happens to be `undefined` which breaks the flow.

Providing a default value if args do not exist, will make the function less error-prone nonetheless; and it won't cause any regression in the existing behavior.
