### PR TITLE
complain about unknown options if there are >0 arguments on command line

### DIFF
--- a/index.js
+++ b/index.js
@@ -653,7 +653,7 @@ Command.prototype.parseArgs = function(args, unknown) {
     if (this.listeners('command:' + name).length) {
       this.emit('command:' + args.shift(), args, unknown);
     } else {
-      this.emit('command:*', args);
+      this.emit('command:*', args, unknown);
     }
   } else {
     outputHelpIfNecessary(this, unknown);

--- a/test/test.arguments.js
+++ b/test/test.arguments.js
@@ -7,6 +7,7 @@ var program = require('../')
 
 var envValue = "";
 var cmdValue = "";
+var optionsValue = {};
 
 program
   .version('0.0.1')
@@ -21,10 +22,11 @@ program
 
 program
   .command("setup [env]")
-  .option("--setup_mode <mode>")
-  .action(function (env) {
+  .option("--setup_mode <mode>", "the setup mode")
+  .action(function (env, options) {
     cmdValue = "setup";
     envValue = env;
+    optionsValue = options
   })
 
 program.parse(['node', 'test', '--config', 'conf']);
@@ -36,3 +38,4 @@ program.parse(['node', 'test', '--config', 'conf1', 'setup', '--setup_mode', 'mo
 program.config.should.equal("conf1");
 cmdValue.should.equal("setup");
 envValue.should.equal("env1");
+optionsValue.setup_mode.should.equal("mode3");

--- a/test/test.arguments.js
+++ b/test/test.arguments.js
@@ -19,6 +19,14 @@ program
   .option('-c, --config <path>', 'set config path. defaults to ./deploy.conf')
   .option('-T, --no-tests', 'ignore test hook');
 
+program
+  .command("setup [env]")
+  .option("--setup_mode <mode>")
+  .action(function (env) {
+    cmdValue = "setup";
+    envValue = env;
+  })
+
 program.parse(['node', 'test', '--config', 'conf']);
 program.config.should.equal("conf");
 cmdValue.should.equal("");


### PR DESCRIPTION
As per https://github.com/tj/commander.js/issues/921  this passes `unknown` to `command:*` listener and as a result, the default command will also complain about unknown options.  Before, it wouldn't.

The test in test.arguments.js needed to be adjusted since it would silently succeed even though an unknown option `--setup_mode` was passed and eaten.

