### PR TITLE
Allow custom usage message to override program name for git-style sub-commands

### DIFF
--- a/index.js
+++ b/index.js
@@ -919,7 +919,12 @@ Command.prototype.usage = function(str) {
     return humanReadableArgName(arg);
   });
 
-  var usage = '[options]' +
+  var cmdName = this._name;
+  if (this._alias) {
+    cmdName = cmdName + '|' + this._alias;
+  }
+
+  var usage = cmdName + ' [options]' +
     (this.commands.length ? ' [command]' : '') +
     (this._args.length ? ' ' + args.join(' ') : '');
 
@@ -1105,10 +1110,6 @@ Command.prototype.helpInformation = function() {
     }
   }
 
-  var cmdName = this._name;
-  if (this._alias) {
-    cmdName = cmdName + '|' + this._alias;
-  }
   var usage = [
     '',
     '  Usage: ' + cmdName + ' ' + this.usage(),

--- a/index.js
+++ b/index.js
@@ -1112,7 +1112,7 @@ Command.prototype.helpInformation = function() {
 
   var usage = [
     '',
-    '  Usage: ' + cmdName + ' ' + this.usage(),
+    '  Usage: ' + this.usage(),
     ''
   ];
 


### PR DESCRIPTION
This pull request changes the behaviour of the ```usage``` method so that a custom usage message can override the program name.

This is a workaround to correctly display the usage of nested git style sub-commands. 

Example:

foo.js
```js
program
    .command('bar [command]', 'Run bar command')
    .command('qux [command]', 'Run qux command')
````

foo-bar.js
```js
program
    .command('baz [options]')
```

foo-bar-baz.js
```js
program
    .description('This program can be run using git-style sub-commands "foo bar baz"')
    .option('-t, --test', 'Test command')
```

This program can be run using git-style sub-commands as follows: ```foo bar baz```. 
However, the usage information will use the filename and display something like the following:

```
Usage: foo-bar-baz [options]
```

This pull-request allows the user to fully override the usage information, so that the correct usage information for nested git-style sub-commands can at least be correctly added manually. 

I have not yet figured out a way to automatically detect the use of nested git-style sub-commands.