### PR TITLE
Allowing RegEx options

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -86,6 +86,18 @@ console.log(' verbosity: %j', program.verbose);
 console.log(' args: %j', program.args);
 ```
 
+## Regular Expression
+```js
+program
+  .version('0.0.1')
+  .option('-s --size <size>', 'Pizza size', /^(large|medium|small)$/i, 'medium')
+  .option('-d --drink [drink]', 'Drink', /^(coke|pepsi|izze)$/i)
+  .parse(process.argv);
+  
+console.log(' size: %j', program.size);
+console.log(' drink: %j', program.drink);
+```
+
 ## Variadic arguments
 
  The last argument of a command can be variadic, and only the last argument.  To make an argument variadic you have to

--- a/examples/regex
+++ b/examples/regex
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+
+/**
+ * Module dependencies.
+ */
+
+var program = require('../');
+
+program
+  .version('0.0.1')
+  .usage('test')
+  .option('-s --size <size>', 'Pizza size', /^(large|medium|small)$/i, 'medium')
+  .option('-d --drink [drink]', 'Drink', /^(coke|pepsi|izze)$/i)
+  .parse(process.argv);
+  
+console.log(' size: %j', program.size);
+console.log(' drink: %j', program.drink);

--- a/index.js
+++ b/index.js
@@ -349,8 +349,17 @@ Command.prototype.option = function(flags, description, fn, defaultValue) {
 
   // default as 3rd arg
   if (typeof fn != 'function') {
-    defaultValue = fn;
-    fn = null;
+    if (fn instanceof RegExp) {
+      var regex = fn;
+      fn = function(val, def) {
+        var m = regex.exec(val);
+        return m ? m[0] : def;
+      }
+    }
+    else {
+      defaultValue = fn;
+      fn = null;
+    }
   }
 
   // preassign default value only for --no-*, [optional], or <required>

--- a/test/test.options.regex.js
+++ b/test/test.options.regex.js
@@ -1,0 +1,16 @@
+/**
+ * Module dependencies.
+ */
+
+var program = require('../')
+  , should = require('should');
+
+
+program
+  .version('0.0.1')
+  .option('-s, --size <size>', 'Pizza Size', /^(large|medium|small)$/i, 'medium')
+  .option('-d, --drink [drink]', 'Drink', /^(Coke|Pepsi|Izze)$/i)
+
+program.parse('node test -s big -d coke'.split(' '));
+program.size.should.equal('medium');
+program.drink.should.equal('coke');


### PR DESCRIPTION
Piggybacking on [coercion](https://github.com/tj/commander.js#coercion) to support options with regular expressions.

This feature allows limiting pre-defined set of values for options.

Taking the Pizza example, the options for size can be limited to /^(large|medium|small)$/i.