### PR TITLE
Fix options key name conflict with commander object's' key

### DIFF
--- a/test/test.options.func.js
+++ b/test/test.options.func.js
@@ -4,18 +4,23 @@ var program = require('../')
 program
   .version('0.0.1')
   .description('sdfdsfsfsdfdsf')
+  .option('-n, --name', 'confliced option')
+  .option('-n, --toString', 'confliced option')
+  .option('-n, --once', 'confliced option')
   .option('-f, --foo', 'add some foo')
   .option('-b, --bar', 'add some bar')
   .option('-M, --no-magic', 'disable magic')
   .option('-c, --camel-case', 'convert to camelCase')
   .option('-q, --quux <quux>', 'add some quux');
 
-program.parse(['node', 'test', '--foo', '--bar', '--no-magic', '--camel-case', '--quux', 'value']);
+program.parse(['node', 'test', '--name', '--toString', '--once', '--foo', '--bar', '--no-magic', '--camel-case', '--quux', 'value']);
 program.opts.should.be.a.Function;
 
 var opts = program.opts();
-opts.should.be.an.Object;
 opts.version.should.equal('0.0.1');
+opts.name.should.be.true;
+opts.toString.should.be.true;
+opts.once.should.be.true;
 opts.foo.should.be.true;
 opts.bar.should.be.true;
 opts.magic.should.be.false;


### PR DESCRIPTION
Fix options key name confliction #404, #648 to use `Object.create(null)` and commander.opts() return object that has only options key value.
`Object.create(null)` is create object that hasn't any prototype, so it can hold any key without confiliction.

But, I'm warried about that it will become problem.
`Object.create(null)` hasn't any prototype chain, so if user extend Object.prototype and expect opts() result object is extended too, it will become problem.
What do you think of that?