### PR TITLE
Move 'description' to the top

### DIFF
--- a/index.js
+++ b/index.js
@@ -975,9 +975,11 @@ Command.prototype.commandHelp = function() {
 
 Command.prototype.helpInformation = function() {
   var desc = [];
-  if (this._description) {
+  if (this.description) {
     desc = [
-      '  ' + this._description
+      '  Description:'
+      ,''
+      ,'    ' + this.description
       , ''
     ];
   }

--- a/index.js
+++ b/index.js
@@ -975,11 +975,17 @@ Command.prototype.commandHelp = function() {
 
 Command.prototype.helpInformation = function() {
   var desc = [];
-  if (this.description) {
+  var descrString;
+  if (typeof(this.description) === 'string') {
+    descrString = this.description;
+  } else {
+    descrString = this.description();
+  }
+  if (descrString) {
     desc = [
       '  Description:'
       ,''
-      ,'    ' + this.description
+      ,'    ' + descrString
       , ''
     ];
   }

--- a/index.js
+++ b/index.js
@@ -1005,8 +1005,8 @@ Command.prototype.helpInformation = function() {
   ];
 
   return usage
-    .concat(cmds)
     .concat(desc)
+    .concat(cmds)
     .concat(options)
     .join('\n');
 };


### PR DESCRIPTION
This moves the program's description in the help display up from between commands and options to the top.