### PR TITLE
Add 'Other modules' section to Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -346,6 +346,12 @@ program.parse(process.argv);
 
 More Demos can be found in the [examples](https://github.com/tj/commander.js/tree/master/examples) directory.
 
+## Other modules
+
+Other modules in the community that may prove useful when used in conjuction with commander:
+
+- [commander.js-error](https://github.com/justinhelmer/commander.js-error) - A tiny module for formatting error output to match commander.js default errors.
+
 ## License
 
 MIT


### PR DESCRIPTION
- add [commander.js-error](https://github.com/justinhelmer/commander.js-error) to the list of other modules
