### PR TITLE
Fix Coercion for Repeated  Options

### DIFF
--- a/index.js
+++ b/index.js
@@ -392,8 +392,8 @@ Command.prototype.option = function(flags, description, fn, defaultValue) {
 
   // Is the default array like, if so its likely repeated options.
   if (defaultValue != null &&
-    typeof defaultValue != 'function' &&
-    typeof defaultValue.length == 'number' &&
+    typeof defaultValue !== 'function' &&
+    typeof defaultValue.length === 'number' &&
     defaultValue.length > -1
   ) {
     option.repeated = true;
@@ -419,7 +419,7 @@ Command.prototype.option = function(flags, description, fn, defaultValue) {
   // and conditionally invoke the callback
   this.on('option:' + oname, function(val) {
     // coercion
-    if (null !== val && fn) {
+    if (val !== null && fn) {
       if (option.repeated) {
         val = fn(val, undefined === self[name] ? defaultValue : self[name]);
       } else {

--- a/test/test.options.coercion.js
+++ b/test/test.options.coercion.js
@@ -9,8 +9,8 @@ function parseRange(str) {
   return str.split('..').map(Number);
 }
 
-function increaseVerbosity(v, total) {
-  return total + 1;
+function increaseVerbosity(v) {
+  return v + 1;
 }
 
 function collectValues(str, memo) {

--- a/test/test.options.default.not.collection.js
+++ b/test/test.options.default.not.collection.js
@@ -1,0 +1,15 @@
+/**
+ * Module dependencies.
+ */
+
+var program = require('../')
+  , should = require('should');
+
+program
+  .version('0.0.1')
+  .option('-i, --int [n]', 'optionally specify the type of cheese provide a false default', parseInt, 2)
+  .option('-d, --data [n]', 'optionally specify the type of cheese provide a false default', parseInt, 4);
+
+program.parse(['node', 'test', '--int', '20', '-d', '30']);
+program.int.should.be.equal(20);
+program.data.should.be.equal(30);


### PR DESCRIPTION
This fixes Issue #686 that appears to have been introduced when
repeated options were added PR #198 that causes the previous value or
default value to be passed as a second parameter to the coercion
function. This obviously causes unintended side effects when a user
specifies a function and a default value unaware that a second value
passed, such as with parseInt.

This change makes the assumption that when a default array is specified
that the user has expecting repeated options. This change is backward
compatible with the existing code.