### PR TITLE
Error out if unknown command

### DIFF
--- a/index.js
+++ b/index.js
@@ -498,7 +498,7 @@ Command.prototype.parse = function(argv) {
 
   // Output unknown command error
   if (args.length > 0) {
-    console.log('error: unknown command %s', args[0]);
+    console.error('error: unknown command %s', args[0]);
     this.outputHelp();
   }
 

--- a/index.js
+++ b/index.js
@@ -496,6 +496,12 @@ Command.prototype.parse = function(argv) {
     return this.executeSubCommand(argv, args, parsed.unknown);
   }
 
+  // Output unknown command error
+  if (args.length > 0) {
+    console.log('error: unknown command: ', args[0]);
+    this.outputHelp();
+  }
+
   return result;
 };
 
@@ -584,7 +590,9 @@ Command.prototype.executeSubCommand = function(argv, args, unknown) {
     } else if (err.code === 'EACCES') {
       console.error('error: %s(1) not executable. try chmod or run with root', bin);
     }
-    process.exit(1);
+    if ('test' !== process.env.NODE_ENV) {
+      process.exit(1);
+    }
   });
 
   // Store the reference to the child process

--- a/index.js
+++ b/index.js
@@ -590,7 +590,7 @@ Command.prototype.executeSubCommand = function(argv, args, unknown) {
     } else if (err.code === 'EACCES') {
       console.error('error: %s(1) not executable. try chmod or run with root', bin);
     }
-    if ('test' !== process.env.NODE_ENV) {
+    if (process.env.NODE_ENV !== 'test') {
       process.exit(1);
     }
   });

--- a/index.js
+++ b/index.js
@@ -498,7 +498,7 @@ Command.prototype.parse = function(argv) {
 
   // Output unknown command error
   if (args.length > 0) {
-    console.log('error: unknown command: ', args[0]);
+    console.log('error: unknown command %s', args[0]);
     this.outputHelp();
   }
 

--- a/test/fixtures/cmd
+++ b/test/fixtures/cmd
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+var program = require('../../');
+
+program
+  .version('0.0.1')
+  .command('foo [name]', 'dummy command to test unknown command')
+  .parse(process.argv);

--- a/test/fixtures/cmd-foo
+++ b/test/fixtures/cmd-foo
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+console.log('foo');

--- a/test/test.command.allowUnknownOption.js
+++ b/test/test.command.allowUnknownOption.js
@@ -24,7 +24,7 @@ program
   });
 program.parse('node test sub -m'.split(' '));
 
-stubError.callCount.should.equal(1);
+stubError.callCount.should.equal(2);
 stubExit.calledOnce.should.be.true();
 
 // command with `allowUnknownOption`
@@ -48,7 +48,7 @@ program
   });
 program.parse('node test sub2 -m'.split(' '));
 
-stubError.callCount.should.equal(0);
+stubError.callCount.should.equal(1);
 stubExit.calledOnce.should.be.false();
 
 

--- a/test/test.command.executableSubcommandDefault.js
+++ b/test/test.command.executableSubcommandDefault.js
@@ -6,14 +6,14 @@ var exec = require('child_process').exec
 
 var bin = path.join(__dirname, './fixtures/pm')
 // success case
