### PR TITLE
Added .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+.*
+test
+Makefile
+History.md


### PR DESCRIPTION
Primarily because (at least on my box) npm complains during install about the symbolic link `test/fixtures/pmlink` since it [doesn't support including them](https://github.com/npm/npm/issues/3310#issuecomment-15904722).

```bash
npm WARN excluding symbolic link test/fixtures/pmlink -> ./pm
```
Note that I also excluded hidden files and some other things that IMO serve no purpose being sent along.