### PR TITLE
Fix the path of tsc command

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "lint": "eslint index.js",
     "test": "node test/run.js && npm run test-typings",
-    "test-typings": "node_modules/typescript/bin/tsc -p tsconfig.json"
+    "test-typings": "tsc -p tsconfig.json"
   },
   "main": "index",
   "files": [


### PR DESCRIPTION
Since there is a tsc command below `./node_modules/.bin`,
`./node_modules/.bin` has been added to `PATH`.