### PR TITLE
remove `subcommand --help` output comma when more than one arg

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -691,7 +690,7 @@ Command.prototype.usage = function(str){
   var usage = '[options'
     + (this.commands.length ? '] [command' : '')
     + ']'
-    + (this._args.length ? ' ' + args : '');
+    + (this._args.length ? ' ' + args.join(' ') : '');
 
   if (0 == arguments.length) return this._usage || usage;
   this._usage = str;


### PR DESCRIPTION
supose I have defined a program `app` below

``` js
var program = require('commander');

program
    .version('0.0.1');

program
    .command('exec <arg1> [arg2]')
    .description('exec example')
    .action(function(arg1, arg2, options){
        console.log('called exec');
    });

program.parse(process.argv);
```

Then when I get the exec help info via `app exec --help`, it will output 

``` bash
Usage: exec [options] <arg1>,[arg2]

  Options:

    -h, --help  output usage information
```

But the right output should be

``` bash
Usage: exec [options] <arg1> [arg2]

  Options:

    -h, --help  output usage information
```

So, I find the problem is that the `args` is an array, when its length is larger than 1, it will join with `,`, what I do is join the array with space :)
