### PR TITLE
Remove `parseRange` function

### DIFF
--- a/test/test.options.hyphen.js
+++ b/test/test.options.hyphen.js
@@ -5,10 +5,6 @@
 var program = require('../')
   , should = require('should');
 
-function parseRange(str) {
-  return str.split('..').map(Number);
-}
-
 program
   .version('0.0.1')
   .option('-a, --alpha <a>', 'hyphen')


### PR DESCRIPTION
There's a reason for the function in this file?