### PR TITLE
Add license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   , "description": "the complete solution for node.js command-line programs"
   , "keywords": ["command", "option", "parser", "prompt"]
   , "author": "TJ Holowaychuk <tj@vision-media.ca>"
+  , "license": "MIT"
   , "repository": { "type": "git", "url": "https://github.com/visionmedia/commander.js.git" }
   , "devDependencies": { "should": ">= 0.0.1" }
   , "scripts": { "test": "make test" }


### PR DESCRIPTION
so it will be shown in https://www.npmjs.org/package/commander (not only in readme part).
