### PR TITLE
implement Command.prototype.name()

### DIFF
--- a/index.js
+++ b/index.js
@@ -744,6 +744,20 @@ Command.prototype.usage = function(str){
 };
 
 /**
+ * Set / get the name for the command
+ *
+ * @param {String} name
+ * @return {String|Command}
+ * @api public
+ */
+
+Command.prototype.name = function(name){
+  if (0 == arguments.length) return this._name;
+  this._name = name;
+  return this;
+};
+
+/**
  * Return the largest option length.
  *
  * @return {Number}

--- a/test/test.command.name.js
+++ b/test/test.command.name.js
@@ -1,0 +1,14 @@
+var program = require('../')
+  , should = require('should');
+
+program
+  .command('mycommand [options]', 'this is my command');
+
+program.parse(['node', 'test']);
+
+program.name.should.be.a.Function;
+program.name().should.equal('test');
+program.commands[0].name().should.equal('mycommand');
+program.commands[1].name().should.equal('help');
+program.commands[0].name('newcommand');
+program.commands[0].name().should.equal('newcommand');


### PR DESCRIPTION
This creates a true public API for the `_name` property of the `Command` object, just like description, usage, etc... as `name()`.

My particular use case is for a pluggable CLI based in commander.js. It uses auto-discovery of CLI commands, and being able to extract the name of those commands from `Command.commands` would help tremendously. 
