### PR TITLE
Explicitly return from error methods

### DIFF
--- a/test/test.options.args.required.noexit.js
+++ b/test/test.options.args.required.noexit.js
@@ -1,0 +1,24 @@
+/**
+ * Module dependencies.
+ */
+
+var util = require('util')
+  , program = require('../')
+  , should = require('should');
+
+var oldProcessExit = process.exit;
+
+// Test for clients that override process.exit
+process.exit = function () {
+};
+
+program
+  .version('0.0.1')
+  .option('-c, --cheese <type>', 'specify the type of cheese')
+  .action(function() {
+    should.fail(null, null, 'The action should not have been executed');
+  });
+
+program.parse(['node', 'test', '--cheese']);
+
+process.exit = oldProcessExit;

--- a/test/test.variadic.args.missing.noexit.js
+++ b/test/test.variadic.args.missing.noexit.js
@@ -1,0 +1,24 @@
+/**
+ * Module dependencies.
+ */
+
+var program = require('../')
+  , should = require('should')
+  , programArgs = ['node', 'test', 'mycommand', 'arg0', 'arg1', 'arg2', 'arg3'];
+
+var oldProcessExit = process.exit;
+
+// Test for clients that override process.exit
+process.exit = function () {
+};
+
+program
+  .version('0.0.1')
+  .command('mycommand <variadicArg...> [optionalArg]')
+  .action(function (arg0, arg1) {
+    should.fail(null, null, 'The action should not have been executed');
+  });
+
+program.parse(programArgs);
+
+process.exit = oldProcessExit;


### PR DESCRIPTION
Instead of relying on process.exit() to terminate execution, also explicitly
return from methods when errors are encountered. This is more flexible for
clients who which to override the methods that use process.exit() in order
to use commander in other contexts than the shell

Fixes #443
