### PR TITLE
Inherit arguments to default subcommand

### DIFF
--- a/examples/pm
+++ b/examples/pm
@@ -8,6 +8,7 @@ program
   .command('search [query]', 'search with optional query').alias('s')
   .command('list', 'list packages installed')
   .command('publish', 'publish the package').alias('p')
+  .command('default', 'default command', { noHelp: true, isDefault: true })
   .parse(process.argv);
 
 // here .command() is invoked with a description,
@@ -25,3 +26,4 @@ program
 //   ./examples/pm install -h
 //   ./examples/pm install foo bar baz
 //   ./examples/pm install foo bar baz --force
+//   ./examples/pm -t 800

--- a/examples/pm-default.js
+++ b/examples/pm-default.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-var program = require('../../');
+var program = require('..');
 
 program
     .option('-t --test <number>', 'Test inherit subcommand option', /^\d+$/, 500)

--- a/index.js
+++ b/index.js
@@ -634,7 +634,8 @@ Command.prototype.parseArgs = function(args, unknown) {
 
     // If there were no args and we have unknown options,
     // then they are extraneous and we need to error.
-    if (unknown.length > 0) {
+    // Extend unknown args to defaultExecutable
+    if (unknown.length > 0 && !this.defaultExecutable) {
       this.unknownOption(unknown[0]);
     }
   }

--- a/index.js
+++ b/index.js
@@ -634,7 +634,7 @@ Command.prototype.parseArgs = function(args, unknown) {
 
     // If there were no args and we have unknown options,
     // then they are extraneous and we need to error.
-    // Extend unknown args to defaultExecutable
+    // Inherit unknown args to 'defaultExecutable'
     if (unknown.length > 0 && !this.defaultExecutable) {
       this.unknownOption(unknown[0]);
     }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "should": ">= 0.0.1 <9.0.0",
-    "sinon": ">=1.17.1 <1.17.7"
+    "sinon": ">=1.17.1 <=1.17.7"
   },
   "scripts": {
     "test": "make test"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "should": ">= 0.0.1 <9.0.0",
-    "sinon": ">=1.17.1"
+    "sinon": ">=1.17.1 <1.17.7"
   },
   "scripts": {
     "test": "make test"

--- a/test/test.command.executableSubcommandDefault.js
+++ b/test/test.command.executableSubcommandDefault.js
@@ -7,12 +7,22 @@ var exec = require('child_process').exec
 var bin = path.join(__dirname, './fixtures/pm')
 // success case
 exec(bin + ' default', function(error, stdout, stderr) {
-  stdout.should.equal('default\n');
+  stdout.should.equal('default\n500\n');
 });
 
 // success case (default)
 exec(bin, function(error, stdout, stderr) {
-  stdout.should.equal('default\n');
+  stdout.should.equal('default\n500\n');
+});
+
+// success case (default) and alisa option
+exec(bin + ' -t 600', function(error, stdout, stderr) {
+  stdout.should.equal('default\n600\n');
+});
+
+// success case (default) and option
+exec(bin + ' --test 800', function(error, stdout, stderr) {
+  stdout.should.equal('default\n800\n');
 });
 
 // not exist


### PR DESCRIPTION
You can use the option on the subcommand.Like so:  
### pm.js
```javascript
var program = require('commander');
program
  .command('default', 'default command', { noHelp: true, isDefault: true });

program
  .command('server')
  .option('-p --port <port>', 'port', /^\d+$/, 3000)
   .action(port => {
     // start a server with the option port
   })
  .parse(process.argv);
```
### pm-default.js
```javascript
#!/usr/bin/env node
var program = require('commander');

program
    .option('-t --test <number>', 'Test inherit subcommand option', /^\d+$/, 500)
    .parse(process.argv);

console.log('default');
console.log(program.test);
```

## RUN
```command
./pm.js -t 800 // echo default 800
```

