### PR TITLE
--save no longer needed

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -13,7 +13,7 @@
 
 ## Installation
 
-    $ npm install commander --save
+    $ npm install commander
 
 ## Option parsing
 


### PR DESCRIPTION
`--save` is on by default as of [npm 5](https://blog.npmjs.org/post/161081169345/v500), so `npm install aphrodite` is functionally equivalent to `npm install --save aphrodite` now