### PR TITLE
Given git-style sub-commands, display help if none called

### DIFF
--- a/index.js
+++ b/index.js
@@ -443,6 +443,12 @@ Command.prototype.parse = function(argv) {
   // guess name
   this._name = this._name || basename(argv[1], '.js');
 
+  // github-style sub-commands with no sub-command
+  if (this.executables && argv.length < 3) {
+    // this user needs help
+    argv.push('--help');
+  }
+
   // process argv
   var parsed = this.parseOptions(this.normalize(argv.slice(2)));
   var args = this.args = parsed.args;

--- a/test/test.command.name.js
+++ b/test/test.command.name.js
@@ -1,5 +1,9 @@
 var program = require('../')
+  , sinon = require('sinon').sandbox.create()
   , should = require('should');
+
+sinon.stub(process, 'exit');
+sinon.stub(process.stdout, 'write');
 
 program
   .command('mycommand [options]', 'this is my command');
@@ -10,3 +14,11 @@ program.name.should.be.a.Function;
 program.name().should.equal('test');
 program.commands[0].name().should.equal('mycommand');
 program.commands[1].name().should.equal('help');
+
+var output = process.stdout.write.args[0];
+
+output[0].should.containEql([
+  '    mycommand [options]  this is my command'
+].join('\n'));
+
+sinon.restore();


### PR DESCRIPTION
When one types `git` and hits enter, top-level git help output appears.

Presently, `./examples/pm` does not follow this behavior; the command simply outputs nothing.

This patch fixes this by injecting `--help` into argv. This approach to the problem causes the `outputHelpIfNecessary` method to behave as expected in existing test cases, yet displays help output in use case described.