### PR TITLE
Documentation updated for options with --no prefix

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -44,6 +44,25 @@ console.log('  - %s cheese', program.cheese);
 
  Short flags may be passed as a single arg, for example `-abc` is equivalent to `-a -b -c`. Multi-word options such as "--template-engine" are camel-cased, becoming `program.templateEngine` etc.
 
+Note that multi-word options starting with `--no` prefix negate the boolean value of the following word. For example, `--no-sauce` sets the value of `program.sauce` to false. 
+
+```js
+#!/usr/bin/env node
+
+/**
+ * Module dependencies.
+ */
+
+var program = require('commander');
+
+program
+  .option('--no-sauce', 'Remove sauce')
+  .parse(process.argv);
+
+console.log('you ordered a pizza');
+if (program.sauce) console.log('  with sauce');
+else console.log(' without sauce');
+```
 
 ## Coercion
 


### PR DESCRIPTION
- The current documentation states that multi-word options are camel-cased but doesn't clearly specify that the options with `--no` prefix negate the boolean value of the word that follows. This leads to a lot of confusion since the general intuition is to access it normally through `program.noWord`. 
- Issues #700 and #630 are due to this confusion only. 
- This adds a small code sample in the main documentation clearing the confusion about the issue above.