### PR TITLE
Enable custom help description messages for -V and -h

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -254,8 +254,8 @@ Usage: pizza [options]
 An application for pizzas ordering
 
 Options:
-  -h, --help           output usage information
-  -V, --version        output the version number
+  -h, --help           Output usage information
+  -V, --version        Output the version number
   -p, --peppers        Add peppers
   -P, --pineapple      Add pineapple
   -b, --bbq            Add bbq sauce
@@ -308,8 +308,8 @@ Yields the following help output when `node script-name.js -h` or `node script-n
 Usage: custom-help [options]
 
 Options:
-  -h, --help     output usage information
-  -V, --version  output the version number
+  -h, --help     Output usage information
+  -V, --version  Output the version number
   -f, --foo      enable some foo
   -b, --bar      enable some bar
   -B, --baz      enable some baz

--- a/Readme_zh-CN.md
+++ b/Readme_zh-CN.md
@@ -192,8 +192,8 @@ Usage: pizza [options]
 An application for pizzas ordering
 
 Options:
-  -h, --help           output usage information
-  -V, --version        output the version number
+  -h, --help           Output usage information
+  -V, --version        Output the version number
   -p, --peppers        Add peppers
   -P, --pineapple      Add pineapple
   -b, --bbq            Add bbq sauce
@@ -241,8 +241,8 @@ console.log('stuff');
 Usage: custom-help [options]
 
 Options:
-  -h, --help     output usage information
-  -V, --version  output the version number
+  -h, --help     Output usage information
+  -V, --version  Output the version number
   -f, --foo      enable some foo
   -b, --bar      enable some bar
   -B, --baz      enable some baz

--- a/examples/help-description.js
+++ b/examples/help-description.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+/**
+ * Module dependencies.
+ */
+
+var program = require('../');
+
+program
+  .option('-f, --food [item]', 'Provide your favourite food item')
+	.version('0.0.1', '-v, --version', 'Display version number')
+	.helpDescription('Display this help message')
+  .parse(process.argv);
+
+/**
+ * Default behaviour
+ */
+
+// program
+//   .option('-f, --food [item]', 'Provide your favourite food item')
+// 	.version('0.0.1')
+//   .parse(process.argv);
+
+console.log('Oh, so you like ' + program.food + '!')

--- a/index.js
+++ b/index.js
@@ -854,21 +854,38 @@ Command.prototype.variadicArgNotLast = function(name) {
  *
  * @param {String} str
  * @param {String} [flags]
+ * @param {String} [description]
  * @return {Command} for chaining
  * @api public
  */
 
-Command.prototype.version = function(str, flags) {
+Command.prototype.version = function(str, flags, description) {
   if (arguments.length === 0) return this._version;
   this._version = str;
   flags = flags || '-V, --version';
-  var versionOption = new Option(flags, 'output the version number');
+  var versionOption = new Option(flags, description || 'Output the version number');
   this._versionOptionName = versionOption.long.substr(2) || 'version';
   this.options.push(versionOption);
   this.on('option:' + this._versionOptionName, function() {
     process.stdout.write(str + '\n');
     process.exit(0);
   });
+  return this;
+};
+
+/**
+ * Set the help message description to `description`.
+ *
+ * This methods sets the help description for the "-h, --help" flag
+ * If not provided, it willl default to 'Output usage information'
+ *
+ * @param {String} [description]
+ * @return {Command} for chaining
+ * @api public
+ */
+
+Command.prototype.helpDescription = function(description) {
+  this._helpDescription = description;
   return this;
 };
 
@@ -1054,7 +1071,7 @@ Command.prototype.optionHelp = function() {
   return this.options.map(function(option) {
     return pad(option.flags, width) + '  ' + option.description +
       ((option.bool && option.defaultValue !== undefined) ? ' (default: ' + JSON.stringify(option.defaultValue) + ')' : '');
-  }).concat([pad('-h, --help', width) + '  ' + 'output usage information'])
+  }).concat([pad('-h, --help', width) + '  ' + (this._helpDescription || 'Output usage information')])
     .join('\n');
 };
 

--- a/test/test.command.helpDescription.js
+++ b/test/test.command.helpDescription.js
@@ -1,0 +1,21 @@
+var program = require('../')
+	, sinon = require('sinon').sandbox.create()
+  , should = require('should');
+
+sinon.stub(process, 'exit');
+sinon.stub(process.stdout, 'write');
+
+program
+  .helpDescription('My custom help description')
+
+program.parse(['node', 'test']);
+
+program._helpDescription.should.equal('My custom help description');
+
+sinon.restore();
+sinon.stub(process.stdout, 'write');
+program.outputHelp();
+
+var output = process.stdout.write.args[0];
+
+output[0].should.equal('Usage: test [options]\n\nOptions:\n  -h, --help  My custom help description\n');

--- a/test/test.command.helpInformation.js
+++ b/test/test.command.helpInformation.js
@@ -10,7 +10,7 @@ var expectedHelpInformation = [
   'Usage:  [options] [command]',
   '',
   'Options:',
-  '  -h, --help                output usage information',
+  '  -h, --help                Output usage information',
   '',
   'Commands:',
   '  somecommand',


### PR DESCRIPTION
### Enable custom help description messages for -V and -h

* Add description argument to .version()

* Add command .helpDescription()

For overriding default -h and -V flag help descriptions.

* Capitalize default help descriptions
	-V: 'Output version number'
	-h: 'Output usage information'

* Add example (help-description.js)

* Add test (test.command.helpDescription)

* Update Readme