### PR TITLE
Fix typing of the help(cb) function

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -271,8 +271,11 @@ declare namespace local {
      */
     outputHelp(cb?: (str: string) => string): void;
 
-    /** Output help information and exit. */
-    help(): void;
+    /** Output help information and exit.
+     *
+     * @param {(str: string) => string} [cb]
+     */
+    help(cb?: (str: string) => string): void;
   }
 
 }


### PR DESCRIPTION
Hi!
I have recently come over a small typing issue of the help() function, namely it currently does not allow to pass a callback function as a parameter and results into the following build-time error: "_Expected 0 arguments, but got 1._"

The [official API documentation for the help() function](https://github.com/tj/commander.js#helpcb) says it is possible to pass the callback parameter, as well as the exported [Command.prototype.help](https://github.com/tj/commander.js/blob/master/index.js#L1081) function expression allows passing a callback too:

```javascript
Command.prototype.help = function(cb) {
  this.outputHelp(cb);
  process.exit();
};
```
So this is just a small typing fix. Let me know if you need any further details.
Best wishes,
Yevhenii.