### PR TITLE
Try to fix travis build for node versions 0.6 and 0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "https://github.com/tj/commander.js.git"
   },
   "devDependencies": {
-    "should": ">= 0.0.1",
+    "should": ">= 0.0.1 <9.0.0",
     "sinon": ">=1.17.1"
   },
   "scripts": {


### PR DESCRIPTION
Limits version of should to be <9.0.0. Version 9.0.0 and above
use caret (^) dependencies, which are not understood by the versions
of npm available on old versions of node