### PR TITLE
Only slice off 1 item from argv, not 2.

### DIFF
--- a/index.js
+++ b/index.js
@@ -452,7 +452,7 @@ Command.prototype.parse = function(argv) {
   }
 
   // process argv
-  var parsed = this.parseOptions(this.normalize(argv.slice(2)));
+  var parsed = this.parseOptions(this.normalize(argv.slice(1)));
   var args = this.args = parsed.args;
 
   var result = this.parseArgs(this.args, parsed.unknown);


### PR DESCRIPTION
Only slice off 1 item from argv, not 2.

Reason:
Normally, it's ok to slice off the first two arguments when doing `node project.js -p paramvalue ...` -> `[ '-p', 'paramvalue',...]`
However, I recently converted my project to an executable using JXCore. So now, I'm doing `project.exe -p paramvalue ...`. Slicing off the first two arguments will result in the -p not even being passed to Commander.
Hence my proposal to slice off only the very first argument.