### PR TITLE
Add helpInformation to typings

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -277,6 +277,13 @@ declare namespace local {
      * @param {(str: string) => string} [cb]
      */
     help(cb?: (str: string) => string): never;
+
+    /**
+     * Returns the help information text as a string.
+     * 
+     * @return {string}
+     */
+    helpInformation(): string;
   }
 
 }


### PR DESCRIPTION
Missing type for [Commander.prototype.helpInformation](https://github.com/tj/commander.js/blob/1c1ffca5d691ada5980ccfd81f42ecc006c0f62c/index.js#L1085-L1129):

https://github.com/tj/commander.js/blob/1c1ffca5d691ada5980ccfd81f42ecc006c0f62c/index.js#L1085-L1129