### PR TITLE
fix help option text for user-defined -h short flags

### DIFF
--- a/index.js
+++ b/index.js
@@ -932,20 +932,35 @@ Command.prototype.largestOptionLength = function() {
 };
 
 /**
+ * Return `Option` object for help option.  
+ *
+ * @return {Option}
+ * @api private
+ */
+Command.prototype.optionHelp = function() { 
+  // check if there is an overriding user-defined `-h` short flag
+  var shortHOptions = this.options.filter(function(option) { 
+    return option.short === '-h';
+  });
+  var helpFlags = shortHOptions.length ? '--help' : '-h, --help';
+  
+  return new Option(helpFlags, 'output usage information');
+};
+
+/**
  * Return help for options.
  *
  * @return {String}
  * @api private
  */
 
-Command.prototype.optionHelp = function() {
+Command.prototype.optionHelpText = function() {
   var width = this.largestOptionLength();
 
-  // Append the help information
-  return this.options.map(function(option) {
-      return pad(option.flags, width) + '  ' + option.description;
-    }).concat([pad('-h, --help', width) + '  ' + 'output usage information'])
-    .join('\n');
+  return [this.optionHelp()].concat(this.options).map(function(option) {
+    return pad(option.flags, width) + '  ' + option.description;
+  })
+  .join('\n');
 };
 
 /**
@@ -1024,7 +1039,7 @@ Command.prototype.helpInformation = function() {
     ''
     , '  Options:'
     , ''
-    , '' + this.optionHelp().replace(/^/gm, '    ')
+    , '' + this.optionHelpText().replace(/^/gm, '    ')
     , ''
   ];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "commander",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "lockfileVersion": 1,
   "dependencies": {
     "diff": {

--- a/test/test.command.helpInformation.js
+++ b/test/test.command.helpInformation.js
@@ -1,0 +1,24 @@
+var program = require('../')
+  , sinon = require('sinon').sandbox.create()
+  , should = require('should');
+
+program.option('-x, --x-option', 'option x');
+
+var helpText = program.helpInformation();
+helpText.should.containEql('-h, --help');
+helpText.should.containEql('-x, --x-option');
+/**
+ * User defined -h should override help option short flag.
+ * In the help information text, -h short flag should
+ * only appear for the user defined option.
+ */
+program
+  .option('-h, --h-option', 'User defined -h.');
+
+helpText = program.helpInformation();
+helpText.should.containEql('-h, --h-option');
+helpText.should.not.containEql('-h, --help');
+helpText.should.containEql('--help');
+
+program.parse(['node', 'test', '-h']);
+program.should.have.property('hOption');


### PR DESCRIPTION
This fixes issue [#645 ](https://github.com/tj/commander.js/issues/645)
if there is a user-defined -h option, the text displayed when running --help should not list a -h short flag for both the help and user-defined options.  
