### PR TITLE
Add parent command as prefix of subcommand

### DIFF
--- a/index.js
+++ b/index.js
@@ -1116,11 +1116,12 @@ Command.prototype.helpInformation = function() {
   if (this._alias) {
     cmdName = cmdName + '|' + this._alias;
   }
-  var ancestor = this;
-  var prefix = [];
-  while ((ancestor = ancestor.parent)) prefix.push(ancestor.name() + ' ');
+  var parentCmdNames = '';
+  for (var parentCmd = this.parent; parentCmd; parentCmd = parentCmd.parent) {
+    parentCmdNames = parentCmd.name() + ' ' + parentCmdNames;
+  }
   var usage = [
-    'Usage: ' + prefix.join('') + cmdName + ' ' + this.usage(),
+    'Usage: ' + parentCmdNames + cmdName + ' ' + this.usage(),
     ''
   ];
 

--- a/test/test.command.usage.js
+++ b/test/test.command.usage.js
@@ -5,4 +5,4 @@ program
   .name('test')
   .command('info [options]')
 
-program.commands[0].helpInformation().should.startWith('\n  Usage: test info [options]')
+program.commands[0].helpInformation().should.startWith('Usage: test info [options]')


### PR DESCRIPTION
This is a minor rework of #740 to add parent commands into usage help for subcommands:

- updated to match current code style (lint)
- fix nested subcommand order, as noted by @simonbuchan

Resolves #739