### PR TITLE
Issue #346, fix collisions when option and first arg have same name

### DIFF
--- a/index.js
+++ b/index.js
@@ -287,8 +287,9 @@ Command.prototype.action = function(fn) {
 
     fn.apply(self, args);
   };
-  this.parent.on(this._name, listener);
-  if (this._alias) this.parent.on(this._alias, listener);
+  this._hasAction = true;
+  this.parent.on('action_' + this._name, listener);
+  if (this._alias) this.parent.on('action_' + this._alias, listener);
   return this;
 };
 
@@ -562,8 +563,8 @@ Command.prototype.parseArgs = function(args, unknown) {
 
   if (args.length) {
     name = args[0];
-    if (this.listeners(name).length) {
-      this.emit(args.shift(), args, unknown);
+    if (this.listeners('action_' + name).length) {
+      this.emit('action_' + args.shift(), args, unknown);
     } else {
       this.emit('*', args);
     }

--- a/index.js
+++ b/index.js
@@ -287,7 +287,6 @@ Command.prototype.action = function(fn) {
 
     fn.apply(self, args);
   };
-  this._hasAction = true;
   this.parent.on('action_' + this._name, listener);
   if (this._alias) this.parent.on('action_' + this._alias, listener);
   return this;

--- a/test/test.options.same-name-arg.js
+++ b/test/test.options.same-name-arg.js
@@ -1,0 +1,14 @@
+/**
+ * Module dependencies.
+ */
+
+var program = require('../')
+  , should = require('should');
+
+program
+  .version('0.0.1')
+  .option('--string <n>', 'pass a string')
+
+program.parse('node test string --string myString'.split(' '));
+program.string.should.equal('myString');
+program.args.should.containEql('string');


### PR DESCRIPTION
This is detailed in full in #346.

This PR has a test case demonstrates the error in the current master, and a less-than-elegant, but non-invasive way to avoid the error of conflicting action and option listeners without negatively impacting either. I am open to better solutions, but other than establishing a separate emitter for both options and actions, I don't know a better way than a naming convention (`action_` prefix) to keep them from colliding, in my brief inspection anyway.