### PR TITLE
resolves #766 suggest to users run --help command

### DIFF
--- a/index.js
+++ b/index.js
@@ -787,6 +787,7 @@ Command.prototype.opts = function() {
 Command.prototype.missingArgument = function(name) {
   console.error();
   console.error("  error: missing required argument `%s'", name);
+  console.error("  Try '--help' for more information.");
   console.error();
   process.exit(1);
 };
@@ -806,6 +807,7 @@ Command.prototype.optionMissingArgument = function(option, flag) {
   } else {
     console.error("  error: option `%s' argument missing", option.flags);
   }
+  console.error("  Try '--help' for more information.");
   console.error();
   process.exit(1);
 };
@@ -821,6 +823,7 @@ Command.prototype.unknownOption = function(flag) {
   if (this._allowUnknownOption) return;
   console.error();
   console.error("  error: unknown option `%s'", flag);
+  console.error("  Try '--help' for more information.");
   console.error();
   process.exit(1);
 };
@@ -835,6 +838,7 @@ Command.prototype.unknownOption = function(flag) {
 Command.prototype.variadicArgNotLast = function(name) {
   console.error();
   console.error("  error: variadic arguments must be last `%s'", name);
+  console.error("  Try '--help' for more information.");
   console.error();
   process.exit(1);
 };

--- a/test/test.command.allowUnknownOption.js
+++ b/test/test.command.allowUnknownOption.js
@@ -13,7 +13,7 @@ program
   .option('-p, --pepper', 'add pepper');
 program.parse('node test -m'.split(' '));
 
-stubError.callCount.should.equal(3);
+stubError.callCount.should.equal(4);
 
 
 // test subcommand
@@ -24,7 +24,7 @@ program
   });
 program.parse('node test sub -m'.split(' '));
 
-stubError.callCount.should.equal(3);
+stubError.callCount.should.equal(4);
 stubExit.calledOnce.should.be.true();
 
 // command with `allowUnknownOption`

--- a/test/test.options.args.required.js
+++ b/test/test.options.args.required.js
@@ -14,7 +14,7 @@ console.error = function () {
 
 process.on('exit', function (code) {
   code.should.equal(1);
-  info.length.should.equal(3);
+  info.length.should.equal(4);
   info[1].should.equal("  error: option `-c, --cheese <type>' argument missing");
   process.exit(0)
 });

--- a/test/test.variadic.args.js
+++ b/test/test.variadic.args.js
@@ -60,5 +60,6 @@ console.error = oldConsoleError;
 [
   '',
   '  error: variadic arguments must be last `variadicArg\'',
+  '  Try \'--help\' for more information.',
   ''
 ].join('\n').should.eql(errorMessage);


### PR DESCRIPTION
Adding one more console.error statements to bellow methods:
- Command.prototype.missingArgument
- Command.prototype.optionMissingArgument
- Command.prototype.unknownOption
- Command.prototype.variadicArgNotLast

This console.error messages propose to user run the same command
with `--help` option to get more info about the command which try
to run. This is something that most UNIX like commands do
(like rm, cp, mv, etc)