### PR TITLE
#395  fix, short options do not understand adjacent values

### DIFF
--- a/index.js
+++ b/index.js
@@ -452,7 +452,8 @@ Command.prototype.parse = function(argv) {
   }
 
   // process argv
-  var parsed = this.parseOptions(this.normalize(argv.slice(2)));
+  var normalized = this.normalize(argv.slice(2));
+  var parsed = this.parseOptions(normalized);
   var args = this.args = parsed.args;
 
   var result = this.parseArgs(this.args, parsed.unknown);
@@ -579,7 +580,9 @@ Command.prototype.normalize = function(args) {
   var ret = []
     , arg
     , lastOpt
-    , index;
+    , index
+    ,short
+    ,opt;
 
   for (var i = 0, len = args.length; i < len; ++i) {
     arg = args[i];
@@ -593,10 +596,17 @@ Command.prototype.normalize = function(args) {
       break;
     } else if (lastOpt && lastOpt.required) {
       ret.push(arg);
-    } else if (arg.length > 1 && '-' == arg[0] && '-' != arg[1]) {
-      arg.slice(1).split('').forEach(function(c) {
-        ret.push('-' + c);
-      });
+    } else if (arg.length > 2 && '-' == arg[0] && '-' != arg[1]) {
+      short = arg.slice(0, 2);
+      opt = this.optionFor(short);
+      if (opt && (opt.required || opt.optional)) {
+        ret.push(short);
+        ret.push(arg.slice(2));
+      } else {
+        arg.slice(1).split('').forEach(function (c) {
+          ret.push('-' + c);
+        });
+      }
     } else if (/^--/.test(arg) && ~(index = arg.indexOf('='))) {
       ret.push(arg.slice(0, index), arg.slice(index + 1));
     } else {

--- a/test/test.options.short.adjacent-value.js
+++ b/test/test.options.short.adjacent-value.js
@@ -1,0 +1,18 @@
+var program = require('../')
+  , should = require('should');
+
+program
+  .option('-c <required>', 'required with adjacent value')
+  .option('-q <required>', 'required with separated value')
+  .option('-o [optional]', 'optional with adjacent value')
+  .option('-p [optional]', 'optional with separated value')
+  .option('-n [optional]', 'optional without value in the middle')
+  .option('-r [optional]', 'optional without value in the end');
+
+program.parse(['node', 'test', '-c22', '-q', '33', '-o44', '-n', '-p', '55', '-r']);
+program.C.should.equal('22');
+program.Q.should.equal('33');
+program.O.should.equal('44');
+program.N.should.equal(true);
+program.P.should.equal('55');
+program.R.should.equal(true);


### PR DESCRIPTION
Example of the bug:

commander.option("-c <value>")
console.log("C:", commander.C)

$ node program -c234
C: -2