### PR TITLE
add executable arguments to spawn

### DIFF
--- a/index.js
+++ b/index.js
@@ -457,9 +457,7 @@ Command.prototype.executeSubCommand = function(argv, args, unknown) {
   args.unshift(local);
 
   // add executable arguments to spawn
-  for (var i = 0; i < process.execArgv.length; i++) {
-    args.unshift(process.execArgv[i]);
-  }
+  args = process.execArgv.concat(args);
 
   // run it
   var proc = spawn('node', args, { stdio: 'inherit', customFds: [0, 1, 2] });

--- a/index.js
+++ b/index.js
@@ -452,9 +452,16 @@ Command.prototype.executeSubCommand = function(argv, args, unknown) {
   // check for ./<bin> first
   var local = path.join(dir, bin);
 
-  // run it
+  // arguments
   args = args.slice(1);
   args.unshift(local);
+
+  // add executable arguments to spawn
+  for (var i = 0; i < process.execArgv.length; i++) {
+    args.unshift(process.execArgv[i]);
+  }
+
+  // run it
   var proc = spawn('node', args, { stdio: 'inherit', customFds: [0, 1, 2] });
   proc.on('error', function(err) {
     if (err.code == "ENOENT") {


### PR DESCRIPTION
A slight modification to inject node arguments into sub-commands. Specifically, I made it to allow the --harmony flag to perpetuate to sub-commands.

I'm not quite sure how to write a test for this as no tests exist to test the function as is. See: [#290](https://github.com/tj/commander.js/issues/290)