### PR TITLE
Document default vs. coercion function order

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -105,6 +105,8 @@ A command's options are validated when the command is used. Any unknown options 
 
 ## Coercion
 
+Options can have a default value and/or a coercion function (usually in that order) passed in after the description string.  For example, a coercion function of `parseInt` or `parseFloat` will transform arguments into integers or floats, respectively.  If the default value is specified after the coercion function, then the function can take a second argument which is the current argument value so far (starting with the default value), which enables accumulating repeated arguments e.g. into an array.
+
 ```js
 function range(val) {
   return val.split('..').map(Number);
@@ -126,7 +128,10 @@ function increaseVerbosity(v, total) {
 program
   .version('0.1.0')
   .usage('[options] <file ...>')
+  .option('-s, --string <x>', 'A string argument')
+  .option('-S, --string-default <x>', 'A string argument with default', 'hello')
   .option('-i, --integer <n>', 'An integer argument', parseInt)
+  .option('-I, --integer-default <n>', 'An integer argument with default', 5, parseInt)
   .option('-f, --float <n>', 'A float argument', parseFloat)
   .option('-r, --range <a>..<b>', 'A range', range)
   .option('-l, --list <items>', 'A list', list)


### PR DESCRIPTION
Add examples and descriptive text about the effects of putting the default argument before the coercion function and vice versa.  Basically, if the default goes before the coercion function, then the function gets no second argument, and you can use coercion functions like `parseInt`.  But if the default goes after the coercion function, then the function gets a second argument, useful for accumulation.  The word "default" is essentially not mentioned in the current readme, so I didn't even realize that it was a feature for a while.

I had to discover this the hard way, and open issue #686 suggested it was a bug, possibly fixed by #757, but I believe that PR changes the behavior.  This PR just documents the existing behavior, which seems pretty functional.