### PR TITLE
Add support for camelCase on opts()

### DIFF
--- a/index.js
+++ b/index.js
@@ -688,7 +688,7 @@ Command.prototype.opts = function() {
     , len = this.options.length;
 
   for (var i = 0 ; i < len; i++) {
-    var key = this.options[i].name();
+    var key = camelcase(this.options[i].name());
     result[key] = key === 'version' ? this._version : this[key];
   }
   return result;

--- a/test/test.options.func.js
+++ b/test/test.options.func.js
@@ -7,9 +7,10 @@ program
   .option('-f, --foo', 'add some foo')
   .option('-b, --bar', 'add some bar')
   .option('-M, --no-magic', 'disable magic')
+  .option('-c, --camel-case', 'convert to camelCase')
   .option('-q, --quux <quux>', 'add some quux');
 
-program.parse(['node', 'test', '--foo', '--bar', '--no-magic', '--quux', 'value']);
+program.parse(['node', 'test', '--foo', '--bar', '--no-magic', '--camel-case', '--quux', 'value']);
 program.opts.should.be.a.Function;
 
 var opts = program.opts();
@@ -18,4 +19,5 @@ opts.version.should.equal('0.0.1');
 opts.foo.should.be.true;
 opts.bar.should.be.true;
 opts.magic.should.be.false;
+opts.camelCase.should.be.true;
 opts.quux.should.equal('value');


### PR DESCRIPTION
Fix `opts()` fails to return an option something like `--foo-bar`.