### PR TITLE
added ability to translate help output

### DIFF
--- a/test/test.translator.js
+++ b/test/test.translator.js
@@ -1,0 +1,48 @@
+var program = require('../')
+  , should = require('should');
+
+var translations = {
+    'Usage:': 'Применение:',
+    'Commands:': 'Команды:',
+    'Arguments:': 'Аргументы:',
+    'Options:': 'Опции:',
+    'output usage information': 'информация об использовании',
+    'application simple description': 'простое описание приложения',
+    'env value': 'значение env'
+};
+
+program.translator = function(str) {
+    return translations[str] || str;
+};
+
+program
+    .helpInformation()
+    .should.equal([
+        '',
+        '  Применение:  [options]',
+        '',
+        '  Опции:',
+        '',
+        '    -h, --help  информация об использовании',
+        ''
+    ].join('\n'));
+
+program
+    .command('mycommand [env]')
+    .description('application simple description', { env: 'env value' })
+    .helpInformation()
+    .should.equal([
+        '',
+        '  Применение: mycommand [options] [env]',
+        '',
+        '  простое описание приложения',
+        '',
+        '  Аргументы:',
+        '',
+        '    env         значение env',
+        '',
+        '  Опции:',
+        '',
+        '    -h, --help  информация об использовании',
+        ''
+    ].join('\n'));

--- a/test/test.translator.js
+++ b/test/test.translator.js
@@ -2,47 +2,47 @@ var program = require('../')
   , should = require('should');
 
 var translations = {
-    'Usage:': 'Применение:',
-    'Commands:': 'Команды:',
-    'Arguments:': 'Аргументы:',
-    'Options:': 'Опции:',
-    'output usage information': 'информация об использовании',
-    'application simple description': 'простое описание приложения',
-    'env value': 'значение env'
+  'Usage:': 'Применение:',
+  'Commands:': 'Команды:',
+  'Arguments:': 'Аргументы:',
+  'Options:': 'Опции:',
+  'output usage information': 'информация об использовании',
+  'application simple description': 'простое описание приложения',
+  'env value': 'значение env'
 };
 
 program.translator = function(str) {
-    return translations[str] || str;
+  return translations[str] || str;
 };
 
 program
-    .helpInformation()
-    .should.equal([
-        '',
-        '  Применение:  [options]',
-        '',
-        '  Опции:',
-        '',
-        '    -h, --help  информация об использовании',
-        ''
-    ].join('\n'));
+  .helpInformation()
+  .should.equal([
+    '',
+    '  Применение:  [options]',
+    '',
+    '  Опции:',
+    '',
+    '    -h, --help  информация об использовании',
+    ''
+  ].join('\n'));
 
 program
-    .command('mycommand [env]')
-    .description('application simple description', { env: 'env value' })
-    .helpInformation()
-    .should.equal([
-        '',
-        '  Применение: mycommand [options] [env]',
-        '',
-        '  простое описание приложения',
-        '',
-        '  Аргументы:',
-        '',
-        '    env         значение env',
-        '',
-        '  Опции:',
-        '',
-        '    -h, --help  информация об использовании',
-        ''
-    ].join('\n'));
+  .command('mycommand [env]')
+  .description('application simple description', { env: 'env value' })
+  .helpInformation()
+  .should.equal([
+    '',
+    '  Применение: mycommand [options] [env]',
+    '',
+    '  простое описание приложения',
+    '',
+    '  Аргументы:',
+    '',
+    '    env         значение env',
+    '',
+    '  Опции:',
+    '',
+    '    -h, --help  информация об использовании',
+    ''
+  ].join('\n'));


### PR DESCRIPTION
```js
var program = require('commander');

program.version('0.0.1')
    .command('setup [env]')
    .description('application simple description', {
        env: 'env value'
    })
    .option('-f, --foo', 'enable some foo')
    .action(function(env, options) {});

var translations = {
    'Usage:': 'Применение:',
    'Commands:': 'Команды:',
    'Arguments:': 'Аргументы:',
    'Options:': 'Опции:',
    'output usage information': 'информация об использовании',
    'output the version number': 'показать номер версии',
    'application simple description': 'простое описание приложения',
    'enable some foo': 'включить некоторые foo',
    'env value': 'значение env'
    // ...
};

program.translator = function(str) {
    return translations[str] || str;
};

program.parse(process.argv);
if (!program.args.length) program.help();
```