### PR TITLE
allow "-" hyphen as an option argument with subcommand

### DIFF
--- a/index.js
+++ b/index.js
@@ -737,7 +737,7 @@ Command.prototype.parseOptions = function(argv) {
       // If the next argument looks like it might be
       // an argument for this option, we pass it on.
       // If it isn't, then it'll simply be ignored
-      if (argv[i+1] && '-' != argv[i+1][0]) {
+      if (argv[i+1] && ('-' != argv[i+1][0] || '-' === argv[i+1])) {
         unknownOptions.push(argv[++i]);
       }
       continue;

--- a/test/test.options.subcommand-hyphen.js
+++ b/test/test.options.subcommand-hyphen.js
@@ -3,16 +3,16 @@
  */
 
 var program = require('../')
-    , should = require('should');
+  , should = require('should');
 
 program
-    .command('subcommand')
-    .description('description')
-    .option('-a, --alpha <a>', 'hyphen')
-    .option('-b, --bravo <b>', 'hyphen')
-    .option('-c, --charlie <c>', 'hyphen')
-    .action(function (options) {
-    });
+  .command('subcommand')
+  .description('description')
+  .option('-a, --alpha <a>', 'hyphen')
+  .option('-b, --bravo <b>', 'hyphen')
+  .option('-c, --charlie <c>', 'hyphen')
+  .action(function (options) {
+  });
 
 program.parse('node test subcommand -a - --bravo - --charlie=-'.split(' '));
 

--- a/test/test.options.subcommand-hyphen.js
+++ b/test/test.options.subcommand-hyphen.js
@@ -1,0 +1,21 @@
+/**
+ * Module dependencies.
+ */
+
+var program = require('../')
+    , should = require('should');
+
+program
+    .command('subcommand')
+    .description('description')
+    .option('-a, --alpha <a>', 'hyphen')
+    .option('-b, --bravo <b>', 'hyphen')
+    .option('-c, --charlie <c>', 'hyphen')
+    .action(function (options) {
+    });
+
+program.parse('node test subcommand -a - --bravo - --charlie=-'.split(' '));
+
+program.commands[0].alpha.should.equal('-');
+program.commands[0].bravo.should.equal('-');
+program.commands[0].charlie.should.equal('-');


### PR DESCRIPTION
One character "-" hyphen is not accepted as an option argument with subcommand.

e.x. node test subcommand -a - --bravo - --charlie=-

Main command allowed "-"  as an option argument in https://github.com/tj/commander.js/pull/139 . This patch will allow it also with subcommand.