### PR TITLE
WIP: Keep command out of program.args and add unknown to .action params

### DIFF
--- a/index.js
+++ b/index.js
@@ -279,16 +279,13 @@ Command.prototype.action = function(fn) {
       }
     });
 
-    // Always append ourselves to the end of the arguments,
-    // to make sure we match the number of arguments the user
-    // expects
-    if (self._args.length) {
-      args[self._args.length] = self;
-    } else {
-      args.push(self);
-    }
+    // The .action callback adds the command itself after the expected arguments.
+    var expectedArgsCount = self._args.length;
+    var actionArgs = args.slice(0, expectedArgsCount);
+    actionArgs[expectedArgsCount] = self;
+    actionArgs = actionArgs.concat(args.slice(expectedArgsCount)); // Unknown arguments beyond expected! Array, or individual, or ignore?
 
-    fn.apply(self, args);
+    fn.apply(self, actionArgs);
   };
   var parent = this.parent || this;
   var name = parent === this ? '*' : this._name;

--- a/index.js
+++ b/index.js
@@ -283,7 +283,8 @@ Command.prototype.action = function(fn) {
     var expectedArgsCount = self._args.length;
     var actionArgs = args.slice(0, expectedArgsCount);
     actionArgs[expectedArgsCount] = self;
-    actionArgs = actionArgs.concat(args.slice(expectedArgsCount)); // Unknown arguments beyond expected! Array, or individual, or ignore?
+    // Add the extra arguments too
+    actionArgs.push(args.slice(expectedArgsCount));
 
     fn.apply(self, actionArgs);
   };

--- a/test/test.variadic.args.js
+++ b/test/test.variadic.args.js
@@ -22,7 +22,7 @@ program.parse(programArgs);
 requiredArg.should.eql('arg0');
 variadicArg.should.eql(['arg1', 'arg2', 'arg3']);
 
-program.args.should.have.lengthOf(3);
+program.args.should.have.lengthOf(2);
 program.args[0].should.eql('arg0');
 program.args[1].should.eql(['arg1', 'arg2', 'arg3']);
 


### PR DESCRIPTION
# Pull Request

I have not written any new tests or updated docs yet. This is a draft PR to show current code. 

## Problem

There are problems with the processing of arguments to call `.action`:
- extra arguments are ignored and the first one is overwritten
- the passed array of arguments is mutated, but that ultimately affects program.args, including especially inappropriately adding the command object into that array
- the combination of issues makes it hard for client code to detect extra arguments

See: #386 #749 #1000 

```
var program = require('commander');

  program
    .option('-v, --verbose', 'Enable verbose output')
    .usage('[options] [command]')

  program
    .command('sub <something>')
    .action(function(oneArgument, cmd, extraArguments) {
      console.log(`Expected argument is: ${oneArgument}`);
      console.log('Extra arguments: ', extraArguments);
      console.log('program.args: ', program.args);
    });

program.parse(["node", "some-file.js", "-v", "sub", 1, 2, 3, 4, 5, 6, 7, 8, 9]);
```

```
$ node index.js 
Expected argument is: 1
Extra arguments:  3
program.args:  [ 1,
  Command {
    ... dump of command object!
  3,
  4,
  5,
  6,
  7,
  8,
  9 ]
```

## Solution

Changed code to prepare parameters for `.action` in a separate array without changing passed array. Pass unexpected parameters to `.action` as an array rather than just tagged on end.

```
$ node index.js 
Expected argument is: 1
Extra arguments:  [ 2, 3, 4, 5, 6, 7, 8, 9 ]
program.args:  [ 1, 2, 3, 4, 5, 6, 7, 8, 9 ]
```