### PR TITLE
WIP resolves #649 switch to a modern test infrastructure

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "url": "https://github.com/tj/commander.js.git"
   },
   "scripts": {
+    "ava": "ava test-ava",
     "test": "make test && npm run test-typings",
     "test-typings": "node_modules/typescript/bin/tsc -p tsconfig.json"
   },
@@ -25,6 +26,7 @@
   ],
   "dependencies": {},
   "devDependencies": {
+    "ava": "^0.24.0",
     "@types/node": "^7.0.48",
     "should": "^11.2.1",
     "sinon": "^2.4.1",

--- a/test-ava/arguments.test.js
+++ b/test-ava/arguments.test.js
@@ -1,0 +1,36 @@
+// converted from test/test.arguments.js
+var Command = require('../').Command
+  , test = require('ava');
+
+function createProgram(capture) {
+  var program = new Command();
+  program
+    .version('0.0.1')
+    .arguments('<cmd> [env]')
+    .action(function (cmd, env) {
+      capture.cmdValue = cmd;
+      capture.envValue = env;
+    })
+    .option('-C, --chdir <path>', 'change the working directory')
+    .option('-c, --config <path>', 'set config path. defaults to ./deploy.conf')
+    .option('-T, --no-tests', 'ignore test hook');
+  return program;
+}
+
+test('option', (t) => {
+  var capture = {};
+  var program = createProgram(capture);
+  program.parse(['node', 'test', '--config', 'conf']);
+  t.is(program.config, 'conf');
+  t.is(capture.cmdValue, undefined);
+  t.is(capture.envValue, undefined);
+})
+
+test('option and command', (t) => {
+  var capture = {};
+  var program = createProgram(capture);
+  program.parse(['node', 'test', '--config', 'conf1', 'setup', '--setup_mode', 'mode3', 'env1']);
+  t.is(program.config, 'conf1');
+  t.is(capture.cmdValue, 'setup');
+  t.is(capture.envValue, 'env1');
+})

--- a/test-ava/command/action.test.js
+++ b/test-ava/command/action.test.js
@@ -1,0 +1,18 @@
+// converted from test/test.command.action.js
+var Command = require('../../').Command
+  , test = require('ava');
+
+test('command action', (t) => {
+  var val;
+  var program = new Command();
+  program
+    .command('info [options]')
+    .option('-C, --no-color', 'turn off color output')
+    .action(function () {
+      val = this.color;
+    });
+  program.parse(['node', 'test', 'info', '-C']);
+  t.is(program.commands.length, 1);
+  t.false(program.commands[0].color);
+  t.false(val);
+})


### PR DESCRIPTION
This PR will hopefully kick off the migration to a modern test infrastructure. There are still many tests to rewrite. But we first need to decide whether ava is the right choice for this project. Then we can divide and conquer to finish migrating the tests.

The tests are temporarily stored in the test-ava folder until the old tests are cleared out of the way.

Use the following command to run the tests:

```sh
npm run ava
```