### PR TITLE
Add support for optional boolean flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -388,7 +388,7 @@ Command.prototype.option = function(flags, description, fn, defaultValue) {
         self[name] = option.bool
           ? defaultValue || true
           : false;
-      } else {
+      } else if (option.flags.indexOf('boolean') === -1) {
         self[name] = val;
       }
     } else if (null !== val) {

--- a/index.js
+++ b/index.js
@@ -388,7 +388,9 @@ Command.prototype.option = function(flags, description, fn, defaultValue) {
         self[name] = option.bool
           ? defaultValue || true
           : false;
-      } else if (option.flags.indexOf('boolean') === -1) {
+      } else if (option.flags.indexOf('<boolean>') > -1 || option.flags.indexOf('[boolean]') > -1) {
+        self[name] = (val === 'true');
+      } else {
         self[name] = val;
       }
     } else if (null !== val) {

--- a/test/test.options.bool.optional.given.js
+++ b/test/test.options.bool.optional.given.js
@@ -1,0 +1,21 @@
+/**
+ * Module dependencies.
+ */
+
+var program = require('../')
+  , should = require('should');
+
+//can be loaded from a config file
+var config = {
+  pepper: true,
+  cheese: false
+}
+
+program
+  .version('0.0.1')
+  .option('-p, --pepper [boolean]', 'add pepper', config.pepper || false)
+  .option('-c, --cheese [boolean]', 'remove cheese', config.cheese || false);
+
+program.parse(['node', 'test', '--pepper', 'false', '--cheese', 'true']);
+program.pepper.should.be.false;
+program.cheese.should.be.true;

--- a/test/test.options.bool.optional.js
+++ b/test/test.options.bool.optional.js
@@ -1,0 +1,21 @@
+/**
+ * Module dependencies.
+ */
+
+var program = require('../')
+  , should = require('should');
+
+//can be loaded from a config file
+var config = {
+  pepper: true,
+  cheese: false
+}
+
+program
+  .version('0.0.1')
+  .option('-p, --pepper [boolean]', 'add pepper', config.pepper || false)
+  .option('-c, --cheese [boolean]', 'remove cheese', config.cheese || false);
+
+program.parse(['node', 'test']);
+program.pepper.should.be.true;
+program.cheese.should.be.false;


### PR DESCRIPTION
This seems to fix the use-case described in https://github.com/tj/commander.js/issues/344 and should not really break any existing code, since it is based on the existence of `boolean` in the flags.
Now that I am saying that, checking for `<boolean>` and `[boolean]` might be better.

Also don't know if that ever was the intended use, but it seems quite intuitive to me and would be really useful.