### PR TITLE
stick to module.exports for clarity

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,19 +14,19 @@ var fs = require('fs');
  * Expose the root command.
  */
 
-exports = module.exports = new Command();
+module.exports = new Command();
 
 /**
  * Expose `Command`.
  */
 
-exports.Command = Command;
+module.exports.Command = Command;
 
 /**
  * Expose `Option`.
  */
 
-exports.Option = Option;
+module.exports.Option = Option;
 
 /**
  * Initialize a new `Option` with the given `flags` and `description`.


### PR DESCRIPTION
- no point using `exports.` as Node ALWAYS uses `module.exports`
- if `exports.x` and `module.exports.x` are stated, which is used? no one knows... that's why better to stick to one, just cleaner... avoid clutter, too :)