### PR TITLE
Prefix events to prevent conflicts between commands and options

### DIFF
--- a/index.js
+++ b/index.js
@@ -302,8 +302,8 @@ Command.prototype.action = function(fn) {
   };
   var parent = this.parent || this;
   var name = parent === this ? '*' : this._name;
-  parent.on(name, listener);
-  if (this._alias) parent.on(this._alias, listener);
+  parent.on('command:' + name, listener);
+  if (this._alias) parent.on('command:' + this._alias, listener);
   return this;
 };
 
@@ -390,7 +390,7 @@ Command.prototype.option = function(flags, description, fn, defaultValue) {
 
   // when it's passed assign the value
   // and conditionally invoke the callback
-  this.on(oname, function(val) {
+  this.on('option:' + oname, function(val) {
     // coercion
     if (null !== val && fn) val = fn(val, undefined === self[name]
       ? defaultValue
@@ -611,10 +611,10 @@ Command.prototype.parseArgs = function(args, unknown) {
 
   if (args.length) {
     name = args[0];
-    if (this.listeners(name).length) {
-      this.emit(args.shift(), args, unknown);
+    if (this.listeners('command:' + name).length) {
+      this.emit('command:' + args.shift(), args, unknown);
     } else {
-      this.emit('*', args);
+      this.emit('command:*', args);
     }
   } else {
     outputHelpIfNecessary(this, unknown);
@@ -687,7 +687,7 @@ Command.prototype.parseOptions = function(argv) {
       if (option.required) {
         arg = argv[++i];
         if (null == arg) return this.optionMissingArgument(option);
-        this.emit(option.name(), arg);
+        this.emit('option:' + option.name(), arg);
       // optional arg
       } else if (option.optional) {
         arg = argv[i+1];
@@ -696,10 +696,10 @@ Command.prototype.parseOptions = function(argv) {
         } else {
           ++i;
         }
-        this.emit(option.name(), arg);
+        this.emit('option:' + option.name(), arg);
       // bool
       } else {
-        this.emit(option.name());
+        this.emit('option:' + option.name());
       }
       continue;
     }
@@ -820,7 +820,7 @@ Command.prototype.version = function(str, flags) {
   this._version = str;
   flags = flags || '-V, --version';
   this.option(flags, 'output the version number');
-  this.on('version', function() {
+  this.on('option:version', function() {
     process.stdout.write(str + '\n');
     process.exit(0);
   });

--- a/test/test.command.noConflict.js
+++ b/test/test.command.noConflict.js
@@ -1,0 +1,25 @@
+var program = require('../')
+  , sinon = require('sinon')
+  , should = require('should');
+
+sinon.stub(process, 'exit');
+sinon.stub(process.stdout, 'write');
+
+program
+  .version('0.0.1')
+  .command('version')
+  .action(function() {
+    console.log('Version command invoked');
+  });
+
+program.parse(['node', 'test', 'version']);
+
+var output = process.stdout.write.args[0];
+output[0].should.equal('Version command invoked\n');
+
+program.parse(['node', 'test', '--version']);
+
+var output = process.stdout.write.args[1];
+output[0].should.equal('0.0.1\n');
+
+sinon.restore();


### PR DESCRIPTION
Prefix internal command events with `'command:'` and options events with `'options:'` to prevent conflicts between equally named commands and options (both user and plugin options, like `--version`).
This fixes #471 as well.
