### PR TITLE
Fixes TypeError when a command has an option called `--description`

### DIFF
--- a/index.js
+++ b/index.js
@@ -943,7 +943,7 @@ Command.prototype.commandHelp = function() {
         + (cmd._alias ? '|' + cmd._alias : '')
         + (cmd.options.length ? ' [options]' : '')
         + ' ' + args
-      , cmd.description()
+      , cmd._description
     ];
   });
 


### PR DESCRIPTION
Using the `description()` method instead of the private property causes a `TypeError` when a command has an option called "description".

Since in the rest of the code the private property is used, I changed this line to use it too.

(this fix was proposed by @jadbox in #422 -- thx!)