### PR TITLE
[Rebase] Fix Coercion for Non Collections

### DIFF
--- a/index.js
+++ b/index.js
@@ -390,6 +390,17 @@ Command.prototype.option = function(flags, description, fn, defaultValue) {
     }
   }
 
+  // Is the default array like, if so its likely repeated options.
+  if (defaultValue != null &&
+    typeof defaultValue != 'function' &&
+    typeof defaultValue.length == 'number' &&
+    defaultValue.length > -1
+  ) {
+    option.repeated = true;
+  } else {
+    option.repeated = false;
+  }
+
   // preassign default value only for --no-*, [optional], or <required>
   if (!option.bool || option.optional || option.required) {
     // when --no-* we make sure default is true
@@ -408,8 +419,16 @@ Command.prototype.option = function(flags, description, fn, defaultValue) {
   // and conditionally invoke the callback
   this.on('option:' + oname, function(val) {
     // coercion
-    if (val !== null && fn) {
-      val = fn(val, self[name] === undefined ? defaultValue : self[name]);
+    if (null !== val && fn) {
+      if (option.repeated) {
+        val = fn(val, undefined === self[name] ? defaultValue : self[name]);
+      } else {
+        if (val === undefined && self[name] !== undefined && self[name] !== defaultValue) {
+          val = fn(self[name]);
+        } else {
+          val = fn((val === undefined) ? defaultValue : val);
+        }
+      }
     }
 
     // unassigned or bool

--- a/index.js
+++ b/index.js
@@ -423,12 +423,10 @@ Command.prototype.option = function(flags, description, fn, defaultValue) {
     if (fn && val !== null) {
       if (option.repeated) {
         val = fn(val, undefined === self[name] ? defaultValue : self[name]);
+      } else if (val === undefined && self[name] !== undefined && self[name] !== defaultValue) {
+        val = fn(self[name]);
       } else {
-        if (val === undefined && self[name] !== undefined && self[name] !== defaultValue) {
-          val = fn(self[name]);
-        } else {
-          val = fn((val === undefined) ? defaultValue : val);
-        }
+        val = fn((val === undefined) ? defaultValue : val);
       }
     }
 

--- a/index.js
+++ b/index.js
@@ -391,9 +391,10 @@ Command.prototype.option = function(flags, description, fn, defaultValue) {
   }
 
   // Is the default array like, if so its likely repeated options.
-  if (defaultValue != null &&
-    typeof defaultValue != 'function' &&
-    typeof defaultValue.length == 'number' &&
+  if (defaultValue !== undefined &&
+    defaultValue !== null &&
+    typeof defaultValue !== 'function' &&
+    typeof defaultValue.length === 'number' &&
     defaultValue.length > -1
   ) {
     option.repeated = true;
@@ -419,7 +420,7 @@ Command.prototype.option = function(flags, description, fn, defaultValue) {
   // and conditionally invoke the callback
   this.on('option:' + oname, function(val) {
     // coercion
-    if (null !== val && fn) {
+    if (fn && val !== null) {
       if (option.repeated) {
         val = fn(val, undefined === self[name] ? defaultValue : self[name]);
       } else {

--- a/test/test.options.coercion.js
+++ b/test/test.options.coercion.js
@@ -9,8 +9,8 @@ function parseRange(str) {
   return str.split('..').map(Number);
 }
 
-function increaseVerbosity(v, total) {
-  return total + 1;
+function increaseVerbosity(v) {
+  return v + 1;
 }
 
 function collectValues(str, memo) {

--- a/test/test.options.default.not.collection.js
+++ b/test/test.options.default.not.collection.js
@@ -1,0 +1,15 @@
+/**
+ * Module dependencies.
+ */
+
+var program = require('../')
+  , should = require('should');
+
+program
+  .version('0.0.1')
+  .option('-i, --int [n]', 'optionally specify the type of cheese provide a false default', parseInt, 2)
+  .option('-d, --data [n]', 'optionally specify the type of cheese provide a false default', parseInt, 4);
+
+program.parse(['node', 'test', '--int', '20', '-d', '30']);
+program.int.should.be.equal(20);
+program.data.should.be.equal(30);


### PR DESCRIPTION
This is a rebase of https://github.com/tj/commander.js/pull/757/files

Initial PR comment:

```
This fixes a bug that appears to have been introduced when
repeated options were added that causes the previous value or
default value to be passed as a second parameter to the coercion
function. This obviously causes unintended side effects when a user
specifies a function and a default value unaware that a second value
passed, such as with parseInt.

This change makes the assumption that when a default array is specified
that the user has expecting repeated options. This change is backward
compatible with the existing code.
```