### PR TITLE
Add ability to specify arguments syntax for top-level command

### DIFF
--- a/index.js
+++ b/index.js
@@ -155,6 +155,16 @@ Command.prototype.command = function(name, desc) {
 };
 
 /**
+ * Define argument syntax for the top-level command.
+ *
+ * @api public
+ */
+
+Command.prototype.arguments = function (desc) {
+  return this.parseExpectedArgs(desc.split(/ +/));
+}
+
+/**
  * Add an implicit `help [cmd]` subcommand
  * which invokes `--help` for the given command.
  *
@@ -247,8 +257,10 @@ Command.prototype.action = function(fn){
 
     fn.apply(this, args);
   };
-  this.parent.on(this._name, listener);
-  if (this._alias) this.parent.on(this._alias, listener);
+  var parent = this.parent || this;
+  var name = parent === this ? '*' : this._name;
+  parent.on(name, listener);
+  if (this._alias) parent.on(this._alias, listener);
   return this;
 };
 

--- a/test/test.arguments.js
+++ b/test/test.arguments.js
@@ -1,0 +1,30 @@
+/**
+ * Module dependencies.
+ */
+
+var program = require('../')
+  , should = require('should');
+
+var envValue = "";
+var cmdValue = "";
+
+program
+  .version('0.0.1')
+  .arguments('<cmd> [env]')
+  .action(function (cmd, env) {
+    cmdValue = cmd;
+    envValue = env;
+  })
+  .option('-C, --chdir <path>', 'change the working directory')
+  .option('-c, --config <path>', 'set config path. defaults to ./deploy.conf')
+  .option('-T, --no-tests', 'ignore test hook')
+
+program.parse(['node', 'test', '--config', 'conf']);
+program.config.should.equal("conf");
+cmdValue.should.equal("");
+envValue.should.equal("");
+
+program.parse(['node', 'test', '--config', 'conf1', 'setup', '--setup_mode', 'mode3', 'env1']);
+program.config.should.equal("conf1");
+cmdValue.should.equal("setup");
+envValue.should.equal("env1");


### PR DESCRIPTION
* index.js: Add arguments method, support top-level command in action.

This would fix issue #257.