### PR TITLE
Add Azure Pipelines for CI (Linux, Mac, and Windows)

### DIFF
--- a/.azure-pipelines-steps.yml
+++ b/.azure-pipelines-steps.yml
@@ -1,0 +1,31 @@
+#
+# Steps for building and testing commander.js. See jobs defined in .azure-pipelines.yml.
+#
+
+steps:
+  # Clones the repo. This is an explicit step to preserve symlinks for Windows.
+  - checkout: self
+
+  - task: NodeTool@0
+    inputs:
+      versionSpec: $(NODE_VERSION)
+      checkLatest: 'true'
+    displayName: 'Install Node.js'
+
+  # Run npm ci by default unless NPM_INSTALL is set
+  - script: npm ci
+    displayName: 'Install dependencies'
+    condition: not(variables.NPM_INSTALL)
+
+  # Otherwise, run npm install if NPM_INSTALL is set (typically for Node versions < 10.x)
+  - script: npm install
+    displayName: 'Install dependencies (npm install)'
+    condition: variables.NPM_INSTALL
+
+  - script: npm run lint
+    displayName: 'Run lint'
+    condition: variables.LINT
+
+  - script: npm run test
+    displayName: 'Run tests'
+    condition: not(variables.SKIP_TESTS)

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,0 +1,49 @@
+#
+# Azure Pipelines configuration for building and testing commander.js on Linux, Windows, and macOS.
+#
+
+trigger:
+- master
+
+jobs:
+- job: Linux
+  pool:
+    vmImage: 'ubuntu-16.04'
+  strategy:
+    matrix:
+      Node6:
+        NODE_VERSION: '6.x'
+        NPM_INSTALL: true
+      Node8:
+        NODE_VERSION: '8.x'
+        NPM_INSTALL: true
+      Node10:
+        NODE_VERSION: '10.x'
+      Lint:
+        NODE_VERSION: '10.x'
+        LINT: true
+        SKIP_TESTS: true
+  steps:
+    - template: .azure-pipelines-steps.yml
+
+- job: Windows
+  pool:
+    vmImage: 'vs2017-win2016'
+  strategy:
+    matrix:
+      Node10:
+        NODE_VERSION: '10.x'
+  steps:
+    - script: git config --global core.symlinks true
+      displayName: 'Preserve symbolic links on check out'
+    - template: .azure-pipelines-steps.yml
+
+- job: Mac
+  pool:
+    vmImage: 'macOS-10.13'
+  strategy:
+    matrix:
+      Node10:
+        NODE_VERSION: '10.x'
+  steps:
+    - template: .azure-pipelines-steps.yml

