### PR TITLE
Add editorconfig with existing style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+tab_width = 2
+# trim_trailing_whitespace = true


### PR DESCRIPTION
[EditorConfig](https://editorconfig.org) is a widely supported configuration file format for specifying a projects text editing preferences.

Adding this file makes it easier for collaborators and contributors to follow the existing text style conventions, if their editor of choice supports `.editorconfig`.

I hopefully made the default format what I saw in `index.js`, but could make it just `.js` files if preferred. I expect I'll suggest some additional settings for markdown when I start serious editing on the `README`, and we can add other file suffix for file types with different conventions.