### PR TITLE
Added option to by pass process exit on unknown options.

### DIFF
--- a/index.js
+++ b/index.js
@@ -359,7 +359,9 @@ Command.prototype.option = function(flags, description, fn, defaultValue){
  * @api public
  */
 
-Command.prototype.parse = function(argv){
+Command.prototype.parse = function(argv, opts){
+  opts = opts || {};
+  var failOnUnknown = typeof opts.failOnUnknown !== 'undefined' ?  opts.failOnUnknown : true;
   // implicit help
   if (this.executables) this.addImplicitHelpCommand();
 
@@ -373,7 +375,7 @@ Command.prototype.parse = function(argv){
   var parsed = this.parseOptions(this.normalize(argv.slice(2)));
   var args = this.args = parsed.args;
 
-  var result = this.parseArgs(this.args, parsed.unknown);
+  var result = this.parseArgs(this.args, parsed.unknown, failOnUnknown);
 
   // executable sub-commands
   var name = result.args[0];
@@ -479,7 +481,7 @@ Command.prototype.normalize = function(args){
  * @api private
  */
 
-Command.prototype.parseArgs = function(args, unknown){
+Command.prototype.parseArgs = function(args, unknown, failOnUnknown){
   var cmds = this.commands
     , len = cmds.length
     , name;
@@ -496,7 +498,7 @@ Command.prototype.parseArgs = function(args, unknown){
 
     // If there were no args and we have unknown options,
     // then they are extraneous and we need to error.
-    if (unknown.length > 0) {
+    if (unknown.length > 0 && failOnUnknown) {
       this.unknownOption(unknown[0]);
     }
   }

--- a/test/test.args.unknown.js
+++ b/test/test.args.unknown.js
@@ -1,0 +1,18 @@
+/**
+ * Module dependencies.
+ */
+
+var program = require('../')
+  , should = require('should');
+
+program
+  .version('0.0.1')
+
+var failOnUnkown = false;
+try {
+  program.parse(['node', 'test', '--unknown'], {failOnUnknown: false});
+} catch (e) {
+  failOnUnkown = true;
+}
+failOnUnkown.should.be.false;
+


### PR DESCRIPTION
Commander should not always exit the process in case of an unknown option.
I'll give an example:
I have a grunt app that uses commander to parse some arguments since I like it better then the default grunt arg parsing, however, some arguments are targeted to grunt directly not my app and since commander doesn't allow unknown options to be by passed it prevents me to setting arguments targeted at grunt.

This pull requests adds the option to not exit the process in the case of encountering an unknown argument.
Tests are included.