### PR TITLE
resolves #877, adds ability to pass execution args on Windows platform

### DIFF
--- a/index.js
+++ b/index.js
@@ -558,7 +558,7 @@ Command.prototype.executeSubCommand = function(argv, args, unknown) {
     if (isExplicitJS) {
       args.unshift(bin);
       // add executable arguments to spawn
-      args = (process.execArgv || []).concat(args);
+      args = this.getExecutableArguments().concat(args);
 
       proc = spawn(process.argv[0], args, { stdio: 'inherit', customFds: [0, 1, 2] });
     } else {
@@ -566,6 +566,9 @@ Command.prototype.executeSubCommand = function(argv, args, unknown) {
     }
   } else {
     args.unshift(bin);
+    // add executable arguments to spawn
+    args = this.getExecutableArguments().concat(args);
+
     proc = spawn(process.execPath, args, { stdio: 'inherit' });
   }
 
@@ -589,6 +592,24 @@ Command.prototype.executeSubCommand = function(argv, args, unknown) {
 
   // Store the reference to the child process
   this.runningCommand = proc;
+};
+
+/**
+ * Get executable arguments for sub-command process.
+ * If COMMANDER_NODE_OPTIONS Environment Variable is set,
+ * it combines current execArgv and COMMANDER_NODE_OPTIONS.
+ *
+ * @return {Array}
+ * @api private
+ */
+
+Command.prototype.getExecutableArguments = function() {
+  var commanderNodeOptions = process.env['COMMANDER_NODE_OPTIONS'];
+  var execArgv = process.execArgv || [];
+  if (commanderNodeOptions && commanderNodeOptions !== null && commanderNodeOptions.length > 0) {
+    execArgv = execArgv.concat(commanderNodeOptions.split(' '));
+  }
+  return execArgv;
 };
 
 /**

--- a/test/test.command.getExecutableArguments.js
+++ b/test/test.command.getExecutableArguments.js
@@ -1,0 +1,20 @@
+var program = require('../')
+  , should = require('should');
+
+program.command('foo');
+
+// empty current execArgv
+process.execArgv = [];
+// in order to run this test properly, COMMANDER_NODE_OPTIONS Environment Variable have to be not defined.
+
+program.getExecutableArguments().should.deepEqual([]);
+
+// lets add some execution arguments to execArgv
+process.execArgv = ["--harmony"];
+// it should be equal to process.execArgv because of our COMMANDER_NODE_OPTIONS haven't been set yet.
+program.getExecutableArguments().should.deepEqual(["--harmony"]);
+
+// set COMMANDER_NODE_OPTIONS environment variable
+process.env["COMMANDER_NODE_OPTIONS"] = "--max-old-space-size=8192";
+// it should be equal to execArgv and COMMANDER_NODE_OPTIONS combined.
+program.getExecutableArguments().should.deepEqual(["--harmony", "--max-old-space-size=8192"]);


### PR DESCRIPTION
Hi,

This pull request resolves the issue #877 
Besides, current code is only passing execution arguments if the platform is not equal to 'win32'. This change adds the capability of passing execution arguments in Windows platform.