### PR TITLE
invoke git-style sub commands only when required

### DIFF
--- a/index.js
+++ b/index.js
@@ -486,7 +486,7 @@ Command.prototype.parse = function(argv) {
 
   if (this._execs[name] && typeof this._execs[name] !== 'function') {
     return this.executeSubCommand(argv, args, parsed.unknown);
-  } else if (aliasCommand) {
+  } else if (aliasCommand && this._execs[aliasCommand._name] && typeof this._execs[aliasCommand._name] !== 'function') {
     // is alias of a subCommand
     args[0] = aliasCommand._name;
     return this.executeSubCommand(argv, args, parsed.unknown);


### PR DESCRIPTION
This PR fixes the below issue

Git-style sub commands are invoked if alias is used as an argument.
Example

```
program
  .command('com')
  .alias('c')
  .action(() => {
    console.log('com called')
  })
```

```

$ > node index.js c c
com called

  index-com(1) does not exist, try --help
```