### PR TITLE
Removing dependency on graceful-readlink

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@
 
 var EventEmitter = require('events').EventEmitter;
 var spawn = require('child_process').spawn;
-var readlink = require('graceful-readlink').readlinkSync;
 var path = require('path');
 var dirname = path.dirname;
 var basename = path.basename;
@@ -513,7 +512,7 @@ Command.prototype.executeSubCommand = function(argv, args, unknown) {
   // In case of globally installed, get the base dir where executable
   //  subcommand file should be located at
   var baseDir
-    , link = readlink(f);
+    , link = fs.lstatSync(f).isSymbolicLink() ? fs.readlinkSync(f) : f;
 
   // when symbolink is relative path
   if (link !== f && link.charAt(0) !== '/') {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,5 @@
   "files": [
     "index.js"
   ],
-  "dependencies": {
-    "graceful-readlink": ">= 1.0.0"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
It's almost exactly the same code as written in graceful-readlink, but replaced with a quick one-liner. Hopefully it might increase attractiveness to those that are dependency-averse. Unlikely to be any regressions due to the tiny nature of the change, and tests passing from my point of view.