### PR TITLE
typedefs: Command and Option types added to commander namespace

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,7 +1,11 @@
+// Type definitions for commander 2.11
 // Project: https://github.com/visionmedia/commander.js
-// Definitions by: Alan Agius <https://github.com/alan-agius4>, Marcelo Dezem <https://github.com/mdezem>, vvakame <https://github.com/vvakame>
+// Definitions by: Alan Agius <https://github.com/alan-agius4>, Marcelo Dezem <https://github.com/mdezem>, vvakame <https://github.com/vvakame>, Jules Randolph <https://github.com/sveinburne>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-declare class Option {
+declare namespace local {
+
+  class Option {
     flags: string;
     required: boolean;
     optional: boolean;
@@ -17,9 +21,9 @@ declare class Option {
      * @param {string} [description]
      */
     constructor(flags: string, description?: string);
-}
+  }
 
-declare class Command extends NodeJS.EventEmitter {
+  class Command extends NodeJS.EventEmitter {
     [key: string]: any;
 
     args: string[];
@@ -121,6 +125,7 @@ declare class Command extends NodeJS.EventEmitter {
      * @returns {Command} for chaining
      */
     parseExpectedArgs(args: string[]): Command;
+
     /**
      * Register callback `fn` for the command.
      *
@@ -262,15 +267,21 @@ declare class Command extends NodeJS.EventEmitter {
     /**
      * Output help information for this command.
      *
-     * @param {(str: string) => string} [cb] 
+     * @param {(str: string) => string} [cb]
      */
     outputHelp(cb?: (str: string) => string): void;
 
     /** Output help information and exit. */
     help(): void;
+  }
+
 }
 
 declare namespace commander {
+
+    type Command = local.Command
+
+    type Option = local.Option
 
     interface CommandOptions {
         noHelp?: boolean;
@@ -283,8 +294,8 @@ declare namespace commander {
     }
 
     interface CommanderStatic extends Command {
-        Command: typeof Command;
-        Option: typeof Option;
+        Command: typeof local.Command;
+        Option: typeof local.Option;
         CommandOptions: CommandOptions;
         ParseOptionsResult: ParseOptionsResult;
     }


### PR DESCRIPTION
**Before** commit, the constructor is resolved but not the type<sup>1</sup> 

![image](https://user-images.githubusercontent.com/3646758/32805901-d3eafb26-c958-11e7-8c91-6fe59927b311.png)


**After** commit, the type `Command` is resolved

![image](https://user-images.githubusercontent.com/3646758/32806019-333f11de-c959-11e7-91c0-e3b08dc257b7.png)


The goal of this typedef enhancement is to allow the library consumer to use `Command` and `Option` types which he cannot yet use, in peculiar when receiving `action` callback arguments.
The way I do this is by creating a `local` namespace which contains class definitions and to cast those definition to a type (i.e. interface) in the `commander` namespace. By doing so, the types are accessible to library consumer.

<hr/>
<sup>1</sup> with typescript 2.5.3 and <code>CommonJS</code> modules