### PR TITLE
Add mjs file extension for git style subcommands

### DIFF
--- a/index.js
+++ b/index.js
@@ -544,6 +544,9 @@ Command.prototype.executeSubCommand = function(argv, args, unknown) {
   } else if (exists(localBin + '.ts')) {
     bin = localBin + '.ts';
     isExplicitJS = true;
+  } else if (exists(localBin + '.mjs')) {
+    bin = localBin + '.mjs';
+    isExplicitJS = true;
   } else if (exists(localBin)) {
     bin = localBin;
   }


### PR DESCRIPTION
Hi, 

I'm sending this PR to add support for `.mjs` files when executing git style subcommands. The explanation for this type of files can be found here: https://nodejs.org/api/esm.html

Following the Readme file, I've setup some code to run a basic cli program. I have changed the shebang in my files for the following, so I'm able to use JS modules in node:
`#!/usr/bin/env node --experimental-modules --no-warnings` .

This adds the ability to find `.mjs` as executable files, as well as the previous `.ts` and `.js`.

Please, let me know if something else is required. 

Thank you