### PR TITLE
Fix require arguments in README.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -137,7 +137,7 @@ program.parse(process.argv);
 ```js
 #!/usr/bin/env node
 
-var program = require('../');
+var program = require('commander');
 
 program
   .version('0.0.1')
@@ -162,7 +162,7 @@ Angled brackets (e.g. `<cmd>`) indicate required input. Square brackets (e.g. `[
 
 ```js
 // file: ./examples/pm
-var program = require('..');
+var program = require('commander');
 
 program
   .version('0.0.1')


### PR DESCRIPTION
It may confuse people if we `require('..')` in README.md
I changed it to `require('commander')`