### PR TITLE
Update downloads badge to point to graph of downloads over time 📈 instead of duplicating link to npm

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -3,7 +3,7 @@
 
 [![Build Status](https://api.travis-ci.org/tj/commander.js.svg?branch=master)](http://travis-ci.org/tj/commander.js)
 [![NPM Version](http://img.shields.io/npm/v/commander.svg?style=flat)](https://www.npmjs.org/package/commander)
-[![NPM Downloads](https://img.shields.io/npm/dm/commander.svg?style=flat)](https://www.npmjs.org/package/commander)
+[![NPM Downloads](https://img.shields.io/npm/dm/commander.svg?style=flat)](https://npmcharts.com/compare/commander?minimal=true)
 [![Join the chat at https://gitter.im/tj/commander.js](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/tj/commander.js?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
   The complete solution for [node.js](http://nodejs.org) command-line interfaces, inspired by Ruby's [commander](https://github.com/commander-rb/commander).  


### PR DESCRIPTION
Hi! I noticed that your "npm" badge and "downloads" badge currently both point to the same page for the project on npmjs.org  

I was wondering if you might prefer having the download badge point to a [download chart](Update downloads badge to point to graph of downloads) instead?

If not, feel free to close and apologies for the drive-by PR 😄