### PR TITLE
Add check for help output callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -1138,7 +1138,11 @@ Command.prototype.outputHelp = function(cb) {
       return passthru;
     };
   }
-  process.stdout.write(cb(this.helpInformation()));
+  const cbOutput = cb(this.helpInformation());
+  if (!cbOutput) {
+    throw new Error('outputHelp callback must return a string or a Buffer');
+  }
+  process.stdout.write(cbOutput);
   this.emit('--help');
 };
 

--- a/index.js
+++ b/index.js
@@ -1139,7 +1139,7 @@ Command.prototype.outputHelp = function(cb) {
     };
   }
   const cbOutput = cb(this.helpInformation());
-  if (!cbOutput) {
+  if (typeof cbOutput !== 'string' && !Buffer.isBuffer(cbOutput)) {
     throw new Error('outputHelp callback must return a string or a Buffer');
   }
   process.stdout.write(cbOutput);


### PR DESCRIPTION
This improves the debugging for potential dev error if a callback is supplied to `outputHelp` that does not return anything. I omitted a `typeof` check because `typeof new Buffer([])` just returns `'object'` which doesn't help.

Else, here is the error which may be difficult to parse.
```
TypeError [ERR_INVALID_ARG_TYPE]: The "chunk" argument must be one of type string or Buffer. Received type undefined
    at validChunk (_stream_writable.js:263:10)
    at WriteStream.Writable.write (_stream_writable.js:297:21)
    at Command.outputHelp (/Users/redacted/Repos/redacted/node_modules/commander/index.js:1138:18)
    at Object.handleCLI (/Users/redacted/Repos/redacted/cli/CLI.js:21:13)
    at Object.<anonymous> (/Users/redacted/Repos/redacted/bin/www:3:23)
    at Module._compile (internal/modules/cjs/loader.js:734:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:745:10)
    at Module.load (internal/modules/cjs/loader.js:626:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:566:12)
    at Function.Module._load (internal/modules/cjs/loader.js:558:3)
Emitted 'error' event at:
    at errorOrDestroy (internal/streams/destroy.js:98:12)
    at validChunk (_stream_writable.js:266:5)
    at WriteStream.Writable.write (_stream_writable.js:297:21)
    [... lines matching original stack trace ...]
    at tryModuleLoad (internal/modules/cjs/loader.js:566:12)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! redacted-template@0.0.0 start: `node ./bin/www`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the redacted-template@0.0.0 start script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```