### PR TITLE
Add a way to override help and version help message

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -224,6 +224,12 @@ You may specify custom flags by passing an additional parameter to the `version`
 program.version('0.0.1', '-v, --version');
 ```
 
+You can also override the help description for the version command.
+
+```js
+program.version('0.0.1', '-v, --version', 'output the current version');
+```
+
 
 
 ## Command-specific options
@@ -431,6 +437,15 @@ if (!process.argv.slice(2).length) {
 function make_red(txt) {
   return colors.red(txt); //display the help text in red on the console
 }
+```
+
+## .help(str)
+
+  Override the default help description.
+
+```js
+program
+  .help('read more information');
 ```
 
 ## .help(cb)

--- a/Readme.md
+++ b/Readme.md
@@ -439,13 +439,13 @@ function make_red(txt) {
 }
 ```
 
-## .help(flags, description)
+## .helpOption(flags, description)
 
   Override the default help flags and description.
 
 ```js
 program
-  .help('-e, --HELP', 'read more information');
+  .helpOption('-e, --HELP', 'read more information');
 ```
 
 ## .help(cb)

--- a/Readme.md
+++ b/Readme.md
@@ -439,13 +439,13 @@ function make_red(txt) {
 }
 ```
 
-## .help(str)
+## .help(flags, description)
 
-  Override the default help description.
+  Override the default help flags and description.
 
 ```js
 program
-  .help('read more information');
+  .help('-e, --HELP', 'read more information');
 ```
 
 ## .help(cb)

--- a/examples/custom-help-description
+++ b/examples/custom-help-description
@@ -9,5 +9,13 @@ var program = require('../');
 program
   .help('-c, --HELP', 'custom help message')
   .option('-s, --sessions', 'add session support')
-  .option('-t, --template <engine>', 'specify template engine (jade|ejs) [jade]', 'jade')
-  .parse(process.argv);
+  .option('-t, --template <engine>', 'specify template engine (jade|ejs) [jade]', 'jade');
+
+program
+  .command('child')
+  .option('--gender', 'specific gender of child')
+  .action((cmd) => {
+    console.log('Childsubcommand...');
+  });
+
+program.parse(process.argv);

--- a/examples/custom-help-description
+++ b/examples/custom-help-description
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+
+/**
+ * Module dependencies.
+ */
+
+var program = require('../');
+
+program
+  .help('-c, --HELP', 'custom help message')
+  .option('-s, --sessions', 'add session support')
+  .option('-t, --template <engine>', 'specify template engine (jade|ejs) [jade]', 'jade')
+  .parse(process.argv);

--- a/examples/custom-help-description
+++ b/examples/custom-help-description
@@ -7,7 +7,7 @@
 var program = require('../');
 
 program
-  .help('-c, --HELP', 'custom help message')
+  .helpOption('-c, --HELP', 'custom help message')
   .option('-s, --sessions', 'add session support')
   .option('-t, --template <engine>', 'specify template engine (jade|ejs) [jade]', 'jade');
 

--- a/examples/custom-version
+++ b/examples/custom-version
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+
+/**
+ * Module dependencies.
+ */
+
+var program = require('../');
+
+program
+  .version('0.0.1', '-v, --VERSION', 'new version message')
+  .option('-s, --sessions', 'add session support')
+  .option('-t, --template <engine>', 'specify template engine (jade|ejs) [jade]', 'jade')
+  .parse(process.argv);

--- a/index.js
+++ b/index.js
@@ -187,6 +187,10 @@ Command.prototype.command = function(name, desc, opts) {
     if (opts.isDefault) this.defaultExecutable = cmd._name;
   }
   cmd._noHelp = !!opts.noHelp;
+  cmd._helpFlags = this._helpFlags;
+  cmd._helpDescription = this._helpDescription;
+  cmd._helpShortFlag = this._helpShortFlag;
+  cmd._helpLongFlag = this._helpLongFlag;
   this.commands.push(cmd);
   cmd.parseExpectedArgs(args);
   cmd.parent = this;
@@ -1137,7 +1141,10 @@ Command.prototype.helpInformation = function() {
 };
 
 /**
- * Output help information for this command
+ * Output help information for this command.
+ *
+ * When listener(s) are available for the helpLongFlag
+ * those callbacks are invoked.
  *
  * @api public
  */
