### PR TITLE
add default executable (subcommand) option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -167,12 +167,14 @@ program
   .version('0.0.1')
   .command('install [name]', 'install one or more packages')
   .command('search [query]', 'search with optional query')
-  .command('list', 'list packages installed')
+  .command('list', 'list packages installed', {isDefault: true})
   .parse(process.argv);
 ```
 
 When `.command()` is invoked with a description argument, no `.action(callback)` should be called to handle sub-commands, otherwise there will be an error. This tells commander that you're going to use separate executables for sub-commands, much like `git(1)` and other popular tools.  
 The commander will try to search the executables in the directory of the entry script (like `./examples/pm`) with the name `program-command`, like `pm-install`, `pm-search`.
+
+Options can be passed with the call to `.command()`. Specifying `true` for `opts.noHelp` will remove the option from the generated help output. Specifying `true` for `opts.isDefault` will run the subcommand if no other subcommand is specified.
 
 If the program is designed to be installed globally, make sure the executables have proper modes, like `755`.
 

--- a/index.js
+++ b/index.js
@@ -165,6 +165,7 @@ Command.prototype.command = function(name, desc, opts) {
     cmd.description(desc);
     this.executables = true;
     this._execs[cmd._name] = true;
+    if (opts.isDefault) this.defaultExecutable = cmd._name;
   }
 
   cmd._noHelp = !!opts.noHelp;
@@ -446,7 +447,7 @@ Command.prototype.parse = function(argv) {
   this._name = this._name || basename(argv[1], '.js');
 
   // github-style sub-commands with no sub-command
-  if (this.executables && argv.length < 3) {
+  if (this.executables && argv.length < 3 && !this.defaultExecutable) {
     // this user needs help
     argv.push('--help');
   }
@@ -460,6 +461,10 @@ Command.prototype.parse = function(argv) {
   // executable sub-commands
   var name = result.args[0];
   if (this._execs[name] && typeof this._execs[name] != "function") {
+    return this.executeSubCommand(argv, args, parsed.unknown);
+  } else if (this.defaultExecutable) {
+    // use the default subcommand
+    args.unshift(name = this.defaultExecutable);
     return this.executeSubCommand(argv, args, parsed.unknown);
   }
 

--- a/test/fixtures/pm
+++ b/test/fixtures/pm
@@ -8,4 +8,5 @@ program
   .command('search [query]', 'search with optional query')
   .command('list', 'list packages installed')
   .command('publish', 'publish or update package')
+  .command('default', 'default command', {noHelp: true, isDefault: true})
   .parse(process.argv);

--- a/test/fixtures/pm-default
+++ b/test/fixtures/pm-default
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+console.log('default');

--- a/test/test.command.executableSubcommandDefault.js
+++ b/test/test.command.executableSubcommandDefault.js
@@ -1,0 +1,46 @@
+var exec = require('child_process').exec
+  , path = require('path')
+  , should = require('should');
+
+
+
+var bin = path.join(__dirname, './fixtures/pm')
+// success case
+exec(bin + ' default', function(error, stdout, stderr) {
+  stdout.should.equal('default\n');
+});
+
+// success case (default)
+exec(bin, function(error, stdout, stderr) {
+  stdout.should.equal('default\n');
+});
+
+// not exist
+exec(bin + ' list', function (error, stdout, stderr) {
+  //stderr.should.equal('\n  pm-list(1) does not exist, try --help\n\n');
+  // TODO error info are not the same in between <=v0.8 and later version
+  should.notEqual(0, stderr.length);
+});
+
+// success case
+exec(bin + ' install', function (error, stdout, stderr) {
+  stdout.should.equal('install\n');
+});
+
+// subcommand bin file with explicit extension
+exec(bin + ' publish', function (error, stdout, stderr) {
+  stdout.should.equal('publish\n');
+});
+
+// spawn EACCES
+exec(bin + ' search', function (error, stdout, stderr) {
+  // TODO error info are not the same in between <v0.10 and v0.12
+  should.notEqual(0, stderr.length);
+});
+
+// when `bin` is a symbol link for mocking global install
+var bin = path.join(__dirname, './fixtures/pmlink')
+// success case
+exec(bin + ' install', function (error, stdout, stderr) {
+  stdout.should.equal('install\n');
+});


### PR DESCRIPTION
This PR introduces an option for the `.command()` call that allows git-style subcommands to default to a specific command in the event one isn't provided on the command line.

The use case that brought about this PR was a build system I'm developing needing to run the subcommand `build` automatically when nothing was specified on the command line. I'm sure there is a hack that could have done this with `.action()` but alas I wanted it to work with the executable functionality (i.e. having another script to do run the command).

I'm sure I'm not the only one who can find a use case for this.

Test is included (based off of the pm-subcommand test) and shouldn't interfere with the existing test.

Also added some documentation (including documentation for the previously undocumented `opts.noHelp` option).

I tried to keep the implementation as minimal as possible. Let me know if I need to change anything.