### PR TITLE
Add support for variadic arguments

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -38,6 +38,37 @@ console.log('  - %s cheese', program.cheese);
 
  Short flags may be passed as a single arg, for example `-abc` is equivalent to `-a -b -c`. Multi-word options such as "--template-engine" are camel-cased, becoming `program.templateEngine` etc.
 
+## Variadic arguments
+
+ The last argument of a command can be variadic, and only the last argument.  To make an argument variadic you have to
+ append `...` to the argument name.  Here is an example:
+
+```js
+#!/usr/bin/env node
+
+/**
+ * Module dependencies.
+ */
+
+var program = require('commander');
+
+program
+  .version('0.0.1')
+  .command('rmdir <dir> [otherDirs...]')
+  .action(function (dir, otherDirs) {
+    console.log('rmdir %s', dir);
+    if (otherDirs) {
+      otherDirs.forEach(function (oDir) {
+        console.log('rmdir %s', oDir);
+      });
+    }
+  })
+  .parse(process.argv);
+```
+
+ An `Array` is used for the value of a variadic argument.  This applies to `program.args` as well as the argument passed
+ to your action as demonstrated above.
+
 ## Automated --help
 
  The help information is auto-generated based on the information commander already knows about your program, so the following `--help` info is for free:
@@ -178,7 +209,7 @@ Examples:
  - [more progress bars](https://github.com/substack/node-multimeter)
  - [examples](https://github.com/visionmedia/commander.js/tree/master/examples)
 
-## License 
+## License
 
 (The MIT License)
 

--- a/test/test.variadic.args.js
+++ b/test/test.variadic.args.js
@@ -1,0 +1,61 @@
+/**
+ * Module dependencies.
+ */
+
+var program = require('../')
+  , should = require('should')
+  , util = require('util')
+  , programArgs = ['node', 'test', 'mycommand', 'arg0', 'arg1', 'arg2', 'arg3']
+  , requiredArg
+  , variadicArg;
+
+program
+  .version('0.0.1')
+  .command('mycommand <requiredArg> [variadicArg...]')
+  .action(function (arg0, arg1) {
+    requiredArg = arg0;
+    variadicArg = arg1;
+  });
+
+program.parse(programArgs);
+
+requiredArg.should.eql('arg0');
+variadicArg.should.eql(['arg1', 'arg2', 'arg3']);
+
+program.args[0].should.eql('arg0');
+program.args[1].should.eql(['arg1', 'arg2', 'arg3']);
+
+program
+  .version('0.0.1')
+  .command('mycommand <variadicArg...> [optionalArg]')
+  .action(function (arg0, arg1) {
+
+  });
+
+// Make sure we still catch errors with required values for options
+var consoleErrors = [];
+var oldProcessExit = process.exit;
+var oldConsoleError = console.error;
+var errorMessage;
+
+process.exit = function() { throw new Error(consoleErrors.join('\n')); };
+console.error = function() {
+  consoleErrors.push(util.format.apply(util, arguments));
+};
+
+try {
+  program.parse(programArgs);
+
+  should.fail(null, null, 'An Error should had been thrown above');
+} catch (err) {
+  errorMessage = err.message;
+}
+
+process.exit = oldProcessExit;
+console.error = oldConsoleError;
+
+[
+  '',
+  '  error: variadic arguments must be last `variadicArg\'',
+  ''
+].join('\n').should.eql(errorMessage);


### PR DESCRIPTION
This is a quick attempt at fixing issue #53.  It works by allowing the user to mark the last argument as variadic by appending `...` to the argument name.  Here is an example:  `.command('mycommand <requiredArg> [variadicArg...]')`.  If you attempt to mark an argument as variadic but it is not the last argument, you will get an error.  Here is an example: `.command('mycommand <variadicArg...> [nonVariadicArg]')`. _(As I type out this message, I realize it could be possible to get fancy and allow commingling of variadic and regular arguments where possible but it would get pretty tricky and I think this is a good start.)_

Also, whenever the `action` is called, the arguments are proper such that the variadic argument is an `Array` of arguments.  So if I were to invoke my command like this `node myapp mycommand arg0 arg1 arg2 arg3`, my action function signature could look like this `function (requiredArg, variadicArg)` and `requiredArg` would have a value of `'arg0'` while `variadicArg` would have a value of `['arg1', 'arg2', 'arg3']`.  `program.args` is also proper such that its value would be this: `['arg0', ['arg1', 'arg2', 'arg3'], [Object object]` where the last argument is the program itself.

Fixes #53
