### PR TITLE
Fail when using same command and alias

### DIFF
--- a/index.js
+++ b/index.js
@@ -880,6 +880,8 @@ Command.prototype.alias = function(alias) {
 
   if (arguments.length === 0) return command._alias;
 
+  if (alias === command._name) throw new Error('Command alias can\'t be the same as its name');
+
   command._alias = alias;
   return this;
 };

--- a/test/test.command.failOnSameAlias.js
+++ b/test/test.command.failOnSameAlias.js
@@ -1,0 +1,14 @@
+var program = require('../')
+  , should = require('should');
+
+var error;
+
+try {
+  program
+    .command('fail')
+    .alias('fail');
+} catch (e) {
+  error = e;
+}
+
+error.should.deepEqual(new Error('Command alias can\'t be the same as its name'));


### PR DESCRIPTION
Fixes #490. Prevents running a command twice when -accidentally- using same command alias and name.