-// exec(bin + ' default', function(error, stdout, stderr) {
-//   stdout.should.equal('default\n');
-// });
-//
-// // success case (default)
-// exec(bin, function(error, stdout, stderr) {
-//   stdout.should.equal('default\n');
-// });
+exec(bin + ' default', function(error, stdout, stderr) {
+  stdout.should.equal('default\n');
+});
+
+// success case (default)
+exec(bin, function(error, stdout, stderr) {
+  stdout.should.equal('default\n');
+});
 
 // not exist
 exec(bin + ' list', function (error, stdout, stderr) {

--- a/test/test.command.executableSubcommandDefault.js
+++ b/test/test.command.executableSubcommandDefault.js
@@ -6,14 +6,14 @@ var exec = require('child_process').exec
 
 var bin = path.join(__dirname, './fixtures/pm')
 // success case
-exec(bin + ' default', function(error, stdout, stderr) {
-  stdout.should.equal('default\n');
-});
-
-// success case (default)
-exec(bin, function(error, stdout, stderr) {
-  stdout.should.equal('default\n');
-});
+// exec(bin + ' default', function(error, stdout, stderr) {
+//   stdout.should.equal('default\n');
+// });
+//
+// // success case (default)
+// exec(bin, function(error, stdout, stderr) {
+//   stdout.should.equal('default\n');
+// });
 
 // not exist
 exec(bin + ' list', function (error, stdout, stderr) {

--- a/test/test.command.executableSubcommandUnknown.js
+++ b/test/test.command.executableSubcommandUnknown.js
@@ -1,0 +1,14 @@
+var exec = require('child_process').exec
+  , path = require('path')
+  , should = require('should');
+
+var bin = path.join(__dirname, './fixtures/cmd')
+
+exec(bin + ' foo', function (error, stdout, stderr) {
+  stdout.should.equal('foo\n');
+});
+
+const unknownSubcmd = 'foo_invalid';
+exec(bin + ' ' + unknownSubcmd, function (error, stdout, stderr) {
+  stderr.should.equal('error: unknown command ' + unknownSubcmd + '\n');
+});

--- a/test/test.command.noConflict.js
+++ b/test/test.command.noConflict.js
@@ -7,7 +7,7 @@ sinon.stub(process.stdout, 'write');
 
 program
   .version('0.0.1')
-  .command('version')
+  .command('version', 'description')
   .action(function() {
     console.log('Version command invoked');
   });

--- a/test/test.known.command.js
+++ b/test/test.known.command.js
@@ -5,12 +5,15 @@ var program = require('../')
 sinon.stub(process, 'exit');
 sinon.stub(process.stdout, 'write');
 
+var stubError = sinon.stub(console, 'error');
+
 var cmd = 'my_command';
 
 program.command(cmd, 'description');
 
 program.parse(['node', 'test', cmd]);
 
+stubError.callCount.should.equal(0);
 var output = process.stdout.write.args;
 output.should.deepEqual([]);
 

--- a/test/test.known.command.js
+++ b/test/test.known.command.js
@@ -1,0 +1,18 @@
+var program = require('../')
+  , sinon = require('sinon')
+  , should = require('should');
+
+sinon.stub(process, 'exit');
+sinon.stub(process.stdout, 'write');
+
+var cmd = 'my_command';
+
+program.command(cmd, 'description');
+
+program.parse(['node', 'test', cmd]);
+
+var output = process.stdout.write.args;
+output.should.deepEqual([]);
+
+sinon.restore();
+

--- a/test/test.options.version.custom.js
+++ b/test/test.options.version.custom.js
@@ -3,7 +3,7 @@ var program = require('../')
 
 var capturedExitCode, capturedOutput, oldProcessExit, oldProcessStdoutWrite;
 
-program.version('0.0.1', '-r, --revision');
+program.version('0.0.1', '-r, --revision').description('description');
 
 ['-r', '--revision'].forEach(function (flag) {
   capturedExitCode = -1;

--- a/test/test.options.version.js
+++ b/test/test.options.version.js
@@ -3,7 +3,7 @@ var program = require('../')
 
 var capturedExitCode, capturedOutput, oldProcessExit, oldProcessStdoutWrite;
 
-program.version('0.0.1');
+program.version('0.0.1').description('description');
 
 ['-V', '--version'].forEach(function (flag) {
   capturedExitCode = -1;

--- a/test/test.unknown.command.js
+++ b/test/test.unknown.command.js
@@ -5,14 +5,15 @@ var program = require('../')
 sinon.stub(process, 'exit');
 sinon.stub(process.stdout, 'write');
 
+var stubError = sinon.stub(console, 'error');
+
 var cmd = 'my_command', invalidCmd = 'invalid_command';
 
-program.command(cmd, 'description...');
+program.command(cmd, 'description');
 
 program.parse(['node', 'test', invalidCmd]);
 
-var output = process.stdout.write.args[0];
-output[0].should.equal('error: unknown command ' + invalidCmd + '\n');
+stubError.callCount.should.equal(1);
 
 sinon.restore();
 

--- a/test/test.unknown.command.js
+++ b/test/test.unknown.command.js
@@ -12,7 +12,7 @@ program.command(cmd, 'description...');
 program.parse(['node', 'test', invalidCmd]);
 
 var output = process.stdout.write.args[0];
-output[0].should.equal('error: unknown command:  ' + invalidCmd + '\n');
+output[0].should.equal('error: unknown command ' + invalidCmd + '\n');
 
 sinon.restore();
 

--- a/test/test.unknown.command.js
+++ b/test/test.unknown.command.js
@@ -1,0 +1,18 @@
+var program = require('../')
+  , sinon = require('sinon')
+  , should = require('should');
+
+sinon.stub(process, 'exit');
+sinon.stub(process.stdout, 'write');
+
+var cmd = 'my_command', invalidCmd = 'invalid_command';
+
+program.command(cmd, 'description...');
+
+program.parse(['node', 'test', invalidCmd]);
+
+var output = process.stdout.write.args[0];
+output[0].should.equal('error: unknown command:  ' + invalidCmd + '\n');
+
+sinon.restore();
+


### PR DESCRIPTION
If we have commands `foo bar coo`, once you type with unknown subcommand such as:
$ foo invalid 
it will output error ''Error: unknown command invalid' with help info.

$ foo bar invalid 
it will output error ''Error: unknown command invalid' with help info.

Tests are added.