### PR TITLE
fix showing help for sub commands with custom executableFile

### DIFF
--- a/index.js
+++ b/index.js
@@ -458,6 +458,14 @@ Command.prototype.parse = function(argv) {
 
   var result = this.parseArgs(this.args, parsed.unknown);
 
+  if (args[0] === 'help' && args.length === 1) this.help();
+
+  // <cmd> --help
+  if (args[0] === 'help') {
+    args[0] = args[1];
+    args[1] = this._helpLongFlag;
+  }
+
   // executable sub-commands
   // (Debugging note for future: args[0] is not right if an action has been called)
   var name = result.args[0];
@@ -511,13 +519,6 @@ Command.prototype.executeSubCommand = function(argv, args, unknown, executableFi
   args = args.concat(unknown);
 
   if (!args.length) this.help();
-  if (args[0] === 'help' && args.length === 1) this.help();
-
-  // <cmd> --help
-  if (args[0] === 'help') {
-    args[0] = args[1];
-    args[1] = this._helpLongFlag;
-  }
 
   var isExplicitJS = false; // Whether to use node to launch "executable"
 


### PR DESCRIPTION
## Problem
As of 3.0.0, the git-style executable sub commands can have `executableFile` option to customize the name of file containing the command.

But running `help` for these kind of sub commands will return error as the built-in `help` sub command will try to look executable files with default constructed name.

Example in old version:
```node
program
  .version('0.0.1')
  .command('specifyInstall', 'specify install subcommand', { executableFile: 'pm-install' })
```

```
$ ./pm help specifyInstall
error: pm-specifyInstall(1) does not exist, try --help
```

## Solution
Turns out, this is because when we run `help`, it will be treated as any user defined sub commands with special treatment of switching the arguments in the `executeSubCommand` function to make it as if we run our custom sub command using `--help` flag (see [here](https://github.com/tj/commander.js/blob/fea94a9feccdc234fead2d74c9bcdc72e598186d/index.js#L517)).

This is incorrect behaviour since the `executeSubCommand` will further assume the executable file name with default constructed name, as the resolving mechanism of the `executableFile` option is done at the `parse` function.

This PR fixes the problem by moving the "argument switching" mechanism to the `parse` function before the resolving mechanism is done, so the `executeSubCommand` will get correct executable file name.