### PR TITLE
Remove --save option as it isn't required anymore

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -13,7 +13,7 @@
 
 ## Installation
 
-    $ npm install commander --save
+    $ npm install commander
 
 ## Option parsing
 


### PR DESCRIPTION
"As of npm 5.0.0, installed modules are added as a dependency by default, so the --save option is no longer needed. The other save options still exist and are listed in the documentation for npm install."

https://stackoverflow.com/a/19578808/142358