### PR TITLE
only register the option:version event once

### DIFF
--- a/index.js
+++ b/index.js
@@ -855,9 +855,9 @@ Command.prototype.version = function(str, flags) {
   if (arguments.length === 0) return this._version;
   this._version = str;
   flags = flags || '-V, --version';
-  var longOptIndex = flags.indexOf('--');
-  this._versionOptionName = ~longOptIndex ? flags.substr(longOptIndex + 2) : 'version';
-  this.option(flags, 'output the version number');
+  var versionOption = new Option(flags, 'output the version number');
+  this._versionOptionName = versionOption.long.substr(2) || 'version';
+  this.options.push(versionOption);
   this.on('option:' + this._versionOptionName, function() {
     process.stdout.write(str + '\n');
     process.exit(0);


### PR DESCRIPTION
- create Option directly to avoid registering the option:version event twice
- defer to the Option instance to resolve the long name of the option for the event