### PR TITLE
add opts() for getting key-value pairs

### DIFF
--- a/index.js
+++ b/index.js
@@ -602,6 +602,23 @@ Command.prototype.parseOptions = function(argv){
 };
 
 /**
+ * Return an object containing options as key-value pairs
+ *
+ * @return {Object}
+ * @api public
+ */
+Command.prototype.opts = function() {
+  var result = {}
+    , len = this.options.length;
+
+  for (var i = 0 ; i < len; i++) {
+    var key = this.options[i].name();
+    result[key] = key === 'version' ? this._version : this[key];
+  }
+  return result;
+};
+
+/**
  * Argument `name` is missing.
  *
  * @param {String} name

--- a/test/test.options.func.js
+++ b/test/test.options.func.js
@@ -1,0 +1,21 @@
+var program = require('../')
+  , should = require('should');
+
+program
+  .version('0.0.1')
+  .description('sdfdsfsfsdfdsf')
+  .option('-f, --foo', 'add some foo')
+  .option('-b, --bar', 'add some bar')
+  .option('-M, --no-magic', 'disable magic')
+  .option('-q, --quux <quux>', 'add some quux');
+
+program.parse(['node', 'test', '--foo', '--bar', '--no-magic', '--quux', 'value']);
+program.opts.should.be.a.Function;
+
+var opts = program.opts();
+opts.should.be.an.Object;
+opts.version.should.equal('0.0.1');
+opts.foo.should.be.true;
+opts.bar.should.be.true;
+opts.magic.should.be.false;
+opts.quux.should.equal('value');


### PR DESCRIPTION
A common usage pattern I have when using commander is to process the CLI in a bin file and defer all actual program-specific execution to a separate module. I often pass all options gathered from commander straight my module, like this:

``` js
#!/usr/bin/env node

var program = require('commander'),
  mymodule = require('mymodule');

// setup the program object

mymodule(program);
```

While this works, it would be nice if the object passed through included _only_ the options I specified when setting up the program object. 

This PR add the `opts()` function to the program object (via `Command.prototype`) so as to return the options, with special handling for the version, as a simple object of key-value pairs. No parsing Option objects, no additional properties associated with the program obejcts, I can then do the following in my above example to get the desired behavior.

``` js
#!/usr/bin/env node

var program = require('commander'),
  mymodule = require('mymodule');

// setup the program object

mymodule(program.opts());
```

The included test case also demonstrates this fairly simply. 

**NOTE**: I am entirely open to changing the name of the API. `opts()` was the first thing to occur to me that wasn't already claimed on the `Command` object. If someone has a better alternative I'd be happy to update the code and testing.
