### PR TITLE
Adds before:command and before:option events

### DIFF
--- a/index.js
+++ b/index.js
@@ -653,8 +653,11 @@ Command.prototype.parseArgs = function(args, unknown) {
   if (args.length) {
     name = args[0];
     if (this.listeners('command:' + name).length) {
-      this.emit('command:' + args.shift(), args, unknown);
+      args.shift();
+      this.emit('before:command', name, args, unknown);
+      this.emit('command:' + name, args, unknown);
     } else {
+      this.emit('before:command', '*', args);
       this.emit('command:*', args);
     }
   } else {
@@ -667,6 +670,7 @@ Command.prototype.parseArgs = function(args, unknown) {
     }
     if (this.commands.length === 0 &&
         this._args.filter(function(a) { return a.required; }).length === 0) {
+      this.emit('before:command', '*');
       this.emit('command:*');
     }
   }
@@ -732,6 +736,7 @@ Command.prototype.parseOptions = function(argv) {
       if (option.required) {
         arg = argv[++i];
         if (arg == null) return this.optionMissingArgument(option);
+        this.emit('before:option', option.name(), arg);
         this.emit('option:' + option.name(), arg);
       // optional arg
       } else if (option.optional) {
@@ -741,9 +746,11 @@ Command.prototype.parseOptions = function(argv) {
         } else {
           ++i;
         }
+        this.emit('before:option', option.name(), arg);
         this.emit('option:' + option.name(), arg);
       // bool
       } else {
+        this.emit('before:option', option.name());
         this.emit('option:' + option.name());
       }
       continue;

--- a/test/test.events.js
+++ b/test/test.events.js
@@ -1,0 +1,126 @@
+var commander = require('../')
+  , should = require('should');
+
+var program = new commander.Command();
+
+program
+  .version('0.0.1')
+  .option('-T, --no-tests', 'ignore test hook')
+  .option('-c, --config <path>', 'set config path. defaults to ./deploy.conf');
+
+var eventsCaptured = [];
+
+function configureEvents(p, prefix) {
+  p.on('before:command', function() {
+    eventsCaptured.push([prefix, 'before:command', Array.prototype.slice.call(arguments)]);
+  });
+  p.on('before:option', function() {
+    eventsCaptured.push([prefix, 'before:option', Array.prototype.slice.call(arguments)]);
+  });
+  p.on('command:setup', function() {
+    eventsCaptured.push([prefix, 'command:setup', Array.prototype.slice.call(arguments)]);
+  });
+  p.on('command:exec', function() {
+    eventsCaptured.push([prefix, 'command:exec', Array.prototype.slice.call(arguments)]);
+  });
+  p.on('command:ex', function() {
+    eventsCaptured.push([prefix, 'command:ex', Array.prototype.slice.call(arguments)]);
+  });
+  p.on('command:*', function() {
+    eventsCaptured.push([prefix, 'command:*', Array.prototype.slice.call(arguments)]);
+  });
+  // Don't capture option config for initial tests.
+  p.on('option:host', function() {
+    eventsCaptured.push([prefix, 'option:host', Array.prototype.slice.call(arguments)]);
+  });
+  p.on('option:exec_mode', function() {
+    eventsCaptured.push([prefix, 'option:exec_mode', Array.prototype.slice.call(arguments)]);
+  });
+  p.on('option:no-tests', function() {
+    eventsCaptured.push([prefix, 'option:no-tests', Array.prototype.slice.call(arguments)]);
+  });
+}
+
+
+var setup = program
+  .command('setup [env]')
+  .option("-o, --host [host]", "Host to use")
+  .action(function (env, options) {
+  });
+
+var exec = program
+  .command('exec <cmd>')
+  .alias('ex')
+  .description('execute the given remote cmd')
+  .option("-e, --exec_mode <mode>", "Which exec mode to use")
+  .action(function (cmd, options) {
+  });
+
+var unknown = program
+  .command('*')
+  .action(function () {
+  });
+
+
+configureEvents(program, 'top');
+configureEvents(setup, 'setup');
+configureEvents(unknown, 'unknown');
+configureEvents(exec, 'exec');
+
+eventsCaptured = [];
+program.parse(['node', 'test', '--config', 'conf']);
+eventsCaptured.should.deepEqual([['top', 'before:option', ['config', 'conf']]]);
+
+eventsCaptured = [];
+program.parse(['node', 'test', '--config', 'conf', 'doesnotexist']);
+eventsCaptured.should.deepEqual([
+  ['top', 'before:option', ['config', 'conf']],
+  ['top', 'before:command', ['*', ['doesnotexist', unknown]]],
+  ['top', 'command:*', [['doesnotexist', unknown]]]
+]);
+
+eventsCaptured = [];
+program.parse(['node', 'test', '--config', 'conf1', 'setup', 'env1']);
+eventsCaptured.should.deepEqual([
+  ['top', 'before:option', ['config', 'conf1']],
+  ['top', 'before:command', ['setup', ['env1', setup], []]],
+  ['top', 'command:setup', [['env1', setup], []]]
+]);
+
+eventsCaptured = [];
+program.parse(['node', 'test', '--config', 'conf2', 'setup', '-o', 'host1', 'env2']);
+eventsCaptured.should.deepEqual([
+  ['top', 'before:option', ['config', 'conf2']],
+  ['top', 'before:command', ['setup', ['env2', setup], ['-o', 'host1']]],
+  ['setup', 'before:option', ['host', 'host1']],
+  ['setup', 'option:host', ['host1']],
+  ['top', 'command:setup', [['env2', setup], ['-o', 'host1']]]
+]);
+
+program.on('option:config', function() {
+  eventsCaptured.push(['top', 'option:config', Array.prototype.slice.call(arguments)]);
+})
+
+// Top level options always parsed before commands even when placed later.
+eventsCaptured = [];
+program.parse(['node', 'test', 'exec', '--config', 'conf4', '--exec_mode', 'mode1', 'exec1']);
+eventsCaptured.should.deepEqual([
+  ['top', 'before:option', ['config', 'conf4']],
+  ['top', 'option:config', ['conf4']],
+  ['top', 'before:command', ['exec', ['exec1', exec], ['--exec_mode', 'mode1']]],
+  ['exec', 'before:option', ['exec_mode', 'mode1']],
+  ['exec', 'option:exec_mode', ['mode1']],
+  ['top', 'command:exec', [['exec1', exec], ['--exec_mode', 'mode1']]]
+]);
+
+// Handle aliases.
+eventsCaptured = [];
+program.parse(['node', 'test', '--config', 'conf5', 'ex', '-e', 'mode2', 'exec2']);
+eventsCaptured.should.deepEqual([
+  ['top', 'before:option', ['config', 'conf5']],
+  ['top', 'option:config', ['conf5']],
+  ['top', 'before:command', ['ex', ['exec2', exec], ['-e', 'mode2']]],
+  ['exec', 'before:option', ['exec_mode', 'mode2']],
+  ['exec', 'option:exec_mode', ['mode2']],
+  ['top', 'command:ex', [['exec2', exec], ['-e', 'mode2']]]
+]);


### PR DESCRIPTION
These events are called with the name (or `*`) prepended to the
same arguments as the command:X and option:X events.

This allows you to run things after all top-level options are parsed, but before any commands are run.