### PR TITLE
Removed newline after Options and Commands headers

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -254,7 +254,6 @@ Usage: pizza [options]
 An application for pizzas ordering
 
 Options:
-
   -h, --help           output usage information
   -V, --version        output the version number
   -p, --peppers        Add peppers
@@ -294,7 +293,6 @@ program
 program.on('--help', function(){
   console.log('')
   console.log('Examples:');
-  console.log('');
   console.log('  $ custom-help --help');
   console.log('  $ custom-help -h');
 });
@@ -310,7 +308,6 @@ Yields the following help output when `node script-name.js -h` or `node script-n
 Usage: custom-help [options]
 
 Options:
-
   -h, --help     output usage information
   -V, --version  output the version number
   -f, --foo      enable some foo
@@ -318,7 +315,6 @@ Options:
   -B, --baz      enable some baz
 
 Examples:
-
   $ custom-help --help
   $ custom-help -h
 ```

--- a/Readme_zh-CN.md
+++ b/Readme_zh-CN.md
@@ -192,7 +192,6 @@ Usage: pizza [options]
 An application for pizzas ordering
 
 Options:
-
   -h, --help           output usage information
   -V, --version        output the version number
   -p, --peppers        Add peppers
@@ -226,10 +225,9 @@ program
 
 program.on('--help', function(){
   console.log('');
-  console.log('  Examples:');
-  console.log('');
-  console.log('    $ custom-help --help');
-  console.log('    $ custom-help -h');
+  console.log('Examples:');
+  console.log('  $ custom-help --help');
+  console.log('  $ custom-help -h');
 });
 
 program.parse(process.argv);
@@ -243,7 +241,6 @@ console.log('stuff');
 Usage: custom-help [options]
 
 Options:
-
   -h, --help     output usage information
   -V, --version  output the version number
   -f, --foo      enable some foo
@@ -251,7 +248,6 @@ Options:
   -B, --baz      enable some baz
 
 Examples:
-
   $ custom-help --help
   $ custom-help -h
 ```

--- a/index.js
+++ b/index.js
@@ -1073,7 +1073,6 @@ Command.prototype.commandHelp = function() {
 
   return [
     'Commands:',
-    '',
     commands.map(function(cmd) {
       var desc = cmd[1] ? '  ' + cmd[1] : '';
       return (desc ? pad(cmd[0], width) : cmd[0]) + desc;
@@ -1124,7 +1123,6 @@ Command.prototype.helpInformation = function() {
 
   var options = [
     'Options:',
-    '',
     '' + this.optionHelp().replace(/^/gm, '  '),
     ''
   ];

--- a/test/test.command.help.js
+++ b/test/test.command.help.js
@@ -5,8 +5,8 @@ var program = require('../')
 
 program.command('bare');
 
-program.commandHelp().should.equal('Commands:\n\n  bare\n');
+program.commandHelp().should.equal('Commands:\n  bare\n');
 
 program.command('mycommand [options]');
 
-program.commandHelp().should.equal('Commands:\n\n  bare\n  mycommand [options]\n');
+program.commandHelp().should.equal('Commands:\n  bare\n  mycommand [options]\n');

--- a/test/test.command.helpInformation.js
+++ b/test/test.command.helpInformation.js
@@ -10,11 +10,9 @@ var expectedHelpInformation = [
   'Usage:  [options] [command]',
   '',
   'Options:',
-  '',
   '  -h, --help                output usage information',
   '',
   'Commands:',
-  '',
   '  somecommand',
   '  anothercommand [options]',
   ''

--- a/test/test.command.nohelp.js
+++ b/test/test.command.nohelp.js
@@ -48,7 +48,6 @@ var output = process.stdout.write.args[0];
 
 var expect = [
 	'Commands:',
-	'',
 	'  mycommand [options]       this is my command',
 	'  anothercommand [options]',
 	'  help [cmd]                display help for [cmd]'


### PR DESCRIPTION
Removed newline in help output after "Options" and "Commands".

Fixes #863.