### PR TITLE
Default value not set on function options

### DIFF
--- a/index.js
+++ b/index.js
@@ -376,6 +376,10 @@ Command.prototype.option = function(flags, description, fn, defaultValue) {
       defaultValue = fn;
       fn = null;
     }
+  } else if (undefined !== defaultValue) {
+    // If the 3rd arg is a function and a default value is given preassign it so
+    // that the default value is available even if the option isn't passed
+    self[name] = defaultValue;
   }
 
   // preassign default value only for --no-*, [optional], or <required>

--- a/test/test.options.defaults.given.js
+++ b/test/test.options.defaults.given.js
@@ -5,19 +5,25 @@
 var program = require('../')
   , should = require('should');
 
+function increaseVerbosity(v, total) {
+  return total + 1;
+}
+
 program
   .version('0.0.1')
   .option('-a, --anchovies', 'Add anchovies?')
   .option('-o, --onions', 'Add onions?', true)
-  .option('-v, --olives', 'Add olives? Sorry we only have black.', 'black')
+  .option('-l, --olives', 'Add olives? Sorry we only have black.', 'black')
   .option('-s, --no-sauce', 'Uh… okay')
   .option('-r, --crust <type>', 'What kind of crust would you like?', 'hand-tossed')
-  .option('-c, --cheese [type]', 'optionally specify the type of cheese', 'mozzarella');
+  .option('-c, --cheese [type]', 'optionally specify the type of cheese', 'mozzarella')
+  .option('-v, --verbose', 'increase verbosity', increaseVerbosity, 3);
 
-program.parse(['node', 'test', '--anchovies', '--onions', '--olives', '--no-sauce', '--crust', 'thin', '--cheese', 'wensleydale']);
+program.parse(['node', 'test', '--anchovies', '--onions', '--olives', '--no-sauce', '--crust', 'thin', '--cheese', 'wensleydale', '-v', '-v']);
 program.should.have.property('anchovies', true);
 program.should.have.property('onions', true);
 program.should.have.property('olives', 'black');
 program.should.have.property('sauce', false);
 program.should.have.property('crust', 'thin');
 program.should.have.property('cheese', 'wensleydale');
+program.should.have.property('verbose', 5);

--- a/test/test.options.defaults.js
+++ b/test/test.options.defaults.js
@@ -5,14 +5,19 @@
 var program = require('../')
   , should = require('should');
 
+function increaseVerbosity(v, total) {
+  return total + 1;
+}
+
 program
   .version('0.0.1')
   .option('-a, --anchovies', 'Add anchovies?')
   .option('-o, --onions', 'Add onions?', true)
-  .option('-v, --olives', 'Add olives? Sorry we only have black.', 'black')
+  .option('-l, --olives', 'Add olives? Sorry we only have black.', 'black')
   .option('-s, --no-sauce', 'Uh… okay')
   .option('-r, --crust <type>', 'What kind of crust would you like?', 'hand-tossed')
-  .option('-c, --cheese [type]', 'optionally specify the type of cheese', 'mozzarella');
+  .option('-c, --cheese [type]', 'optionally specify the type of cheese', 'mozzarella')
+  .option('-v, --verbose', 'increase verbosity', increaseVerbosity, 12);
 
 program.should.have.property('_name', '');
 
@@ -24,3 +29,4 @@ program.should.not.have.property('olives');
 program.should.have.property('sauce', true);
 program.should.have.property('crust', 'hand-tossed');
 program.should.have.property('cheese', 'mozzarella');
+program.should.have.property('verbose', 12);


### PR DESCRIPTION
When a function is passed as the third argument to `.option` the default
value from the fourth argument isn't set when the flag/option isn't
given on the commmand line.

E.g. in the README 

```
.option('-v, --verbose', 'A value that can be increased', increaseVerbosity, 0)
```

if no `-v` or `-verbose` flag is passed then `program.verbose` will be `undefined` rather than `0`.
I feel that this is unexpected and not intended behavior.

This commit fixes the problem (as far as I can figure) and adds tests to
ensure the functionality works.
