### PR TITLE
Removed 'prompt' from keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "commander"
   , "version": "2.6.0"
   , "description": "the complete solution for node.js command-line programs"
-  , "keywords": ["command", "option", "parser", "prompt"]
+  , "keywords": ["command", "option", "parser"]
   , "author": "TJ Holowaychuk <tj@vision-media.ca>"
   , "license": "MIT"
   , "repository": { "type": "git", "url": "https://github.com/tj/commander.js.git" }


### PR DESCRIPTION
prompt functionality was removed along with other input methods in v2.0.0.
No need to be in the keyword list or [here](https://www.npmjs.com/search?q=prompt)
