### PR TITLE
bugfix: the coercion fn will not be called of optional  value, when not providing values

### DIFF
--- a/index.js
+++ b/index.js
@@ -326,7 +326,7 @@ Command.prototype.option = function(flags, description, fn, defaultValue){
   // and conditionally invoke the callback
   this.on(oname, function(val){
     // coercion
-    if (null !== val && fn) val = fn(val, undefined === self[name] ? defaultValue : self[name]);
+    if (fn) val = fn(val, undefined === self[name] ? defaultValue : self[name]);
 
     // unassigned or bool
     if ('boolean' == typeof self[name] || 'undefined' == typeof self[name]) {


### PR DESCRIPTION
Demo: file `app.js`

``` js
var program = require('commander');

program.option('-p, --port [port]', 'server on port [port]', function (val) {
        console.log('fixed');
});
program.parse(process.argv);
```

when execute `./app.js -p`, the `fn` was not called.

I think in above case,the coercion function should alse be called.

thx.
