### PR TITLE
Allow for commands to be hidden from help menu

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,7 +156,8 @@ Command.prototype.__proto__ = EventEmitter.prototype;
  * @api public
  */
 
-Command.prototype.command = function(name, desc) {
+Command.prototype.command = function(name, desc, opts) {
+  opts = opts || {};
   var args = name.split(/ +/);
   var cmd = new Command(args.shift());
 
@@ -166,6 +167,7 @@ Command.prototype.command = function(name, desc) {
     this._execs[cmd._name] = true;
   }
 
+  cmd._noHelp = !!opts.noHelp;
   this.commands.push(cmd);
   cmd.parseExpectedArgs(args);
   cmd.parent = this;
@@ -900,7 +902,9 @@ Command.prototype.optionHelp = function() {
 Command.prototype.commandHelp = function() {
   if (!this.commands.length) return '';
 
-  var commands = this.commands.map(function(cmd) {
+  var commands = this.commands.filter(function(cmd) {
+    return !cmd._noHelp;
+  }).map(function(cmd) {
     var args = cmd._args.map(function(arg) {
       return humanReadableArgName(arg);
     }).join(' ');

--- a/test/test.command.nohelp.js
+++ b/test/test.command.nohelp.js
@@ -1,0 +1,46 @@
+var program = require('../')
+	, sinon = require('sinon').sandbox.create()
+  , should = require('should');
+
+program.command('mycommand [options]', 'this is my command');
+
+program
+	.command('anothercommand [options]')
+  .action(function() { return; });
+
+program.command('hiddencommand [options]', 'you won\'t see me', { noHelp: true });
+
+program
+	.command('hideagain [options]', null, { noHelp: true })
+  .action(function() { return; });
+
+program.parse(['node', 'test']);
+
+program.name.should.be.a.Function;
+program.name().should.equal('test');
+program.commands[0].name().should.equal('mycommand');
+program.commands[0]._noHelp.should.be.false;
+program.commands[1].name().should.equal('anothercommand');
+program.commands[1]._noHelp.should.be.false;
+program.commands[2].name().should.equal('hiddencommand');
+program.commands[2]._noHelp.should.be.true;
+program.commands[3].name().should.equal('hideagain');
+program.commands[3]._noHelp.should.be.true;
+program.commands[4].name().should.equal('help');
+
+sinon.stub(process.stdout, 'write');
+program.outputHelp();
+
+process.stdout.write.calledOnce.should.be.true;
+process.stdout.write.args.length.should.equal(1);
+
+var output = process.stdout.write.args[0];
+sinon.restore();
+
+output[0].should.containEql([
+	'  Commands:',
+	'',
+	'    mycommand [options]       this is my command',
+	'    anothercommand [options]  ',
+	'    help [cmd]                display help for [cmd]'
+].join('\n'));


### PR DESCRIPTION
This PR allows you to specify a command for commander.js, but prevent it from showing up in the help listing. My particular use case is that I'm writing a CLI which is going to be leveraged by a GUI. There are specific commands (and options) that are only going to be relevant when invoked by the GUI's special use cases. The commands are not relevant to the straight-up CLI user, and therefore I don't want to display them to the user when they call for `help`.

I'm not married to the API here, which simply allows for a 3rd arg to be passed to the `command()` function. I think it works, it's functional, and it doesn't interfere with any existing code, but I'm open to suggestions. Particularly considering that if this PR is accepted I'd like to do the same for options. Given the complexity of the `option()` API compared to the `command()` one, though,  I figured `command()` was a simpler place to start.

The change and intended usage can be found in the test included with this PR.