### PR TITLE
Fixed TSC error

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -23,7 +23,7 @@ declare namespace local {
     constructor(flags: string, description?: string);
   }
 
-  class Command extends NodeJS.EventEmitter {
+  class Command {
     [key: string]: any;
 
     args: string[];


### PR DESCRIPTION
fixes #787

node_modules/commander/typings/index.d.ts(26,25): error TS2689: Cannot extend an interface 'NodeJS.EventEmitter'. Did you mean 'implements'?