### PR TITLE
Add API-Doc to http://doclets.io

### DIFF
--- a/.doclets.yml
+++ b/.doclets.yml
@@ -1,0 +1,4 @@
+dir: lib
+flavor: jsdoc
+articles:
+  - Readme: README.md

--- a/.doclets.yml
+++ b/.doclets.yml
@@ -2,4 +2,4 @@ files:
   - index.js
 flavor: jsdoc
 articles:
-  - Readme: README.md
+  - Readme: Readme.md

--- a/.doclets.yml
+++ b/.doclets.yml
@@ -1,4 +1,5 @@
-dir: lib
+files:
+  - index.js
 flavor: jsdoc
 articles:
   - Readme: README.md

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 /**
  * Module dependencies.
+ * @private
  */
 
 var EventEmitter = require('events').EventEmitter;
@@ -11,19 +12,23 @@ var basename = path.basename;
 var fs = require('fs');
 
 /**
- * Expose the root command.
+ * Expose the root command. Requiring command returns a `Command` instance.
+ * @example
+ * var program = require('commander')
  */
 
 exports = module.exports = new Command();
 
 /**
  * Expose `Command`.
+ * @private
  */
 
 exports.Command = Command;
 
 /**
  * Expose `Option`.
+ * @private
  */
 
 exports.Option = Option;
@@ -33,7 +38,7 @@ exports.Option = Option;
  *
  * @param {String} flags
  * @param {String} description
- * @api public
+ * @api private
  */
 
 function Option(flags, description) {
@@ -74,6 +79,8 @@ Option.prototype.is = function(arg) {
 
 /**
  * Initialize a new `Command`.
+ * @class
+ * @augments EventEmitter
  *
  * @param {String} name
  * @api public

--- a/index.js
+++ b/index.js
@@ -97,6 +97,7 @@ function Command(name) {
 
 /**
  * Inherit from `EventEmitter.prototype`.
+ * @private
  */
 
 Command.prototype.__proto__ = EventEmitter.prototype;

--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ var basename = path.basename;
 var fs = require('fs');
 
 /**
- * Expose the root command. Requiring command returns a `Command` instance.
+ * The root `command` instance. 
+ * Requiring "commander" returns a default initialized `Command` instance.
  * @example
  * var program = require('commander')
  */


### PR DESCRIPTION
Adds documentation to [doclets.io](https://doclets.io) service. Future tags and master branch will be published automatically. Makes gh-pages API-Doc obsolete.

[Preview generated with my account](https://doclets.io/lipp/commander.js/add-to-doclets)

@tj If you like this, you are very welcomed to login to https://doclets.io with GitHub OAuth. If you don't like it, I'd be happy to hear what you don't like about it :) 

Steps required (3min):
1) tj logs in to doclets.io
2) tj adds commander.js 
3) someone merges this PR
