### PR TITLE
fix a bug in the `Variadic arguments` demo

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -65,8 +65,9 @@ program
         console.log('rmdir %s', oDir);
       });
     }
-  })
-  .parse(process.argv);
+  });
+
+program.parse(process.argv);
 ```
 
  An `Array` is used for the value of a variadic argument.  This applies to `program.args` as well as the argument passed


### PR DESCRIPTION
There's a bug in the `Variadic arguments` demo.  

cc @whitlockjc 
