### PR TITLE
removed unused fs module

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,8 +5,6 @@
 
 var EventEmitter = require('events').EventEmitter;
 var spawn = require('child_process').spawn;
-var fs = require('fs');
-var exists = fs.existsSync;
 var path = require('path');
 var dirname = path.dirname;
 var basename = path.basename;


### PR DESCRIPTION
The `fs` module and a reference to `fs.existsSync` are included in the variable declarations. They are unused, so I removed them.
