### PR TITLE
follow links

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var path = require('path');
 var dirname = path.dirname;
 var basename = path.basename;
 var fs = require('fs');
+var readlink = require('readlink').sync;
 
 /**
  * Inherit `Command` from `EventEmitter.prototype`.
@@ -527,13 +528,12 @@ Command.prototype.executeSubCommand = function(argv, args, unknown) {
 
   // In case of globally installed, get the base dir where executable
   //  subcommand file should be located at
-  var baseDir,
-    link = fs.lstatSync(f).isSymbolicLink() ? fs.readlinkSync(f) : f;
+  var baseDir, link = f;
 
-  // when symbolink is relative path
-  if (link !== f && link.charAt(0) !== '/') {
-    link = path.join(dirname(f), link);
+  while (fs.lstatSync(link).isSymbolicLink()) {
+    link = readlink(link);
   }
+
   baseDir = dirname(link);
 
   // prefer local `./<bin>` to bin in the $PATH

--- a/package-lock.json
+++ b/package-lock.json
@@ -173,6 +173,14 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
+    "async": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+      "requires": {
+        "lodash": "^4.17.10"
+      }
+    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -1190,8 +1198,7 @@
     "lodash": {
       "version": "4.17.10",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-      "dev": true
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -1587,6 +1594,14 @@
             "locate-path": "^2.0.0"
           }
         }
+      }
+    },
+    "readlink": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/readlink/-/readlink-2.0.0.tgz",
+      "integrity": "sha512-P/JmBwzcHlMiynQbwx++rYIEhhODRoEMrlB88qjNLXVUVHms+Ntgi+PZEaqXlpgCwQNZUx6km/5uA+II6ElxhQ==",
+      "requires": {
+        "async": "^2.5.0"
       }
     },
     "regexpp": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "index.js",
     "typings/index.d.ts"
   ],
-  "dependencies": {},
+  "dependencies": {
+    "readlink": "^2.0.0"
+  },
   "devDependencies": {
     "@types/node": "^10.11.3",
     "eslint": "^5.6.1",

--- a/test/fixtures-yarn/bin/pm
+++ b/test/fixtures-yarn/bin/pm
@@ -1,0 +1,1 @@
+../config/bin/pm

--- a/test/fixtures-yarn/config/bin/pm
+++ b/test/fixtures-yarn/config/bin/pm
@@ -1,0 +1,1 @@
+../package/pm

--- a/test/fixtures-yarn/config/package/pm
+++ b/test/fixtures-yarn/config/package/pm
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+var program = require('../../../../');
+
+program
+  .version('0.0.1')
+  .command('install [name]', 'install one or more packages').alias('i')
+  .command('search [query]', 'search with optional query').alias('s')
+  .command('cache', 'actions dealing with the cache').alias('c')
+  .command('list', 'list packages installed')
+  .command('listen', 'listen for supported signal events').alias('l')
+  .command('publish', 'publish or update package').alias('p')
+  .command('default', 'default command', {noHelp: true, isDefault: true})
+  .parse(process.argv);

--- a/test/fixtures-yarn/config/package/pm-install
+++ b/test/fixtures-yarn/config/package/pm-install
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+console.log('install')
+

--- a/test/test.command.executableSubcommand.js
+++ b/test/test.command.executableSubcommand.js
@@ -34,3 +34,10 @@ var bin = path.join(__dirname, './fixtures/pmlink')
 exec(bin + ' install', function (error, stdout, stderr) {
   stdout.should.equal('install\n');
 });
+
+// when `bin` is a symbol link for symbol link for mocking global install
+var bin = path.join(__dirname, './fixtures-yarn/bin/pm')
+// success case
+exec(bin + ' install', function (error, stdout, stderr) {
+  stdout.should.equal('install\n');
+});


### PR DESCRIPTION
yarn ~v1.10.x changed bin linking for global packages (I can't find commit with that changes).

How yarn link bin after `$ yarn global add package`?

```bash
$ file ~/.yarn/bin/package
~/.yarn/bin/package: symbolic link to ../../.config/yarn/global/node_modules/.bin/package
```

```bash
$ file ~/.config/yarn/global/node_modules/.bin/package
~/.config/yarn/global/node_modules/.bin/package: symbolic link to ../package/bin/package.js
```

But `commander.js` read link only once time. And sub-commands not work,  because in directory `~/.config/yarn/global/node_modules/.bin` other files doesn't exists.

My solution: follow links and get real file name.

In GNU/Linux shell command `readlink -f` implements it:

```bash
$ readlink -f ~/.yarn/bin/package
~/.config/yarn/global/node_modules/package/bin/package.js
```

For Node.js I found package [readlink](https://www.npmjs.com/package/readlink) with almost similar behavior (from description).

Close #866 