--- a/Readme.md
+++ b/Readme.md
@@ -2,6 +2,7 @@
 
 
 [![Build Status](https://api.travis-ci.org/tj/commander.js.svg?branch=master)](http://travis-ci.org/tj/commander.js)
+[![Azure Pipelines Build Status](https://dev.azure.com/commanderjs/commander.js/_apis/build/status/commander.js-CI?branchName=master)](https://dev.azure.com/commanderjs/commander.js/_build/latest?definitionId=1&branchName=master)
 [![NPM Version](http://img.shields.io/npm/v/commander.svg?style=flat)](https://www.npmjs.org/package/commander)
 [![NPM Downloads](https://img.shields.io/npm/dm/commander.svg?style=flat)](https://npmcharts.com/compare/commander?minimal=true)
 [![Install Size](https://packagephobia.now.sh/badge?p=commander)](https://packagephobia.now.sh/result?p=commander)

--- a/Readme_zh-CN.md
+++ b/Readme_zh-CN.md
@@ -2,6 +2,7 @@
 
 
 [![Build Status](https://api.travis-ci.org/tj/commander.js.svg)](http://travis-ci.org/tj/commander.js)
+[![Azure Pipelines Build Status](https://dev.azure.com/commanderjs/commander.js/_apis/build/status/commander.js-CI?branchName=master)](https://dev.azure.com/commanderjs/commander.js/_build/latest?definitionId=1&branchName=master)
 [![NPM Version](http://img.shields.io/npm/v/commander.svg?style=flat)](https://www.npmjs.org/package/commander)
 [![NPM Downloads](https://img.shields.io/npm/dm/commander.svg?style=flat)](https://www.npmjs.org/package/commander)
 [![Join the chat at https://gitter.im/tj/commander.js](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/tj/commander.js?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)

--- a/test/run.js
+++ b/test/run.js
@@ -3,6 +3,7 @@
 const { spawnSync } = require('child_process')
 const { readdirSync } = require('fs')
 const { extname, join } = require('path')
+const { isSkipped } = require('./utils.js');
 
 process.env.NODE_ENV = 'test';
 
@@ -13,7 +14,11 @@ readdirSync(__dirname).forEach((file) => {
   process.stdout.write(`\x1b[90m   ${file}\x1b[0m `);
   const result = spawnSync(process.argv0, [ join('test', file) ]);
   if (result.status === 0) {
-    process.stdout.write('\x1b[36m✓\x1b[0m\n');
+    if (isSkipped(result.stdout)) {
+      process.stdout.write('\x1b[33mSKIPPED\x1b[0m\n');
+    } else {
+      process.stdout.write('\x1b[36m✓\x1b[0m\n');
+    }
   } else {
     process.stdout.write('\x1b[31m✖\x1b[0m\n');
     console.error(result.stderr.toString('utf8'));

--- a/test/test.command.executableSubcommand.js
+++ b/test/test.command.executableSubcommand.js
@@ -1,8 +1,7 @@
 var exec = require('child_process').exec
   , path = require('path')
-  , should = require('should');
-
-
+  , should = require('should')
+  , utils = require('./utils.js');
 
 var bin = 'node ' + path.join(__dirname, './fixtures/pm')
 // not exist
@@ -25,7 +24,12 @@ exec(bin + ' publish', function (error, stdout, stderr) {
 // spawn EACCES
 exec(bin + ' search', function (error, stdout, stderr) {
   // TODO error info are not the same in between <v0.10 and v0.12
-  should.notEqual(0, stderr.length);
+  // search command works on windows
+  if (utils.isWindows()) {
+    stdout.should.equal('search\n');
+  } else {
+    should.notEqual(0, stderr.length);
+  }
 });
 
 // when `bin` is a symbol link for mocking global install

--- a/test/test.command.executableSubcommand.js
+++ b/test/test.command.executableSubcommand.js
@@ -4,7 +4,7 @@ var exec = require('child_process').exec
 
 
 
-var bin = path.join(__dirname, './fixtures/pm')
+var bin = 'node ' + path.join(__dirname, './fixtures/pm')
 // not exist
 exec(bin + ' list', function (error, stdout, stderr) {
   //stderr.should.equal('\n  pm-list(1) does not exist, try --help\n\n');
@@ -29,7 +29,7 @@ exec(bin + ' search', function (error, stdout, stderr) {
 });
 
 // when `bin` is a symbol link for mocking global install
-var bin = path.join(__dirname, './fixtures/pmlink')
+var bin = 'node ' + path.join(__dirname, './fixtures/pmlink')
 // success case
 exec(bin + ' install', function (error, stdout, stderr) {
   stdout.should.equal('install\n');

--- a/test/test.command.executableSubcommand.signals.hup.js
+++ b/test/test.command.executableSubcommand.signals.hup.js
@@ -1,6 +1,13 @@
 var spawn = require('child_process').spawn,
   path = require('path'),
-  should = require('should');
+  should = require('should'),
+  utils = require('./utils.js');
+
+// Skip this test for Windows since signals are unsupported
+if (utils.isWindows()) {
+  utils.skip();
+  return;
+}
 
 var bin = path.join(__dirname, './fixtures/pm');
 var proc = spawn(bin, ['listen'], {});

--- a/test/test.command.executableSubcommand.signals.int.js
+++ b/test/test.command.executableSubcommand.signals.int.js
@@ -1,6 +1,13 @@
 var spawn = require('child_process').spawn,
   path = require('path'),
-  should = require('should');
+  should = require('should'),
+  utils = require('./utils.js');
+
+// Skip this test for Windows since signals are unsupported
+if (utils.isWindows()) {
+  utils.skip();
+  return;
+}
 
 var bin = path.join(__dirname, './fixtures/pm');
 var proc = spawn(bin, ['listen'], {});

--- a/test/test.command.executableSubcommand.signals.term.js
+++ b/test/test.command.executableSubcommand.signals.term.js
@@ -1,6 +1,13 @@
 var spawn = require('child_process').spawn,
   path = require('path'),
-  should = require('should');
+  should = require('should'),
+  utils = require('./utils.js');
+
+// Skip this test for Windows since signals are unsupported
+if (utils.isWindows()) {
+  utils.skip();
+  return;
+}
 
 var bin = path.join(__dirname, './fixtures/pm');
 var proc = spawn(bin, ['listen'], {});

--- a/test/test.command.executableSubcommand.signals.usr1.js
+++ b/test/test.command.executableSubcommand.signals.usr1.js
@@ -1,6 +1,13 @@
 var spawn = require('child_process').spawn,
   path = require('path'),
-  should = require('should');
+  should = require('should'),
+  utils = require('./utils.js');
+
+// Skip this test for Windows since signals are unsupported
+if (utils.isWindows()) {
+  utils.skip();
+  return;
+}
 
 var bin = path.join(__dirname, './fixtures/pm');
 var proc = spawn(bin, ['listen'], {});

--- a/test/test.command.executableSubcommand.signals.usr2.js
+++ b/test/test.command.executableSubcommand.signals.usr2.js
@@ -1,6 +1,13 @@
 var spawn = require('child_process').spawn,
   path = require('path'),
-  should = require('should');
+  should = require('should'),
+  utils = require('./utils.js');
+
+// Skip this test for Windows since signals are unsupported
+if (utils.isWindows()) {
+  utils.skip();
+  return;
+}
 
 var bin = path.join(__dirname, './fixtures/pm');
 var proc = spawn(bin, ['listen'], {});

--- a/test/test.command.executableSubcommandAlias.help.js
+++ b/test/test.command.executableSubcommandAlias.help.js
@@ -4,7 +4,7 @@ var exec = require('child_process').exec
 
 
 
-var bin = path.join(__dirname, './fixtures/pm')
+var bin = 'node ' + path.join(__dirname, './fixtures/pm')
 
 // success case
 exec(bin + ' help', function (error, stdout, stderr) {

--- a/test/test.command.executableSubcommandAlias.js
+++ b/test/test.command.executableSubcommandAlias.js
@@ -2,7 +2,7 @@ var exec = require('child_process').exec
   , path = require('path')
   , should = require('should');
 
-var bin = path.join(__dirname, './fixtures/pm')
+var bin = 'node ' + path.join(__dirname, './fixtures/pm')
 
 // success case
 exec(bin + ' i', function (error, stdout, stderr) {
@@ -21,7 +21,7 @@ exec(bin + ' s', function (error, stdout, stderr) {
 });
 
 // when `bin` is a symbol link for mocking global install
-var bin = path.join(__dirname, './fixtures/pmlink')
+var bin = 'node ' + path.join(__dirname, './fixtures/pmlink')
 // success case
 exec(bin + ' i', function (error, stdout, stderr) {
   stdout.should.equal('install\n');

--- a/test/test.command.executableSubcommandAlias.js
+++ b/test/test.command.executableSubcommandAlias.js
@@ -1,6 +1,7 @@
 var exec = require('child_process').exec
   , path = require('path')
-  , should = require('should');
+  , should = require('should')
+  , utils = require('./utils.js');
 
 var bin = 'node ' + path.join(__dirname, './fixtures/pm')
 
@@ -17,7 +18,12 @@ exec(bin + ' p', function (error, stdout, stderr) {
 // spawn EACCES
 exec(bin + ' s', function (error, stdout, stderr) {
   // error info are not the same in between <v0.10 and v0.12
-  should.notEqual(0, stderr.length);
+  // search command works on windows
+  if (utils.isWindows()) {
+    stdout.should.equal('search\n');
+  } else {
+    should.notEqual(0, stderr.length);
+  }
 });
 
 // when `bin` is a symbol link for mocking global install

--- a/test/test.command.executableSubcommandDefault.js
+++ b/test/test.command.executableSubcommandDefault.js
@@ -1,6 +1,7 @@
 var exec = require('child_process').exec
   , path = require('path')
-  , should = require('should');
+  , should = require('should')
+  , utils = require('./utils.js');
 
 
 
@@ -35,7 +36,12 @@ exec(bin + ' publish', function (error, stdout, stderr) {
 // spawn EACCES
 exec(bin + ' search', function (error, stdout, stderr) {
   // TODO error info are not the same in between <v0.10 and v0.12
-  should.notEqual(0, stderr.length);
+  // search command works on windows
+  if (utils.isWindows()) {
+    stdout.should.equal('search\n');
+  } else {
+    should.notEqual(0, stderr.length);
+  }
 });
 
 // when `bin` is a symbol link for mocking global install

--- a/test/test.command.executableSubcommandDefault.js
+++ b/test/test.command.executableSubcommandDefault.js
@@ -4,7 +4,7 @@ var exec = require('child_process').exec
 
 
 
-var bin = path.join(__dirname, './fixtures/pm')
+var bin = 'node ' + path.join(__dirname, './fixtures/pm')
 // success case
 exec(bin + ' default', function(error, stdout, stderr) {
   stdout.should.equal('default\n');
@@ -39,7 +39,7 @@ exec(bin + ' search', function (error, stdout, stderr) {
 });
 
 // when `bin` is a symbol link for mocking global install
-var bin = path.join(__dirname, './fixtures/pmlink')
+var bin = 'node ' + path.join(__dirname, './fixtures/pmlink')
 // success case
 exec(bin + ' install', function (error, stdout, stderr) {
   stdout.should.equal('install\n');

--- a/test/test.command.executableSubcommandSubCommand.js
+++ b/test/test.command.executableSubcommandSubCommand.js
@@ -10,7 +10,7 @@ var exec = require('child_process').exec
  * pm cache validate (default)
  */
 
-var bin = path.join(__dirname, './fixtures/pm')
+var bin = 'node ' + path.join(__dirname, './fixtures/pm')
 // should list commands at top-level sub command
 exec(bin + ' cache help', function (error, stdout, stderr) {
   stdout.should.containEql('Usage:');

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,14 @@
+
+const SKIPPED_MESSAGE = '**SKIPPED**';
+
+exports.isWindows = function() {
+    return process.platform == 'win32';
+}
+
+exports.skip = function() {
+    process.stdout.write(SKIPPED_MESSAGE);
+}
+
+exports.isSkipped = function(stdout) {
+    return stdout.indexOf(SKIPPED_MESSAGE) == 0;
+}


### PR DESCRIPTION
Azure Pipelines gives open source projects 10 build pipelines with unlimited minutes for Linux, Mac, and Windows.

This PR adds support to run CI on all three platforms and also makes changes so that the tests pass on Windows (fixes #635). I did have to special case some tests; for example, `search` works on Windows whereas the tests expect an `EACCES` error for Linux/Mac. Any pointers on preferred ways to make the tests Windows-friendly would be much appreciated!

I set up a commander.js pipeline [here](https://dev.azure.com/commanderjs/commander.js/_build/results?buildId=2). The builds seem to be slightly faster than on Travis. I'm happy to transfer ownership over if this is something you want to pursue. Here's a screenshot of the UI:
![image](https://user-images.githubusercontent.com/20052233/52803390-f73c8900-304f-11e9-9513-870629dd2f29.png)


Azure Pipelines also has rich test reporting which works well with commonly used test runners, including mocha and ava which are being considered in #649. Here's an [example from prettier](https://dev.azure.com/prettier/prettier/_build/results?buildId=545&view=ms.vss-test-web.build-test-results-tab):
![image](https://user-images.githubusercontent.com/20052233/52802943-efc8b000-304e-11e9-9e35-54f8bec02fa0.png)

Let me know if there are any questions or suggestions. I'm a Program Manager for Azure Pipelines and happy to help!