### PR TITLE
Add docs badge to README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -3,6 +3,7 @@
  [![Build Status](https://api.travis-ci.org/tj/commander.js.svg)](http://travis-ci.org/tj/commander.js)
 [![NPM Version](http://img.shields.io/npm/v/commander.svg?style=flat)](https://www.npmjs.org/package/commander)
 [![NPM Downloads](https://img.shields.io/npm/dm/commander.svg?style=flat)](https://www.npmjs.org/package/commander)
+[![Inline docs](http://inch-ci.org/github/tj/commander.js.svg?branch=master)](http://inch-ci.org/github/tj/commander.js)
 
   The complete solution for [node.js](http://nodejs.org) command-line interfaces, inspired by Ruby's [commander](https://github.com/tj/commander).  
   [API documentation](http://tj.github.com/commander.js/)


### PR DESCRIPTION
Hi there,

I want to propose to add this badge to the README to show off inline-documentation: [![Inline docs](http://inch-ci.org/github/tj/commander.js.svg?branch=master)](http://inch-ci.org/github/tj/commander.js)

The badge shows an evaluation by [InchJS](http://trivelop.de/inchjs), a project that tries to raise the visibility of inline-docs in Open Source to encourage aspiring programmers to document their code. So far over 500 Ruby projects **including [Commander](https://github.com/tj/commander)** are sporting these badges to raise awareness for the importance of inline-docs and to show potential contributors that they can expect a certain level of code documentation when they dive into your code.

I would really like to do the same for the **JavaScript** community and although this is "only" a passion project, I really would like to hear your thoughts, critique and suggestions. Your status page is https://inch-ci.org/github/tj/commander.js

What do you think?