### PR TITLE
Force version of npm that understands caret (^) dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,5 @@ node_js:
   - "3"
   - "4"
   - "node"
+before_install:
+  npm install -g npm@'>=1.4.3'


### PR DESCRIPTION
Try to fix travis build for older versions of node

Cribbed from travis-ci/travis-ci#2076