### PR TITLE
Restore arguments order to pass to subcommands

### DIFF
--- a/index.js
+++ b/index.js
@@ -485,15 +485,16 @@ Command.prototype.parse = function(argv) {
   }
 
   if (this._execs[name] && typeof this._execs[name] !== 'function') {
-    return this.executeSubCommand(argv, args, parsed.unknown);
+    this.args = args = argv.slice(2)
+    return this.executeSubCommand(argv, args);
   } else if (aliasCommand) {
     // is alias of a subCommand
-    args[0] = aliasCommand._name;
-    return this.executeSubCommand(argv, args, parsed.unknown);
+    this.args = args = [ aliasCommand._name ].concat(argv.slice(3))
+    return this.executeSubCommand(argv, args);
   } else if (this.defaultExecutable) {
     // use the default subcommand
-    args.unshift(this.defaultExecutable);
-    return this.executeSubCommand(argv, args, parsed.unknown);
+    this.args = args = [ this.defaultExecutable ].concat(argv.slice(3))
+    return this.executeSubCommand(argv, args);
   }
 
   return result;
@@ -508,9 +509,7 @@ Command.prototype.parse = function(argv) {
  * @api private
  */
 
-Command.prototype.executeSubCommand = function(argv, args, unknown) {
-  args = args.concat(unknown);
-
+Command.prototype.executeSubCommand = function(argv, args) {
   if (!args.length) this.help();
   if (args[0] === 'help' && args.length === 1) this.help();
 


### PR DESCRIPTION
so that option parsing is done by the subcommand, which may have its own options.

Addressed cases of the kind: `cmd subcmd -o arg1 arg2` where `-o` is a boolean option defined on the subcommand, and thus will not be identified by `parseOptions` when called from the parent command, and fall in the `// looks like an option` block, which will alter the arguments order: the subcommand will receive an args array that looks like `[ arg2, -o, arg1 ]`

Possibly related to #692 and #289