### PR TITLE
Move @types/node to dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,13 +22,12 @@
   "files": [
     "index.js"
   ],
-  "dependencies": {
-    "@types/node": "^7.0.48"
-  },
+  "dependencies": {},
   "devDependencies": {
     "should": "^11.2.1",
     "sinon": "^2.3.5",
-    "typescript": "^2.6.1"
+    "typescript": "^2.6.1",
+    "@types/node": "^7.0.48"
   },
   "typings": "typings/index.d.ts"
 }


### PR DESCRIPTION
cause duplicate require error when compile react native type script code