### PR TITLE
Add definition for executableFile CommandOption

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -279,6 +279,7 @@ declare namespace commander {
     interface CommandOptions {
         noHelp?: boolean;
         isDefault?: boolean;
+        executableFile?: string;
     }
 
     interface ParseOptionsResult {


### PR DESCRIPTION
Add TypeScript definition for executableFile to CommandOptions

As noted by https://github.com/tj/commander.js/pull/999#issuecomment-523879411