### PR TITLE
#330 make .option defaultValue and fn and .version flag optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -350,8 +350,8 @@ Command.prototype.action = function(fn) {
  *
  * @param {String} flags
  * @param {String} description
- * @param {Function|Mixed} fn or default
- * @param {Mixed} defaultValue
+ * @param {Function|*} [fn] or default
+ * @param {*} [defaultValue]
  * @return {Command} for chaining
  * @api public
  */
@@ -810,7 +810,7 @@ Command.prototype.variadicArgNotLast = function(name) {
  * which will print the version number when passed.
  *
  * @param {String} str
- * @param {String} flags
+ * @param {String} [flags]
  * @return {Command} for chaining
  * @api public
  */


### PR DESCRIPTION
#330 make option defaultValue and fn and .version flag optional according to JSDoc's to resolve  IDE reporting wrong argument count number errors.

https://github.com/tj/commander.js/issues/330
