### PR TITLE
use current node

### DIFF
--- a/index.js
+++ b/index.js
@@ -542,7 +542,7 @@ Command.prototype.executeSubCommand = function(argv, args, unknown) {
       // add executable arguments to spawn
       args = (process.execArgv || []).concat(args);
 
-      proc = spawn('node', args, { stdio: 'inherit', customFds: [0, 1, 2] });
+      proc = spawn(process.argv[0], args, { stdio: 'inherit', customFds: [0, 1, 2] });
     } else {
       proc = spawn(bin, args, { stdio: 'inherit', customFds: [0, 1, 2] });
     }


### PR DESCRIPTION
I'm running an app as that I wrote with commander.js (using the sub command feature)

I'm using nvm and running a subcommnd as a LaunchAgent through osx' launchctrl. 

Under this configuration, I had an issue where commander ended up using the node on my system path instead of the node that my main binary script was invoked with, and that version of node couldn't find my globally installed package.

This commit fixes it by using the first argument that was passed to the node process, which is node's process.execPath https://nodejs.org/docs/latest/api/process.html#process_process_execpath
https://nodejs.org/docs/latest/api/process.html#process_process_argv

This resolves my issue
