### PR TITLE
Fixes issue #727: Passing empty string for option on command is set to undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -747,7 +747,7 @@ Command.prototype.parseOptions = function(argv) {
       // If the next argument looks like it might be
       // an argument for this option, we pass it on.
       // If it isn't, then it'll simply be ignored
-      if (argv[i + 1] && argv[i + 1][0] !== '-') {
+      if ((i + 1) < argv.length && argv[i + 1][0] !== '-') {
         unknownOptions.push(argv[++i]);
       }
       continue;

--- a/index.js
+++ b/index.js
@@ -855,8 +855,8 @@ Command.prototype.version = function(str, flags) {
   if (arguments.length === 0) return this._version;
   this._version = str;
   flags = flags || '-V, --version';
-  var longOptIndex = flags.indexOf('--')
-  this._versionOptionName = ~longOptIndex ? flags.substr(longOptIndex + 2) : 'version'
+  var longOptIndex = flags.indexOf('--');
+  this._versionOptionName = ~longOptIndex ? flags.substr(longOptIndex + 2) : 'version';
   this.option(flags, 'output the version number');
   this.on('option:' + this._versionOptionName, function() {
     process.stdout.write(str + '\n');

--- a/test/test.command.action.emptyOption.js
+++ b/test/test.command.action.emptyOption.js
@@ -1,0 +1,20 @@
+/**
+ * Module dependencies.
+ */
+
+var program = require('../')
+  , should = require('should');
+
+var val = "some cheese"
+program
+  .name('test')
+  .command('mycommand')
+  .option('-c, --cheese [type]', 'optionally specify the type of cheese')
+  .action(function(cmd) {
+    val = cmd.cheese;
+  });
+
+program.parse(['node', 'test', 'mycommand', '--cheese', '']);
+
+val.should.equal('');
+


### PR DESCRIPTION
This is probably a breaking change, but I would consider it the expected behaviour. It's currently checking if the next argument after an --option is truthy, but that makes it impossible to pass an empty string, which is sometimes needed.