### PR TITLE
Fixed #37, --help should not display first

### DIFF
--- a/index.js
+++ b/index.js
@@ -914,10 +914,9 @@ Command.prototype.optionHelp = function() {
   var width = this.largestOptionLength();
 
   // Prepend the help information
-  return [pad('-h, --help', width) + '  ' + 'output usage information']
-    .concat(this.options.map(function(option) {
+  return this.options.map(function(option) {
       return pad(option.flags, width) + '  ' + option.description;
-      }))
+    }).concat([pad('-h, --help', width) + '  ' + 'output usage information'])
     .join('\n');
 };
 


### PR DESCRIPTION
Although the original suggestion was from 2011, the issue is still open.  So if this issue is still relevant here is a pull request to move the `--help` option to the end.
