### PR TITLE
Added missing semicolon

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,7 @@
   "extends": "standard",
   "rules": {
     "one-var": "off",
-    "semi": ["error", "always", { "omitLastInOneLineBlock": true }],
+    "semi": ["error", "always"],
     "space-before-function-paren": ["error", "never"]
   }
 }

--- a/index.js
+++ b/index.js
@@ -664,7 +664,7 @@ Command.prototype.parseArgs = function(args, unknown) {
       this.unknownOption(unknown[0]);
     }
     if (this.commands.length === 0 &&
-        this._args.filter(function(a) { return a.required }).length === 0) {
+        this._args.filter(function(a) { return a.required; }).length === 0) {
       this.emit('command:*');
     }
   }


### PR DESCRIPTION
There originally was a special ESLint exception for the one missing semicolon case:

https://github.com/tj/commander.js/blob/master/.eslintrc.json#L5

```js
    "semi": ["error", "always", { "omitLastInOneLineBlock": true }],
```

Other TJ projects like mocha always require semicolons, even in this case ([`mocha`](https://github.com/mochajs/mocha/blob/master/.eslintrc.yml#L3) uses [`semistandard`](https://github.com/Flet/eslint-config-semistandard) whose rule is [`"semi": [2, "always"]`](https://github.com/Flet/eslint-config-semistandard/blob/master/eslintrc.json)

Going back to the blame log, https://github.com/tj/commander.js/commit/4c9b4b8ee608f6f3bdcaf3674cf26700f999722f is the commit that introduced it and the comment "customize linter to fit with style of project" suggests the original contributor @mojavelinux thought the missing semicolon was intentional.