### PR TITLE
Change CHANGELOG format for next release, and add pending changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * help for sub commands with custom executableFile ([#1018])
 
-[#1010]: https://github.com/tj/commander.js/pull/1010
-[#1018]: https://github.com/tj/commander.js/pull/1018
-
 3.0.0 / 2019-08-08
 =================
 
@@ -67,20 +64,6 @@ program
   .command('action1', undefined, { noHelp: true }) // No longer valid
   .command('action2', { noHelp: true }) // Correct
 ```
-
- [#599]: https://github.com/tj/commander.js/issues/599
- [#611]: https://github.com/tj/commander.js/issues/611
- [#697]: https://github.com/tj/commander.js/issues/697
- [#795]: https://github.com/tj/commander.js/issues/795
- [#915]: https://github.com/tj/commander.js/issues/915
- [#938]: https://github.com/tj/commander.js/issues/938
- [#963]: https://github.com/tj/commander.js/issues/963
- [#974]: https://github.com/tj/commander.js/issues/974
- [#980]: https://github.com/tj/commander.js/issues/980
- [#987]: https://github.com/tj/commander.js/issues/987
- [#990]: https://github.com/tj/commander.js/issues/990
- [#991]: https://github.com/tj/commander.js/issues/991
- [#999]: https://github.com/tj/commander.js/issues/999
 
 3.0.0-0 Prerelease / 2019-07-28
 ==============================
@@ -494,5 +477,21 @@ program
 ==================
 
   * Initial release
+
+[#599]: https://github.com/tj/commander.js/issues/599
+[#611]: https://github.com/tj/commander.js/issues/611
+[#697]: https://github.com/tj/commander.js/issues/697
+[#795]: https://github.com/tj/commander.js/issues/795
+[#915]: https://github.com/tj/commander.js/issues/915
+[#938]: https://github.com/tj/commander.js/issues/938
+[#963]: https://github.com/tj/commander.js/issues/963
+[#974]: https://github.com/tj/commander.js/issues/974
+[#980]: https://github.com/tj/commander.js/issues/980
+[#987]: https://github.com/tj/commander.js/issues/987
+[#990]: https://github.com/tj/commander.js/issues/990
+[#991]: https://github.com/tj/commander.js/issues/991
+[#999]: https://github.com/tj/commander.js/issues/999
+[#1010]: https://github.com/tj/commander.js/pull/1010
+[#1018]: https://github.com/tj/commander.js/pull/1018
 
 [Unreleased]: https://github.com/tj/commander.js/compare/master...develop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html). (Format adopted after v3.0.0.)
+
+## [Unreleased] (date goes here)
+
+### Added
+
+* Table of Contents to README ([#1010])
+* .name and .usage to README ([#1010])
+
+### Fixed
+
+* help for sub commands with custom executableFile ([#1018])
+
+[#1010]: https://github.com/tj/commander.js/pull/1010
+[#1018]: https://github.com/tj/commander.js/pull/1018
+
 3.0.0 / 2019-08-08
 =================
 
@@ -473,3 +494,5 @@ program
 ==================
 
   * Initial release
+
+[Unreleased]: https://github.com/tj/commander.js/compare/master...develop


### PR DESCRIPTION
We could adopt "Keep a Changelog" format for our CHANGELOG. 

This is what it looks like rendered:
https://github.com/shadowspawn/commander.js/blob/feature/keepachangelog/CHANGELOG.md

I only use "Unreleased" on the develop branch. When we are preparing the release before we merge to master, we put in the release version number and date. 

I put the date in brackets as it is the most common style used on GitHub.

I have added the links to make the Pull Requests clickable when viewing the CHANGELOG directly. It is a little tedious adding them, but does make the references more useful.

All the link definitions are at the bottom of the file so they are out of the way when reading the plain text.

The version numbers in the headings (and "Unreleased") are clickable links which do a compare in GitHub to see the changes from last release. Again, adding the URLs is a bit manual but it is an easy copy-and-edit after the first one.

Example of a section with a version number:

```
## [3.0.0] (2019-08-08)

[3.0.0]: https://github.com/tj/commander.js/compare/v2.20.0...v3.0.0
```

Rendered markdown:

## [3.0.0] (2019-08-08)

[3.0.0]: https://github.com/tj/commander.js/compare/v2.20.0...v3.0.0
