### PR TITLE
Write help text to stderr instead of stdout

### DIFF
--- a/index.js
+++ b/index.js
@@ -880,7 +880,7 @@ Command.prototype.version = function(str, flags, description) {
   this._versionOptionName = versionOption.long.substr(2) || 'version';
   this.options.push(versionOption);
   this.on('option:' + this._versionOptionName, function() {
-    process.stdout.write(str + '\n');
+    process.stderr.write(str + '\n');
     process.exit(0);
   });
   return this;
@@ -1172,7 +1172,7 @@ Command.prototype.outputHelp = function(cb) {
   if (typeof cbOutput !== 'string' && !Buffer.isBuffer(cbOutput)) {
     throw new Error('outputHelp callback must return a string or a Buffer');
   }
-  process.stdout.write(cbOutput);
+  process.stderr.write(cbOutput);
   this.emit(this._helpLongFlag);
 };
 

--- a/index.js
+++ b/index.js
@@ -1162,7 +1162,7 @@ Command.prototype.helpInformation = function() {
  * @api public
  */
 
-Command.prototype.outputHelp = function(cb) {
+Command.prototype.outputHelp = function(cb, err = true) {
   if (!cb) {
     cb = function(passthru) {
       return passthru;
@@ -1172,7 +1172,11 @@ Command.prototype.outputHelp = function(cb) {
   if (typeof cbOutput !== 'string' && !Buffer.isBuffer(cbOutput)) {
     throw new Error('outputHelp callback must return a string or a Buffer');
   }
-  process.stderr.write(cbOutput);
+  if (err) {
+    process.stderr.write(cbOutput);
+  } else {
+    process.stdout.write(cbOutput);
+  }
   this.emit(this._helpLongFlag);
 };
 
@@ -1207,7 +1211,7 @@ Command.prototype.helpOption = function(flags, description) {
  */
 
 Command.prototype.help = function(cb) {
-  this.outputHelp(cb);
+  this.outputHelp(cb, false);
   process.exit();
 };
 
@@ -1252,7 +1256,7 @@ function outputHelpIfNecessary(cmd, options) {
 
   for (var i = 0; i < options.length; i++) {
     if (options[i] === cmd._helpLongFlag || options[i] === cmd._helpShortFlag) {
-      cmd.outputHelp();
+      cmd.outputHelp(null, false);
       process.exit(0);
     }
   }


### PR DESCRIPTION
# Pull Request

https://github.com/tj/commander.js/issues/997

## Problem

Informative functions were writing to stdout, causing problems in piping the output of the script.

## Solution

Changed writing stdout to stderr.

## ChangeLog

- Changed stdout to stderr for informative outputs.