### PR TITLE
Add camelCase example to `Readme.md`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -31,14 +31,14 @@ program
   .version('0.0.1')
   .option('-p, --peppers', 'Add peppers')
   .option('-P, --pineapple', 'Add pineapple')
-  .option('-b, --bbq', 'Add bbq sauce')
+  .option('-b, --bbq-sauce', 'Add bbq sauce')
   .option('-c, --cheese [type]', 'Add the specified type of cheese [marble]', 'marble')
   .parse(process.argv);
 
 console.log('you ordered a pizza with:');
 if (program.peppers) console.log('  - peppers');
 if (program.pineapple) console.log('  - pineapple');
-if (program.bbq) console.log('  - bbq');
+if (program.bbqSauce) console.log('  - bbq');
 console.log('  - %s cheese', program.cheese);
 ```
 


### PR DESCRIPTION
The first example `Readme.md` doesn't include an example of how
options with dashes are converted to camelCased properties on the
`program` variable. This confused me for quite a while (I was trying
to do something like `program['bbq-sauce']`).

Even though it says so in text right below the example, I think I'm not
the only who learns library usage _only_ through the examples.

This commit changes the `bbq` option in the example to `bbq-sauce` in
order to make this clear.