### PR TITLE
add support for execute typescript subcommand via ts-node

### DIFF
--- a/index.js
+++ b/index.js
@@ -523,7 +523,7 @@ Command.prototype.executeSubCommand = function(argv, args, unknown) {
   // executable
   var f = argv[1];
   // name of the subcommand, link `pm-install`
-  var bin = basename(f, '.js') + '-' + args[0];
+  var bin = basename(f, path.extname(f)) + '-' + args[0];
 
   // In case of globally installed, get the base dir where executable
   //  subcommand file should be located at
@@ -539,10 +539,13 @@ Command.prototype.executeSubCommand = function(argv, args, unknown) {
   // prefer local `./<bin>` to bin in the $PATH
   var localBin = path.join(baseDir, bin);
 
-  // whether bin file is a js script with explicit `.js` extension
+  // whether bin file is a js script with explicit `.js` or `.ts` extension
   var isExplicitJS = false;
   if (exists(localBin + '.js')) {
     bin = localBin + '.js';
+    isExplicitJS = true;
+  } else if (exists(localBin + '.ts')) {
+    bin = localBin + '.ts';
     isExplicitJS = true;
   } else if (exists(localBin)) {
     bin = localBin;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1150,6 +1150,12 @@
         "yallist": "^2.1.2"
       }
     },
+    "make-error": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.4.tgz",
+      "integrity": "sha512-0Dab5btKVPhibSalc9QGXb559ED7G7iLjFXBaj9Wq8O3vorueR5K5jaE3hkG6ZQINyhA/JgG6Qk4qdFQjsYV6g==",
+      "dev": true
+    },
     "mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
@@ -1787,6 +1793,22 @@
         "is-fullwidth-code-point": "^2.0.0"
       }
     },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.8.tgz",
+      "integrity": "sha512-WqAEWPdb78u25RfKzOF0swBpY0dKrNdjc4GvLwm7ScX/o9bj8Eh/YL8mcMhBHYDGl87UkkSXDOFnW4G7GhWhGg==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "spdx-correct": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
@@ -2137,6 +2159,30 @@
         "os-tmpdir": "~1.0.2"
       }
     },
+    "ts-node": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
+      "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.0",
+        "buffer-from": "^1.1.0",
+        "diff": "^3.1.0",
+        "make-error": "^1.1.1",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.5.6",
+        "yn": "^2.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -2235,6 +2281,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    },
+    "yn": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
+      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "should": "^13.2.3",
     "sinon": "^6.1.4",
     "standard": "^11.0.1",
+    "ts-node": "^7.0.1",
     "typescript": "^2.9.2"
   },
   "typings": "typings/index.d.ts"

--- a/test/fixtures-ts/pm-install.ts
+++ b/test/fixtures-ts/pm-install.ts
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+console.log('install');

--- a/test/fixtures-ts/pm.ts
+++ b/test/fixtures-ts/pm.ts
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+var program = require('../../');
+
+program
+    .version('0.0.1')
+    .command('install [name]', 'install one or more packages')
+    .parse(process.argv);

--- a/test/test.command.executableSubcommand.tsnode.js
+++ b/test/test.command.executableSubcommand.tsnode.js
@@ -1,0 +1,10 @@
+var exec = require('child_process').exec
+  , path = require('path')
+  , should = require('should');
+
+var bin = path.join(__dirname, './fixtures-ts/pm.ts')
+
+// success case
+exec(process.argv[0] + ' -r ts-node/register ' + bin + ' install', function (error, stdout, stderr) {
+  stdout.should.equal('install\n');
+});


### PR DESCRIPTION
`Command.prototype.executeSubCommand` doesn't support `.ts` extension for scripts. It is bad if you want run something via [ts-node](https://github.com/TypeStrong/ts-node).

https://github.com/tj/commander.js/blob/e5b27cc553c0c55eb2f8890dc83034d3a3eee531/index.js#L526

First, hardcoded `.js` extension is bad. I suggest use real file extension.

https://github.com/tj/commander.js/blob/e5b27cc553c0c55eb2f8890dc83034d3a3eee531/index.js#L544-L546

Second, I suggest use similar block of code for check exists file with `.ts` extension. I don't think that this duplication is serious.