### PR TITLE
Use dynamic references for LTS and current versions of node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
 - "8"
-- "10"
-- "12"
+- "lts/*"
+- "node"
 cache:
   directories:
     - "node_modules"


### PR DESCRIPTION
This is an optional change to test against the current and LTS versions of node, without needing to update the configurations when they change.

Inspired by a draft package maintenance suggestion here:
- https://github.com/nodejs/package-maintenance/pull/260/files#diff-b270f7bd39d3ce7c4e83355971b959a0

And the version-names are documented here:
- https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#specifying-nodejs-versions

(I am not a great fan of `node` or `lts/*` but they are the historical names used by `nvm` and what is current available in Travis. In the future we might get plain `lts` and `current` or `latest`, as they are being proposed by node and git action teams coming up with standard grammar for referring to node versions.)