### PR TITLE
possible bug: first literal after '--' is eaten

### DIFF
--- a/test/test.subcommand.hyphen.js
+++ b/test/test.subcommand.hyphen.js
@@ -1,0 +1,15 @@
+/**
+ * Module dependencies.
+ */
+
+var program = require('../')
+  , should = require('should');
+
+program
+  .command('sub2')
+  .action( function ()  {})
+
+// action modifies by side effect
+program.parse('node aScript.js sub2 -- many extra args'.split(' '))
+program.args.should.deepEqual(['sub2', 'many', 'extra', 'args'])
+


### PR DESCRIPTION
## Goal

Pass along all arguments after `--` to another executable.
## Confusion

Something about optional positionals and the magic `--` doesn't seem to work like I would expect.
## Example

**cmd.js**

``` js
#!/usr/bin/env node
var program = require('commander');

program
  .command('try <dir>')
  .action(function (dir) {
    console.log('try %s', dir);
  });
;

program.parse(process.argv);
console.log(program.args);
```

```
$ node cmd.js try b -- c
try b
[ 'b',
  Command {
    commands: [],
    options: [],
    _execs: {},
    _allowUnknownOption: false,
    _args: [ [Object] ],
    _name: 'try',
    _noHelp: false,
    parent:
     Command {
       commands: [Object],
       options: [],
       _execs: {},
       _allowUnknownOption: false,
       _args: [],
       _name: 'cmd',
       Command: [Function: Command],
       Option: [Function: Option],
       _events: [Object],
       _eventsCount: 1,
       rawArgs: [Object],
       args: [Circular] } } ]
```

I also tried this:

```
node ./cmd.js  try -- b      # uses "b" for dir
```

I could easily be not understanding something here.  
