### PR TITLE
Unify readme code examples with 'const'

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -289,7 +289,7 @@ program
 You use `.arguments` to specify the arguments for the top-level command, and for subcommands they are included in the `.command` call. Angled brackets (e.g. `<required>`) indicate required input. Square brackets (e.g. `[optional]`) indicate optional input.
 
 ```js
-var program = require('commander');
+const program = require('commander');
 
 program
   .version('0.1.0')
@@ -313,7 +313,7 @@ console.log('environment:', envValue || "no environment given");
  append `...` to the argument name. For example:
 
 ```js
-var program = require('commander');
+const program = require('commander');
 
 program
   .version('0.1.0')
@@ -339,7 +339,7 @@ The action handler gets passed a parameter for each argument you declared, and o
 command object itself. This command argument has the values for the command-specific options added as properties.
 
 ```js
-var program = require('commander');
+const program = require('commander');
 
 program
   .command('rm <dir>')
@@ -365,7 +365,7 @@ You handle the options for an executable (sub)command in the executable, and don
 
 ```js
 // file: ./examples/pm
-var program = require('commander');
+const program = require('commander');
 
 program
   .version('0.1.0')
@@ -413,7 +413,7 @@ Options:
 ```js
 #!/usr/bin/env node
 
-var program = require('commander');
+const program = require('commander');
 
 program
   .version('0.1.0')
@@ -478,8 +478,8 @@ Optional callback cb allows post-processing of help text before it is displayed.
 If you want to display help by default (e.g. if no command was provided), you can use something like:
 
 ```js
-var program = require('commander');
-var colors = require('colors');
+const program = require('commander');
+const colors = require('colors');
 
 program
   .version('0.1.0')
@@ -557,7 +557,7 @@ the inspector port is incremented by 1 for the spawned subcommand.
 ## Examples
 
 ```js
-var program = require('commander');
+const program = require('commander');
 
 program
   .version('0.1.0')
@@ -570,7 +570,7 @@ program
   .description('run setup commands for all envs')
   .option("-s, --setup_mode [mode]", "Which setup mode to use")
   .action(function(env, options){
-    var mode = options.setup_mode || "normal";
+    const mode = options.setup_mode || "normal";
     env = env || 'all';
     console.log('setup for %s env(s) with %s mode', env, mode);
   });

--- a/Readme_zh-CN.md
+++ b/Readme_zh-CN.md
@@ -286,7 +286,7 @@ program
 你可以通过使用 `.arguments` 来为最顶级命令指定参数，对于子命令来说参数都包括在 `.command` 调用之中了。尖括号(e.g. `<required>`)意味着必须的输入，而方括号(e.g. `[optional]`)则是代表了可选的输入
 
 ```js
-var program = require('commander');
+const program = require('commander');
 
 program
   .version('0.1.0')
@@ -309,7 +309,7 @@ console.log('environment:', envValue || "no environment given");
 一个命令有且仅有最后一个参数是可变的，你需要在参数名后加上 `...` 来使它可变，例如
 
 ```js
-var program = require('commander');
+const program = require('commander');
 
 program
   .version('0.1.0')
@@ -334,7 +334,7 @@ program.parse(process.argv);
 操作处理程序会接收每一个你声明的参数的变量，和一个额外的参数——这个命令对象自己。这个命令的参数包括添加的命令特定选项的值。
 
 ```js
-var program = require('commander');
+const program = require('commander');
 
 program
   .command('rm <dir>')
@@ -361,7 +361,7 @@ Commander 将会尝试在入口脚本（例如 `./examples/pm`）的目录中搜
 
 ```js
 // file: ./examples/pm
-var program = require('commander');
+const program = require('commander');
 
 program
   .version('0.1.0')
@@ -405,7 +405,7 @@ Options:
 ```js
 #!/usr/bin/env node
 
-var program = require('commander');
+const program = require('commander');
 
 program
   .version('0.0.1')
@@ -468,8 +468,8 @@ Usage: my-command [global options] command
 如果你想显示默认的帮助（例如，如果没有提供命令），你可以使用类似的东西：
 
 ```js
-var program = require('commander');
-var colors = require('colors');
+const program = require('commander');
+const colors = require('colors');
 
 program
   .version('0.1.0')
@@ -548,7 +548,7 @@ node -r ts-node/register pm.ts
 ## 例子
 
 ```js
-var program = require('commander');
+const program = require('commander');
 
 program
   .version('0.1.0')
@@ -561,7 +561,7 @@ program
   .description('run setup commands for all envs')
   .option("-s, --setup_mode [mode]", "Which setup mode to use")
   .action(function(env, options){
-    var mode = options.setup_mode || "normal";
+    const mode = options.setup_mode || "normal";
     env = env || 'all';
     console.log('setup for %s env(s) with %s mode', env, mode);
   });


### PR DESCRIPTION
<!--
The text in these markdown comments is instructions that will not appear in the displayed pull request,
and can be deleted.

Please submit pull requests against the develop branch.

Follow the existing code style. Check the tests succeed, including lint.
  npm run test
  npm run lint

Don't update the CHANGELOG or command version number. That gets done by maintainers when preparing the release.

Commander currently has zero production dependencies. That isn't a hard requirement, but is a simple story. Requests which 
add a dependency are much less likely to be accepted, and we are likely to ask if there alternative approaches to avoid the dependency.
-->

## Problem

'var' and 'const' are mixed in Readme code example.

## Solution
* It is better to be unified.
* Recently, 'const' is often used.

## ChangeLog

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->
