### PR TITLE
Add public `reset` method to enable multiple calls to `parse`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1036,6 +1036,20 @@ Command.prototype.help = function(cb) {
 };
 
 /**
+ * Clear parsed options so that `parse` may be run again.
+ *
+ * @api public
+ */
+
+Command.prototype.reset = function() {
+  var self = this;
+  this.args = [];
+  this.options.forEach(function(option) {
+    self[option.name()] = undefined;
+  });
+};
+
+/**
  * Camel-case the given `flag`
  *
  * @param {String} flag

--- a/test/test.reset.js
+++ b/test/test.reset.js
@@ -1,0 +1,30 @@
+/**
+ * Module dependencies.
+ */
+
+var program = require('../')
+  , should = require('should');
+
+program
+  .version('0.0.1')
+  .arguments('<req> [opt]')
+  .option('-p, --pepper', 'add pepper')
+  .option('-c|--no-cheese', 'remove cheese')
+  .action(function(req, opt) {
+    myreq = req;
+    myopt = opt
+  });
+
+program.parse(['node', 'test', 'foo', 'baz', '--no-cheese']);
+should.equal(undefined, program.pepper);
+program.cheese.should.be.false;
+myreq.should.equal('foo');
+myopt.should.equal('baz');
+
+program.reset();
+
+program.parse(['node', 'test', 'bar', '-p']);
+program.pepper.should.be.true
+should.equal(undefined, program.cheese);
+myreq.should.equal('bar');
+should.equal(undefined, myopt);


### PR DESCRIPTION
This makes it easier to unit test code that runs commander.

Addresses #438 

I don't have tons of experience with commander.js so this approach may not work for all cases.
