### PR TITLE
add coverage reporting using nyc and coveralls.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 node_modules
 *.sock
 .idea
+coverage
+nyc_output

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "0.6"
   - "0.8"
   - "0.10"
   - "0.12"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ node_js:
   - "0.10"
   - "0.12"
   - "io.js"
+after_success: npm run coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ node_js:
   - "0.12"
   - "io.js"
 after_success: npm run coveralls
+before_install:
+  - npm install -g npm@~1.4.28

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ node_js:
   - "io.js"
 after_success: npm run coveralls
 before_install:
-  - npm install -g npm@~1.4.28
+  - npm install -g npm@2.10.0

--- a/Readme.md
+++ b/Readme.md
@@ -5,6 +5,8 @@
 [![NPM Version](http://img.shields.io/npm/v/commander.svg?style=flat)](https://www.npmjs.org/package/commander)
 [![NPM Downloads](https://img.shields.io/npm/dm/commander.svg?style=flat)](https://www.npmjs.org/package/commander)
 [![Join the chat at https://gitter.im/tj/commander.js](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/tj/commander.js?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Coverage Status](https://coveralls.io/repos/tj/commander.js/badge.svg?branch=)](https://coveralls.io/r/tj/commander.js?branch=)
+
 
   The complete solution for [node.js](http://nodejs.org) command-line interfaces, inspired by Ruby's [commander](https://github.com/tj/commander).  
   [API documentation](http://tj.github.com/commander.js/)
@@ -95,7 +97,7 @@ program
   .option('-s --size <size>', 'Pizza size', /^(large|medium|small)$/i, 'medium')
   .option('-d --drink [drink]', 'Drink', /^(coke|pepsi|izze)$/i)
   .parse(process.argv);
-  
+
 console.log(' size: %j', program.size);
 console.log(' drink: %j', program.drink);
 ```
@@ -339,4 +341,3 @@ More Demos can be found in the [examples](https://github.com/tj/commander.js/tre
 ## License
 
 MIT
-

--- a/package.json
+++ b/package.json
@@ -14,11 +14,15 @@
     "url": "https://github.com/tj/commander.js.git"
   },
   "devDependencies": {
+    "coveralls": "^2.11.2",
+    "nyc": "^2.1.4",
     "should": ">= 0.0.1",
     "sinon": ">= 1.14.1"
   },
   "scripts": {
-    "test": "make test"
+    "test": "make test",
+    "coverage": "nyc npm test && nyc report",
+    "coveralls": "nyc npm test && nyc report --reporter=text-lcov | coveralls"
   },
   "main": "index",
   "engines": {


### PR DESCRIPTION
This pull adds coverage reporting, using coveralls.io and the [nyc](https://www.npmjs.com/package/nyc) instrumenter.

* run `npm run coverage` to get a human readable coverage report.
* run `npm run coverage -- --reporter=lcov` to get an HTML report over coverage in the /coverage folder.
* run `npm run coveralls` to report coverage to the [coveralls.io](https://coveralls.io/).
  * you'll need to setup your repo on coveralls.io and grap the `COVERALLS_REPO_TOKEN`.
  * on travis-ci.org, you'll need to set an environment variable with the value of `COVERALLS_REPO_TOKEN `

Here's what the report looks like:

```shell
---------------|-----------|-----------|-----------|-----------|
File           |   % Stmts |% Branches |   % Funcs |   % Lines |
---------------|-----------|-----------|-----------|-----------|
   ./          |     94.25 |     88.94 |     94.55 |     95.38 |
      index.js |     94.25 |     88.94 |     94.55 |     95.38 |
---------------|-----------|-----------|-----------|-----------|
All files      |     94.25 |     88.94 |     94.55 |     95.38 |
---------------|-----------|-----------|-----------|-----------|
```
