### PR TITLE
remove trailing spaces in command help

### DIFF
--- a/index.js
+++ b/index.js
@@ -990,7 +990,7 @@ Command.prototype.commandHelp = function() {
       cmd._name
         + (cmd._alias ? '|' + cmd._alias : '')
         + (cmd.options.length ? ' [options]' : '')
-        + ' ' + args
+        + (args ? ' ' + args : '')
       , cmd._description
     ];
   });
@@ -1005,7 +1005,7 @@ Command.prototype.commandHelp = function() {
     , ''
     , commands.map(function(cmd) {
       var desc = cmd[1] ? '  ' + cmd[1] : '';
-      return pad(cmd[0], width) + desc;
+      return (desc ? pad(cmd[0], width) : cmd[0]) + desc;
     }).join('\n').replace(/^/gm, '    ')
     , ''
   ].join('\n');

--- a/test/test.command.help.js
+++ b/test/test.command.help.js
@@ -3,8 +3,10 @@ var program = require('../')
   , should = require('should');
 
 
+program.command('bare');
+
+program.commandHelp().should.equal('\n  Commands:\n\n    bare\n');
+
 program.command('mycommand [options]');
 
-program.parse(['node', 'test']);
-
-program.commandHelp().should.equal('\n  Commands:\n\n    mycommand [options]\n');
+program.commandHelp().should.equal('\n  Commands:\n\n    bare\n    mycommand [options]\n');


### PR DESCRIPTION
The `commandHelp()` function was leaving trailing spaces on some lines. This patch removes them and verifies the change with an update to the test.