### PR TITLE
Subcommands broken if bin name is different from name of script it resolves to

### DIFF
--- a/index.js
+++ b/index.js
@@ -546,6 +546,16 @@ Command.prototype.executeSubCommand = function(argv, args, unknown) {
     isExplicitJS = true;
   } else if (exists(localBin)) {
     bin = localBin;
+  } else if (link !== f) {
+    // if the resolved bin file is different, try that instead
+    bin = basename(link, '.js') + '-' + args[0];
+    localBin = path.join(baseDir, bin);
+    if (exists(localBin + '.js')) {
+      bin = localBin + '.js';
+      isExplicitJS = true;
+    } else if (exists(localBin)) {
+      bin = localBin;
+    }
   }
 
   args = args.slice(1);

--- a/test/test.command.executableSubcommand.js
+++ b/test/test.command.executableSubcommand.js
@@ -34,3 +34,8 @@ var bin = path.join(__dirname, './fixtures/pmlink')
 exec(bin + ' install', function (error, stdout, stderr) {
   stdout.should.equal('install\n');
 });
+
+// pmlink-publish should fallback to pm-publish with explicit extension
+exec(bin + ' publish', function (error, stdout, stderr) {
+  stdout.should.equal('publish\n');
+});


### PR DESCRIPTION
When using subcommands, you may have a list of scripts like:
```
cli.js
cli-search.js
cli-parse.js
```
You might then supply a `bin` field like:
```javascript
"bin": { "mytool": "cli.js" }
```
However, this does not work with subcommands, as Commander.js will search for `mytool-search.js`, `mytool-parse.js`, etc... For some projects, renaming all the scripts to be the same as what's in the `bin` field may not be a viable option.

This fix adds additional logic to check if the symlink in bin resolved to a different name, and if so will use that name only if the regular logic fails to find the subcommand. Thus, this change should not affect cases that were already working before, it would only affect cases that were broken (the new logic is only invoked when Commander.js would bail out after failing to find the subcommand script).

I've also added a test case, which verifies that the new behavior is working properly.