### PR TITLE
Fix Sub-Subcommands

### DIFF
--- a/index.js
+++ b/index.js
@@ -525,7 +525,7 @@ Command.prototype.executeSubCommand = function(argv, args, unknown) {
   var proc;
   if (process.platform !== 'win32') {
     if (isExplicitJS) {
-      args.unshift(localBin);
+      args.unshift(bin);
       // add executable arguments to spawn
       args = (process.execArgv || []).concat(args);
 
@@ -534,7 +534,7 @@ Command.prototype.executeSubCommand = function(argv, args, unknown) {
       proc = spawn(bin, args, { stdio: 'inherit', customFds: [0, 1, 2] });
     }
   } else {
-    args.unshift(localBin);
+    args.unshift(bin);
     proc = spawn(process.execPath, args, { stdio: 'inherit'});
   }
 

--- a/test/fixtures/pm
+++ b/test/fixtures/pm
@@ -6,6 +6,7 @@ program
   .version('0.0.1')
   .command('install [name]', 'install one or more packages')
   .command('search [query]', 'search with optional query')
+  .command('cache', 'actions dealing with the cache')
   .command('list', 'list packages installed')
   .command('publish', 'publish or update package')
   .command('default', 'default command', {noHelp: true, isDefault: true})

--- a/test/fixtures/pm-cache-clear.js
+++ b/test/fixtures/pm-cache-clear.js
@@ -1,0 +1,1 @@
+console.log('cache-clear')

--- a/test/fixtures/pm-cache-validate.js
+++ b/test/fixtures/pm-cache-validate.js
@@ -1,0 +1,1 @@
+console.log('cache-validate')

--- a/test/fixtures/pm-cache.js
+++ b/test/fixtures/pm-cache.js
@@ -1,0 +1,6 @@
+var program = require('../../');
+
+program
+  .command('clear', 'clear the cache')
+  .command('validate', 'validate the cache', { isDefault: true })
+  .parse(process.argv);

--- a/test/test.command.executableSubcommandSubCommand.js
+++ b/test/test.command.executableSubcommandSubCommand.js
@@ -1,0 +1,32 @@
+var exec = require('child_process').exec
+  , path = require('path')
+  , should = require('should');
+
+
+/*
+ * The commands look like this
+ * pm cache
+ * pm cache clear
+ * pm cache validate (default)
+ */
+
+var bin = path.join(__dirname, './fixtures/pm')
+// should list commands at top-level sub command
+exec(bin + ' cache help', function (error, stdout, stderr) {
+  stdout.should.containEql('Usage:');
+  stdout.should.containEql('cache');
+  stdout.should.containEql('validate');
+});
+
+// should run sub-subcommand
+exec(bin + ' cache clear', function (error, stdout, stderr) {
+  stdout.should.equal('cache-clear\n');
+  stderr.should.equal('');
+});
+
+// should print the default command when passed invalid sub-subcommand
+exec(bin + ' cache nope', function (error, stdout, stderr) {
+  stdout.should.equal('cache-validate\n');
+  stderr.should.equal('');
+});
+


### PR DESCRIPTION
When commands were nested, I was finding that it was trying to run a file that didn't exist. The logic here _found_ the correct path and file, but then used an incorrect variable later in the code.

I added a test for this since I didn't see one already in place.