### PR TITLE
Do not print default for "--no-"

### DIFF
--- a/index.js
+++ b/index.js
@@ -964,7 +964,7 @@ Command.prototype.optionHelp = function() {
   // Append the help information
   return this.options.map(function(option) {
       return pad(option.flags, width) + '  ' + option.description
-        + (option.defaultValue !== undefined ? ' (default: ' + option.defaultValue + ')' : '');
+        + ((option.bool != false && option.defaultValue !== undefined) ? ' (default: ' + option.defaultValue + ')' : '');
   }).concat([pad('-h, --help', width) + '  ' + 'output usage information'])
     .join('\n');
 };


### PR DESCRIPTION
Consider the following case:

```
  Options:

     --no-color         Disable color. (default: true)
```

**Internally** the "default: true" would make sense because we normalize `--no-color` to `color`, so `color` would have default true.

However, from a user perspective it makes absolutely no sense. Users would interpret it as: `--no-color` has default true, which means `color` would be off by default, which is the opposite to what it is.

Let's assume we fix it by change it to print false, now look at the following case (#108 & #691):

```
  Options:

     --color            Enable color.
     --no-color         Disable color. (default: false)
```

In this case no matter which default it prints, it would be nothing but confusions.

So instead of printing `default: false`, I suggest to not print any default for `--no-`, and this PR would do that.
  
  