### PR TITLE
Fix a typo in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ Command.prototype.__proto__ = EventEmitter.prototype;
  *
  * The `.action()` callback is invoked when the
  * command `name` is specified via __ARGV__,
- * and the remaining arguments are applied to the
+ * and the remaining arguments are supplied to the
  * function for access.
  *
  * When the `name` is "*" an un-matched command


### PR DESCRIPTION
Extra arguments to a command's `action` function are "supplied" to it, not "applied" to it.
