### PR TITLE
Add extension to .eslintrc

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,6 +3,6 @@
   "rules": {
     "one-var": "off",
     "semi": ["error", "always", { "omitLastInOneLineBlock": true }],
-    "space-before-function-paren": ["error", "never"],
+    "space-before-function-paren": ["error", "never"]
   }
 }


### PR DESCRIPTION
A small fix, .eslintrc without extension is deprecated (https://eslint.org/docs/user-guide/configuring#configuration-file-formats).

### Changes
- Add extension to .eslintrc file
- Remove dangling comma, incompatible with json format