### PR TITLE
Add .npmignore to exclude unnecessary development files from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+.DS_Store
+*.sock
+.idea
+
+# Development files
+/test/
+/.travis.yml


### PR DESCRIPTION
I copied .gitignore as .npmignore and added a few development files and folders to be excluded from the npm package as they're unnecessary. Also removed node_modules as it's unnecessary as per npm's documentation.