### PR TITLE
Make 'npm test' run on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 
-TESTS = $(shell find test/test.*.js)
 
 test:
-	@./test/run $(TESTS)
+	@./test/run.js
 
 .PHONY: test

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "lint": "eslint index.js",
-    "test": "make test && npm run test-typings",
+    "test": "node test/run.js && npm run test-typings",
     "test-typings": "node_modules/typescript/bin/tsc -p tsconfig.json"
   },
   "main": "index",

--- a/test/run.js
+++ b/test/run.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+const { spawnSync } = require('child_process')
+const { readdirSync } = require('fs')
+const { extname, join } = require('path')
+
+process.env.NODE_ENV = 'test';
+
+process.stdout.write('\n')
+readdirSync(__dirname).forEach((file) => {
+  if (!file.startsWith('test.') || extname(file) !== '.js')
+    return;
+  process.stdout.write(`\x1b[90m   ${file}\x1b[0m `);
+  const result = spawnSync(process.argv0, [ join('test', file) ]);
+  if (result.status === 0) {
+    process.stdout.write('\x1b[36m✓\x1b[0m\n');
+  } else {
+    process.stdout.write('\x1b[31m✖\x1b[0m\n');
+    console.error(result.stderr.toString('utf8'));
+    process.exit(result.status);
+  }
+})


### PR DESCRIPTION
Uses Node to run the tests. Running `make test` will still work.