### PR TITLE
Make app name settable #292

### DIFF
--- a/index.js
+++ b/index.js
@@ -787,7 +787,7 @@ Command.prototype.usage = function(str) {
 };
 
 /**
- * Get the name of the command
+ * Get/set the name of the command
  *
  * @param {String} name
  * @return {String|Command}
@@ -795,7 +795,9 @@ Command.prototype.usage = function(str) {
  */
 
 Command.prototype.name = function(name) {
-  return this._name;
+  if (0 == arguments.length) return this._name;
+  this._name = name;
+  return this;
 };
 
 /**


### PR DESCRIPTION
Turns out this was ever easier than I thought it would be. The `prototype.name` function already took a name parameter, but for some reason didn't allow setting?

With this alteration you can now set the name of your command very much like you would the description.

```
program = require('commander')

program
  .name('nice-cli-name')
  .description('your standard app')
```
