### PR TITLE
Fix option parsing with sub-commands.

### DIFF
--- a/index.js
+++ b/index.js
@@ -675,7 +675,7 @@ Command.prototype.optionFor = function(arg) {
 
 Command.prototype.isSubcommand = function(name) {
   for (var i = 0; i < this.commands.length; ++i) {
-    if (name === this.commands[i]._name) {
+    if (this.commands[i]._execs[name] === true) {
       return true;
     }
   }

--- a/index.js
+++ b/index.js
@@ -666,6 +666,23 @@ Command.prototype.optionFor = function(arg) {
 };
 
 /**
+ * Return whether `name` corresponds to a defined subcommand.
+ *
+ * @param {String} name
+ * @return {boolean}
+ * @api private
+ */
+
+Command.prototype.isSubcommand = function(name) {
+  for (var i = 0; i < this.commands.length; ++i) {
+    if (name === this.commands[i]._name) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Parse options from `argv` returning `argv`
  * void of these options.
  *
@@ -687,6 +704,9 @@ Command.prototype.parseOptions = function(argv) {
   for (var i = 0; i < len; ++i) {
     arg = argv[i];
 
+    if (this.isSubcommand(arg)) {
+      return { args: argv.slice(i), unknown: unknownOptions };
+    }
     // literal args after --
     if (literal) {
       args.push(arg);


### PR DESCRIPTION
Hi, my subcommand options were being wrongly parsed by the main command, so I made this PR to just pass them through in case of using a subcommand. Please let me know if I should add or modify anything.