@@ -1157,10 +1164,14 @@ Command.prototype.outputHelp = function(cb) {
 };
 
 /**
- * Output help information and exit.
+ * When called with no arguments, or with a callback, this will
+ * output help information and exit.
  *
- * @param {Function|String} cb
- * @param {String} description
+ * You can pass in flags and a description to override the help
+ * flags and help description for your command.
+ *
+ * @param {Function|String} [flagsOrCb]
+ * @param {String} [description]
  * @return {Command?}
  * @api public
  */
@@ -1175,7 +1186,9 @@ Command.prototype.help = function(flagsOrCb, description) {
   this._helpDescription = description || this._helpDescription;
 
   var flags = this._helpFlags.split(/[ ,|]+/);
-  if (flags.length > 1 && !/^[[<]/.test(flags[1])) this._helpShortFlag = flags.shift();
+
+  if (flags.length > 1) this._helpShortFlag = flags.shift();
+
   this._helpLongFlag = flags.shift();
 
   return this;

--- a/index.js
+++ b/index.js
@@ -852,11 +852,12 @@ Command.prototype.variadicArgNotLast = function(name) {
  * @api public
  */
 
-Command.prototype.version = function(str, flags) {
+Command.prototype.version = function(str, flags, description) {
   if (arguments.length === 0) return this._version;
   this._version = str;
   flags = flags || '-V, --version';
-  var versionOption = new Option(flags, 'output the version number');
+  description = description || 'output the version number';
+  var versionOption = new Option(flags, description);
   this._versionOptionName = versionOption.long.substr(2) || 'version';
   this.options.push(versionOption);
   this.on('option:' + this._versionOptionName, function() {
@@ -1043,12 +1044,13 @@ Command.prototype.padWidth = function() {
 
 Command.prototype.optionHelp = function() {
   var width = this.padWidth();
+  var description = this._helpDescription || 'output usage information';
 
   // Append the help information
   return this.options.map(function(option) {
     return pad(option.flags, width) + '  ' + option.description +
       ((option.bool && option.defaultValue !== undefined) ? ' (default: ' + JSON.stringify(option.defaultValue) + ')' : '');
-  }).concat([pad('-h, --help', width) + '  ' + 'output usage information'])
+  }).concat([pad('-h, --help', width) + '  ' + description])
     .join('\n');
 };
 
@@ -1151,10 +1153,17 @@ Command.prototype.outputHelp = function(cb) {
 /**
  * Output help information and exit.
  *
+ * @param {Function|String} cb
+ * @return {Command?}
  * @api public
  */
 
 Command.prototype.help = function(cb) {
+  if (typeof cb === 'string') {
+    this._helpDescription = cb;
+    return this;
+  }
+
   this.outputHelp(cb);
   process.exit();
 };

--- a/index.js
+++ b/index.js
@@ -1164,34 +1164,38 @@ Command.prototype.outputHelp = function(cb) {
 };
 
 /**
- * When called with no arguments, or with a callback, this will
- * output help information and exit.
- *
  * You can pass in flags and a description to override the help
  * flags and help description for your command.
  *
- * @param {Function|String} [flagsOrCb]
- * @param {String} [description]
- * @return {Command?}
+ * @param {String} flags
+ * @param {String} description
+ * @return {Command}
  * @api public
  */
 
-Command.prototype.help = function(flagsOrCb, description) {
-  if (typeof cb === 'function' || arguments.length === 0) {
-    this.outputHelp(flagsOrCb);
-    process.exit();
-  }
-
-  this._helpFlags = flagsOrCb || this._helpFlags;
+Command.prototype.helpOption = function(flags, description) {
+  this._helpFlags = flags || this._helpFlags;
   this._helpDescription = description || this._helpDescription;
 
-  var flags = this._helpFlags.split(/[ ,|]+/);
+  var splitFlags = this._helpFlags.split(/[ ,|]+/);
 
-  if (flags.length > 1) this._helpShortFlag = flags.shift();
+  if (splitFlags.length > 1) this._helpShortFlag = splitFlags.shift();
 
-  this._helpLongFlag = flags.shift();
+  this._helpLongFlag = splitFlags.shift();
 
   return this;
+};
+
+/**
+ * Output help information and exit.
+ *
+ * @param {Function} cb
+ * @api public
+ */
+
+Command.prototype.help = function(cb) {
+  this.outputHelp(cb);
+  process.exit();
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -1160,6 +1160,7 @@ Command.prototype.outputHelp = function(cb) {
  * Output help information and exit.
  *
  * @param {Function|String} cb
+ * @param {String} description
  * @return {Command?}
  * @api public
  */

--- a/index.js
+++ b/index.js
@@ -997,7 +997,7 @@ Command.prototype.largestCommandLength = function() {
 Command.prototype.largestOptionLength = function() {
   var options = [].slice.call(this.options);
   options.push({
-    flags: this._helpFlags,
+    flags: this._helpFlags
   });
 
   return options.reduce(function(max, option) {

--- a/test/test.command.helpInformation.custom.js
+++ b/test/test.command.helpInformation.custom.js
@@ -1,0 +1,21 @@
+var program = require('../')
+  , sinon = require('sinon').sandbox.create()
+  , should = require('should');
+
+program.help('custom help output');
+program.command('somecommand');
+program.command('anothercommand [options]');
+
+var expectedHelpInformation = [
+  'Usage:  [options] [command]',
+  '',
+  'Options:',
+  '  -h, --help                custom help output',
+  '',
+  'Commands:',
+  '  somecommand',
+  '  anothercommand [options]',
+  ''
+].join('\n');
+
+program.helpInformation().should.equal(expectedHelpInformation);

--- a/test/test.command.helpInformation.custom.js
+++ b/test/test.command.helpInformation.custom.js
@@ -5,7 +5,7 @@ var program = require('../')
 sinon.stub(process, 'exit');
 sinon.stub(process.stdout, 'write');
 
-program.help('-c, --HELP', 'custom help output');
+program.helpOption('-c, --HELP', 'custom help output');
 program.command('somecommand');
 program.command('anothercommand [options]');
 

--- a/test/test.command.helpInformation.custom.js
+++ b/test/test.command.helpInformation.custom.js
@@ -2,7 +2,10 @@ var program = require('../')
   , sinon = require('sinon').sandbox.create()
   , should = require('should');
 
-program.help('custom help output');
+sinon.stub(process, 'exit');
+sinon.stub(process.stdout, 'write');
+
+program.help('-c, --HELP', 'custom help output');
 program.command('somecommand');
 program.command('anothercommand [options]');
 
@@ -10,7 +13,7 @@ var expectedHelpInformation = [
   'Usage:  [options] [command]',
   '',
   'Options:',
-  '  -h, --help                custom help output',
+  '  -c, --HELP                custom help output',
   '',
   'Commands:',
   '  somecommand',
@@ -19,3 +22,25 @@ var expectedHelpInformation = [
 ].join('\n');
 
 program.helpInformation().should.equal(expectedHelpInformation);
+
+// Test arguments
+var expectedCommandHelpInformation = [
+  'Usage: test [options] [command]',
+  '',
+  'Options:',
+  '  -c, --HELP                custom help output',
+  '',
+  'Commands:',
+  '  somecommand',
+  '  anothercommand [options]',
+  ''
+].join('\n');
+
+program.parse(['node', 'test', '--HELP']);
+
+process.stdout.write.called.should.equal(true);
+
+var output = process.stdout.write.args[0];
+output[0].should.equal(expectedCommandHelpInformation);
+
+sinon.restore();

--- a/test/test.command.helpSubCommand.customFlags.js
+++ b/test/test.command.helpSubCommand.customFlags.js
@@ -1,0 +1,65 @@
+var program = require('../'),
+  sinon = require('sinon').sandbox.create(),
+  should = require('should');
+
+sinon.stub(process, 'exit');
+sinon.stub(process.stdout, 'write');
+
+// Test that subcommands inherit the help flags
+// but can also override help flags
+program
+  .help('-i, --ihelp', 'foo foo');
+
+program
+  .command('child')
+  .option('--gender', 'specific gender of child')
+  .action((cmd) => {
+    console.log('Childsubcommand...');
+  });
+
+program
+  .command('family')
+  .help('-h, --help')
+  .action((cmd) => {
+    console.log('Familysubcommand...');
+  });
+
+// Test arguments
+var expectedCommandHelpInformation = [
+  'Usage: child [options]',
+  '',
+  'Options:',
+  '  --gender     specific gender of child',
+  '  -i, --ihelp  foo foo',
+  ''
+].join('\n');
+
+program.parse(['node', 'test', 'child', '-i']);
+
+process.stdout.write.called.should.equal(true);
+
+var output = process.stdout.write.args[0];
+output[0].should.equal(expectedCommandHelpInformation);
+
+// Test other command
+sinon.restore();
+
+sinon.stub(process, 'exit');
+sinon.stub(process.stdout, 'write');
+
+var expectedFamilyCommandHelpInformation = [
+  'Usage: family [options]',
+  '',
+  'Options:',
+  '  -h, --help  foo foo',
+  ''
+].join('\n');
+
+program.parse(['node', 'test', 'family', '-h']);
+
+process.stdout.write.called.should.equal(true);
+
+var output2 = process.stdout.write.args[0];
+output2[0].should.equal(expectedFamilyCommandHelpInformation);
+
+sinon.restore();

--- a/test/test.command.helpSubCommand.customFlags.js
+++ b/test/test.command.helpSubCommand.customFlags.js
@@ -8,7 +8,7 @@ sinon.stub(process.stdout, 'write');
 // Test that subcommands inherit the help flags
 // but can also override help flags
 program
-  .help('-i, --ihelp', 'foo foo');
+  .helpOption('-i, --ihelp', 'foo foo');
 
 program
   .command('child')
@@ -19,7 +19,7 @@ program
 
 program
   .command('family')
-  .help('-h, --help')
+  .helpOption('-h, --help')
   .action((cmd) => {
     console.log('Familysubcommand...');
   });

--- a/test/test.options.version.customHelpDescription.js
+++ b/test/test.options.version.customHelpDescription.js
@@ -1,0 +1,22 @@
+var program = require('../')
+  , sinon = require('sinon').sandbox.create()
+  , should = require('should');
+
+program.version('1.0.0', undefined, 'custom version output');
+program.command('somecommand');
+program.command('anothercommand [options]');
+
+var expectedHelpInformation = [
+  'Usage:  [options] [command]',
+  '',
+  'Options:',
+  '  -V, --version             custom version output',
+  '  -h, --help                output usage information',
+  '',
+  'Commands:',
+  '  somecommand',
+  '  anothercommand [options]',
+  ''
+].join('\n');
+
+program.helpInformation().should.equal(expectedHelpInformation);

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -282,10 +282,18 @@ declare namespace local {
      * You can pass in flags and a description to override the help
      * flags and help description for your command.
      *
-     * @param {string | (str: string) => string} [flagsOrCb]
+     * @param {string} [flags]
+     * @param {string} [description]
+     * @return {Command}
+     */
+    helpOption(flags?: string, description?: string): Command;
+
+    /** Output help information and exit.
+     *
+     * @param {(str: string) => string} [cb]
      * @param {string} [description]
      */
-    help(flagsOrCb?: string | helpCallback, description?: string): never;
+    help(cb: helpCallback, description?: string): never;
   }
 
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -45,7 +45,7 @@ declare namespace local {
      * @param {string} [flags]
      * @returns {Command} for chaining
      */
-    version(str: string, flags?: string): Command;
+    version(str: string, flags?: string, description?: string): Command;
 
     /**
      * Add command `name`.
@@ -274,12 +274,15 @@ declare namespace local {
 
     /** Output help information and exit.
      *
-     * @param {(str: string) => string} [cb]
+     * @param {string | (str: string) => string} [flagsOrCb]
+     * @param {string} [description]
      */
-    help(cb?: (str: string) => string): never;
+    help(flagsOrCb?: string | callback, description?: string): never;
   }
 
 }
+
+type callback = (str: string) => string;
 
 declare namespace commander {
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -268,21 +268,29 @@ declare namespace local {
     /**
      * Output help information for this command.
      *
+     * When listener(s) are available for the helpLongFlag
+     * those callbacks are invoked.
+     * 
      * @param {(str: string) => string} [cb]
      */
     outputHelp(cb?: (str: string) => string): void;
 
-    /** Output help information and exit.
+    /**
+     * When called with no arguments, or with a callback, this will
+     * output help information and exit.
+     *
+     * You can pass in flags and a description to override the help
+     * flags and help description for your command.
      *
      * @param {string | (str: string) => string} [flagsOrCb]
      * @param {string} [description]
      */
-    help(flagsOrCb?: string | callback, description?: string): never;
+    help(flagsOrCb?: string | helpCallback, description?: string): never;
   }
 
 }
 
-type callback = (str: string) => string;
+type helpCallback = (str: string) => string;
 
 declare namespace commander {
 


### PR DESCRIPTION
Close #47.

Add override for the help message by calling program.help(message).

Add override for the version message by calling
program.version(version, flag, message);