### PR TITLE
Properly handle subcommands with no args

### DIFF
--- a/index.js
+++ b/index.js
@@ -644,6 +644,10 @@ Command.prototype.parseArgs = function(args, unknown) {
     if (unknown.length > 0) {
       this.unknownOption(unknown[0]);
     }
+    
+    // If there are no args and we are still alive, then
+    // this is a subcommand with no args so go ahead.
+    this.emit('command:*', args);
   }
 
   return this;


### PR DESCRIPTION
Consider the following:

    // main
    program
      .usage('<command> [options...]
      .command('sub [arg1]', 'Do something with optional parameter')
      .parse(process.argv);

    // pm-sub
    program
      .arguments('[arg1'])
      .action(function (arg1) {
        // Use arg1 if exists otherwise do something else
        })
      .parse(process.argv);

Currently, the subcommand will never execute if there are no arguments (even if only arguments are optional). Proposed fix will ensure that subcommands are called even if there are no arguments.