### PR TITLE
Pass unknown also as a second argument to the command:* event

### DIFF
--- a/index.js
+++ b/index.js
@@ -626,7 +626,7 @@ Command.prototype.parseArgs = function(args, unknown) {
     if (this.listeners('command:' + name).length) {
       this.emit('command:' + args.shift(), args, unknown);
     } else {
-      this.emit('command:*', args);
+      this.emit('command:*', args, unknown);
     }
   } else {
     outputHelpIfNecessary(this, unknown);
@@ -1127,4 +1127,3 @@ function exists(file) {
     return false;
   }
 }
-

--- a/test/test.arguments.js
+++ b/test/test.arguments.js
@@ -11,6 +11,7 @@ var cmdValue = "";
 program
   .version('0.0.1')
   .arguments('<cmd> [env]')
+  .allowUnknownOption()
   .action(function (cmd, env) {
     cmdValue = cmd;
     envValue = env;

--- a/test/test.command.allowUnknownOption.js
+++ b/test/test.command.allowUnknownOption.js
@@ -51,6 +51,20 @@ program.parse('node test sub2 -m'.split(' '));
 stubError.callCount.should.equal(0);
 stubExit.calledOnce.should.be.false();
 
+// test unknown argument passed to listeners
+resetStubStatus();
+program
+  .command('sub2')
+  .allowUnknownOption()
+  .action(function () {
+  });
+program.on("command:sub", function(args, unknown) {
+  unknown.should.equal(["-m"]);
+})
+program.on("command:*", function(args, unknown) {
+  unknown.should.equal(["-m"]);
+})
+program.parse('node test sub2 -m'.split(' '));
 
 function resetStubStatus() {
   stubError.reset();


### PR DESCRIPTION
Thanks a lot for the amazing library.

I was browsing through the code to find a way to get access to the `unknown` options array that is currently only exposed through the `command:${commandName}` event. But this event also calls `.shift()` on the arguments array, which is not something that we'd want.

Therefore I was wondering, if there is a specific reason that the `unknown` array is not passed as a second argument to the `command:*` event?

I added it there, but had to fix one test as this was passing unknown options and without specifying that unknown options are allowed, the test would crash now.

I also added a test case to actually test that the `unknown` array is being passed as the second argument in both `command:[*|commandName]` events.