### PR TITLE
Chainable name setter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 *.sock
 .idea
+.vscode/

--- a/index.js
+++ b/index.js
@@ -898,15 +898,17 @@ Command.prototype.usage = function(str) {
 };
 
 /**
- * Get the name of the command
+ * Get or set the name of the command
  *
- * @param {String} name
+ * @param {String} str
  * @return {String|Command}
  * @api public
  */
 
-Command.prototype.name = function() {
-  return this._name;
+Command.prototype.name = function(str) {
+  if (0 === arguments.length) return this._name;
+  this._name = str;
+  return this;
 };
 
 /**

--- a/test/test.command.name.set.js
+++ b/test/test.command.name.set.js
@@ -1,0 +1,16 @@
+var program = require('../')
+  , sinon = require('sinon').sandbox.create()
+  , should = require('should');
+
+sinon.stub(process, 'exit');
+sinon.stub(process.stdout, 'write');
+
+program.name('foobar').description('This is a test.');
+
+program.name.should.be.a.Function;
+program.name().should.equal('foobar');
+program.description().should.equal('This is a test.');
+
+var output = process.stdout.write.args[0];
+
+sinon.restore();


### PR DESCRIPTION
Similar to `description`, `name` now acts as getter or setter, depending on whether an argument is passed or not.

As a result, the command name can now be set through builder-like setups:

```
program
  .version(myVersion)
  .name('mytool foobar')
  .description('This is a test.');
```