### PR TITLE
Completed nested command support.

### DIFF
--- a/test/test.options.command-context.js
+++ b/test/test.options.command-context.js
@@ -1,0 +1,21 @@
+/**
+ * Module dependencies.
+ */
+
+var program = require('../')
+  , should = require('should');
+
+program
+  .version('0.0.1');
+
+var commandContext;
+var optionContext;
+
+var setup = program.command('setup')
+  .description('run setup commands for all envs')
+  .action(function(env, options){
+      commandContext = this;
+  });
+
+program.parse(['node', 'test', 'setup']);
+commandContext._name.should.equal('setup');

--- a/test/test.options.nested-commands.js
+++ b/test/test.options.nested-commands.js
@@ -1,0 +1,88 @@
+/**
+ * Module dependencies.
+ */
+
+var program = require('../')
+  , should = require('should');
+
+var commandContext;
+
+program
+  .version('0.0.1')
+  .on('--help', function() {
+    helpCommand = this._name;
+  });
+
+var setupCommand = program
+  .command('setup')
+  .action(function(env, options){
+    commandContext = this;
+  })
+  .on('--help', function() {
+    helpCommand = this._name;
+  });
+
+var addCommand = setupCommand
+  .command('add')
+  .option('--value [value]')
+  .action(function() {
+    commandContext = this;
+  })
+  .on('--help', function() {
+    helpCommand = this._name;
+  });
+
+var remoteCommand = addCommand
+  .command('remote')
+  .action(function() {
+    commandContext = this;
+  })
+  .on('--help', function() {
+    helpCommand = this._name;
+  });
+
+program.parse(['node', 'test', 'setup']);
+commandContext._name.should.equal('setup');
+
+program.parse(['node', 'test', 'setup', 'add']);
+commandContext._name.should.equal('add');
+
+program.parse(['node', 'test', 'setup', 'add', '--value', 'true']);
+commandContext._name.should.equal('add');
+
+program.parse(['node', 'test', 'setup', 'add', 'remote']);
+commandContext._name.should.equal('remote');
+
+// Make sure we still catch errors with required values for options
+var exceptionOccurred = false;
+var oldProcessExit = process.exit;
+var oldConsoleError = console.error;
+process.exit = function() { exceptionOccurred = true; throw new Error(); };
+console.error = function() {};
+
+try {
+  program.parse(['node', 'test', '--help']);
+} catch(ex) {
+}
+helpCommand.should.equal('test');
+
+try {
+  program.parse(['node', 'test', 'setup', '--help']);
+} catch(ex) {
+}
+helpCommand.should.equal('setup');
+
+try {
+  program.parse(['node', 'test', 'setup', 'add', '--help']);
+} catch(ex) {
+}
+helpCommand.should.equal('add');
+
+try {
+  program.parse(['node', 'test', 'setup', 'add', 'remote', '--help']);
+} catch(ex) {
+}
+helpCommand.should.equal('remote');
+
+process.exit = oldProcessExit;
+exceptionOccurred.should.be.true;


### PR DESCRIPTION
Nested command support was almost completely available, however, a few things
seemed to be missing to me.
- `this` context on `action` event listeners was not bound properly.
- We output `help` too early, the deepest referenced command should handle help.
- We did not have `action` handling logic to delegate to subcommands if they existed.

This should address #226, and #1. Pretty much all of the support was already there, and it seemed useful to just connect the wires. I know that #63 referenced using the git subcommand model, which I love and use frequently, but there are several use cases (creating a command framework that loads external "plugin" module commands into the parent executable) that would be more easily expressed with this simple fix to connect the wires for sub-commands.
