### PR TITLE
Add .requiredOption() for mandatory options

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -245,7 +245,7 @@ $ custom --list x,y,z
 
 ### Required option
 
-You may specify a required (mandatory) option using `.requiredOption`, which must have a value after parsing. This is otherwise the same as `.option` in format, taking flags and description, and optional default value or custom processing.
+You may specify a required (mandatory) option using `.requiredOption`. The option must be specified on the command line, or by having a default value. The method is otherwise the same as `.option` in format, taking flags and description, and optional default value or custom processing.
 
 ```js
 const program = require('commander');

--- a/Readme.md
+++ b/Readme.md
@@ -15,6 +15,7 @@ The complete solution for [node.js](http://nodejs.org) command-line interfaces, 
     - [Default option value](#default-option-value)
     - [Other option types, negatable boolean and flag|value](#other-option-types-negatable-boolean-and-flagvalue)
     - [Custom option processing](#custom-option-processing)
+    - [Required option](#required-option)
     - [Version option](#version-option)
   - [Commands](#commands)
     - [Specify the argument syntax](#specify-the-argument-syntax)
@@ -240,6 +241,24 @@ $ custom -c a -c b -c c
 [ 'a', 'b', 'c' ]
 $ custom --list x,y,z
 [ 'x', 'y', 'z' ]
+```
+
+### Required option
+
+You may specify a required (mandatory) option using `.requiredOption`, which must have a value after parsing. This is otherwise the same as `.option` in format, taking flags and description, and optional default value or custom processing.
+
+```js
+const program = require('commander');
+
+program
+  .requiredOption('-c, --cheese <type>', 'pizza must have cheese');
+
+program.parse(process.argv);
+```
+
+```
+$ pizza
+error: required option '-c, --cheese <type>' not specified
 ```
 
 ### Version option

--- a/examples/options-mandatory.js
+++ b/examples/options-mandatory.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+// This is used as an example in the README for:
+//    Required option
+//    You may specify a required (mandatory) option using `.requiredOption`, which must have a value after parsing.
+//
+// Example output pretending command called pizza (or try directly with `node options-mandatory.js`)
+//
+// $ pizza
+// error: required option '-c, --cheese <type>' not specified
+
+const commander = require('..'); // For running direct from git clone of commander repo
+const program = new commander.Command();
+
+program
+  .requiredOption('-c, --cheese <type>', 'pizza must have cheese');
+
+program.parse(process.argv);

--- a/examples/options-required.js
+++ b/examples/options-required.js
@@ -2,9 +2,10 @@
 
 // This is used as an example in the README for:
 //    Required option
-//    You may specify a required (mandatory) option using `.requiredOption`, which must have a value after parsing.
+//    You may specify a required (mandatory) option using `.requiredOption`.
+//    The option must be specified on the command line, or by having a default value.
 //
-// Example output pretending command called pizza (or try directly with `node options-mandatory.js`)
+// Example output pretending command called pizza (or try directly with `node options-required.js`)
 //
 // $ pizza
 // error: required option '-c, --cheese <type>' not specified

--- a/index.js
+++ b/index.js
@@ -826,6 +826,21 @@ Command.prototype.optionFor = function(arg) {
 };
 
 /**
+ * Display an error message if a mandatory option does not have a value.
+ *
+ * @api private
+ */
+
+Command.prototype._checkForMissingMandatoryOptions = function() {
+  const self = this;
+  this.options.forEach((anOption) => {
+    if (anOption.mandatory && (self[anOption.name()] === undefined)) {
+      self.missingMandatoryOptionValue(anOption);
+    }
+  });
+};
+
+/**
  * Parse options from `argv` returning `argv`
  * void of these options.
  *
@@ -901,6 +916,8 @@ Command.prototype.parseOptions = function(argv) {
     args.push(arg);
   }
 
+  this._checkForMissingMandatoryOptions();
+
   return { args: args, unknown: unknownOptions };
 };
 
@@ -951,6 +968,19 @@ Command.prototype.optionMissingArgument = function(option, flag) {
   }
   console.error(message);
   this._exit(1, 'commander.optionMissingArgument', message);
+};
+
+/**
+ * `Option` does not have a value, and is a mandatory option.
+ *
+ * @param {String} option
+ * @api private
+ */
+
+Command.prototype.missingMandatoryOptionValue = function(option) {
+  const message = `error: required option '${option.flags}' not specified`;
+  console.error(message);
+  this._exit(1, 'commander.missingMandatoryOptionValue', message);
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -834,7 +834,7 @@ Command.prototype.optionFor = function(arg) {
 Command.prototype._checkForMissingMandatoryOptions = function() {
   const self = this;
   this.options.forEach((anOption) => {
-    if (anOption.mandatory && (self[anOption.name()] === undefined)) {
+    if (anOption.mandatory && (self[anOption.attributeName()] === undefined)) {
       self.missingMandatoryOptionValue(anOption);
     }
   });

--- a/tests/command.exitOverride.test.js
+++ b/tests/command.exitOverride.test.js
@@ -210,4 +210,21 @@ describe('.exitOverride and error details', () => {
 
     program.parse(['node', pm, 'does-not-exist']);
   });
+
+  test('when mandatory program option missing then throw CommanderError', () => {
+    const optionFlags = '-p, --pepper <type>';
+    const program = new commander.Command();
+    program
+      .exitOverride()
+      .requiredOption(optionFlags, 'add pepper');
+
+    let caughtErr;
+    try {
+      program.parse(['node', 'test']);
+    } catch (err) {
+      caughtErr = err;
+    }
+
+    expectCommanderError(caughtErr, 1, 'commander.missingMandatoryOptionValue', `error: required option '${optionFlags}' not specified`);
+  });
 });

--- a/tests/options.mandatory.test.js
+++ b/tests/options.mandatory.test.js
@@ -1,19 +1,30 @@
 const commander = require('../');
 
-// Assuming mandatory options behave as expected apart from the mandatory aspect, not retesting all permutations.
+// Assuming mandatory options behave as normal options apart from the mandatory aspect, not retesting all behaviour.
 
 describe('required program option with mandatory value specified', () => {
-  test('when program has required value specified then specified value', () => {
+  test('when program has required value specified then value as specified', () => {
     const program = new commander.Command();
     program
+      .exitOverride()
       .requiredOption('--cheese <type>', 'cheese type');
     program.parse(['node', 'test', '--cheese', 'blue']);
     expect(program.cheese).toBe('blue');
   });
 
+  test('when program has option with name different than property then still recognised', () => {
+    const program = new commander.Command();
+    program
+      .exitOverride()
+      .requiredOption('--cheese-type <type>', 'cheese type');
+    program.parse(['node', 'test', '--cheese-type', 'blue']);
+    expect(program.cheeseType).toBe('blue');
+  });
+
   test('when program has required value default then default value', () => {
     const program = new commander.Command();
     program
+      .exitOverride()
       .requiredOption('--cheese <type>', 'cheese type', 'default');
     program.parse(['node', 'test']);
     expect(program.cheese).toBe('default');
@@ -22,6 +33,7 @@ describe('required program option with mandatory value specified', () => {
   test('when program has optional value flag specified then true', () => {
     const program = new commander.Command();
     program
+      .exitOverride()
       .requiredOption('--cheese [type]', 'cheese type');
     program.parse(['node', 'test', '--cheese']);
     expect(program.cheese).toBe(true);
@@ -30,25 +42,38 @@ describe('required program option with mandatory value specified', () => {
   test('when program has optional value default then default value', () => {
     const program = new commander.Command();
     program
+      .exitOverride()
       .requiredOption('--cheese [type]', 'cheese type', 'default');
     program.parse(['node', 'test']);
     expect(program.cheese).toBe('default');
   });
 
-  test('when program has yes/no flag specified with value then specified value', () => {
+  test('when program has value/no flag specified with value then specified value', () => {
     const program = new commander.Command();
     program
+      .exitOverride()
       .requiredOption('--cheese <type>', 'cheese type')
-      .option('--no-cheese', 'no cheese thanks');
+      .requiredOption('--no-cheese', 'no cheese thanks');
     program.parse(['node', 'test', '--cheese', 'blue']);
     expect(program.cheese).toBe('blue');
   });
 
-  test('when program has yes/no flag specified with flag then true', () => {
+  test('when program has mandatory-yes/no flag specified with flag then true', () => {
     const program = new commander.Command();
     program
+      .exitOverride()
       .requiredOption('--cheese', 'cheese type')
       .option('--no-cheese', 'no cheese thanks');
+    program.parse(['node', 'test', '--cheese']);
+    expect(program.cheese).toBe(true);
+  });
+
+  test('when program has mandatory-yes/mandatory-no flag specified with flag then true', () => {
+    const program = new commander.Command();
+    program
+      .exitOverride()
+      .requiredOption('--cheese', 'cheese type')
+      .requiredOption('--no-cheese', 'no cheese thanks');
     program.parse(['node', 'test', '--cheese']);
     expect(program.cheese).toBe(true);
   });
@@ -56,6 +81,7 @@ describe('required program option with mandatory value specified', () => {
   test('when program has yes/no flag specified negated then false', () => {
     const program = new commander.Command();
     program
+      .exitOverride()
       .requiredOption('--cheese <type>', 'cheese type')
       .option('--no-cheese', 'no cheese thanks');
     program.parse(['node', 'test', '--no-cheese']);
@@ -65,6 +91,7 @@ describe('required program option with mandatory value specified', () => {
   test('when program has required value specified and subcommand then specified value', () => {
     const program = new commander.Command();
     program
+      .exitOverride()
       .requiredOption('--cheese <type>', 'cheese type')
       .command('sub')
       .action(() => {});
@@ -142,6 +169,7 @@ describe('required command option with mandatory value specified', () => {
     const program = new commander.Command();
     let cmdOptions;
     program
+      .exitOverride()
       .command('sub')
       .requiredOption('--subby <type>', 'description')
       .action((cmd) => {

--- a/tests/options.mandatory.test.js
+++ b/tests/options.mandatory.test.js
@@ -1,0 +1,198 @@
+const commander = require('../');
+
+// Assuming mandatory options behave as expected apart from the mandatory aspect, not retesting all permutations.
+
+describe('required program option with mandatory value specified', () => {
+  test('when program has required value specified then specified value', () => {
+    const program = new commander.Command();
+    program
+      .requiredOption('--cheese <type>', 'cheese type');
+    program.parse(['node', 'test', '--cheese', 'blue']);
+    expect(program.cheese).toBe('blue');
+  });
+
+  test('when program has required value default then default value', () => {
+    const program = new commander.Command();
+    program
+      .requiredOption('--cheese <type>', 'cheese type', 'default');
+    program.parse(['node', 'test']);
+    expect(program.cheese).toBe('default');
+  });
+
+  test('when program has optional value flag specified then true', () => {
+    const program = new commander.Command();
+    program
+      .requiredOption('--cheese [type]', 'cheese type');
+    program.parse(['node', 'test', '--cheese']);
+    expect(program.cheese).toBe(true);
+  });
+
+  test('when program has optional value default then default value', () => {
+    const program = new commander.Command();
+    program
+      .requiredOption('--cheese [type]', 'cheese type', 'default');
+    program.parse(['node', 'test']);
+    expect(program.cheese).toBe('default');
+  });
+
+  test('when program has yes/no flag specified with value then specified value', () => {
+    const program = new commander.Command();
+    program
+      .requiredOption('--cheese <type>', 'cheese type')
+      .option('--no-cheese', 'no cheese thanks');
+    program.parse(['node', 'test', '--cheese', 'blue']);
+    expect(program.cheese).toBe('blue');
+  });
+
+  test('when program has yes/no flag specified with flag then true', () => {
+    const program = new commander.Command();
+    program
+      .requiredOption('--cheese', 'cheese type')
+      .option('--no-cheese', 'no cheese thanks');
+    program.parse(['node', 'test', '--cheese']);
+    expect(program.cheese).toBe(true);
+  });
+
+  test('when program has yes/no flag specified negated then false', () => {
+    const program = new commander.Command();
+    program
+      .requiredOption('--cheese <type>', 'cheese type')
+      .option('--no-cheese', 'no cheese thanks');
+    program.parse(['node', 'test', '--no-cheese']);
+    expect(program.cheese).toBe(false);
+  });
+
+  test('when program has required value specified and subcommand then specified value', () => {
+    const program = new commander.Command();
+    program
+      .requiredOption('--cheese <type>', 'cheese type')
+      .command('sub')
+      .action(() => {});
+    program.parse(['node', 'test', '--cheese', 'blue', 'sub']);
+    expect(program.cheese).toBe('blue');
+  });
+});
+
+describe('required program option with mandatory value not specified', () => {
+  // Optional. Use internal knowledge to suppress output to keep test output clean.
+  let consoleErrorSpy;
+
+  beforeAll(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => { });
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockClear();
+  });
+
+  afterAll(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  test('when program has required option not specified then error', () => {
+    const program = new commander.Command();
+    program
+      .exitOverride()
+      .requiredOption('--cheese <type>', 'cheese type');
+
+    expect(() => {
+      program.parse(['node', 'test']);
+    }).toThrow();
+  });
+
+  test('when program has optional option not specified then error', () => {
+    const program = new commander.Command();
+    program
+      .exitOverride()
+      .requiredOption('--cheese [type]', 'cheese type');
+
+    expect(() => {
+      program.parse(['node', 'test']);
+    }).toThrow();
+  });
+
+  test('when program has yes/no not specified then error', () => {
+    const program = new commander.Command();
+    program
+      .exitOverride()
+      .requiredOption('--cheese', 'cheese type')
+      .option('--no-cheese', 'no cheese thanks');
+
+    expect(() => {
+      program.parse(['node', 'test']);
+    }).toThrow();
+  });
+
+  test('when program has required value not specified and subcommand then error', () => {
+    const program = new commander.Command();
+    program
+      .exitOverride()
+      .requiredOption('--cheese <type>', 'cheese type')
+      .command('sub')
+      .action(() => {});
+
+    expect(() => {
+      program.parse(['node', 'test', 'sub']);
+    }).toThrow();
+  });
+});
+
+describe('required command option with mandatory value specified', () => {
+  test('when command has required value specified then specified value', () => {
+    const program = new commander.Command();
+    let cmdOptions;
+    program
+      .command('sub')
+      .requiredOption('--subby <type>', 'description')
+      .action((cmd) => {
+        cmdOptions = cmd;
+      });
+
+    program.parse(['node', 'test', 'sub', '--subby', 'blue']);
+
+    expect(cmdOptions.subby).toBe('blue');
+  });
+});
+
+describe('required command option with mandatory value not specified', () => {
+  // Optional. Use internal knowledge to suppress output to keep test output clean.
+  let consoleErrorSpy;
+
+  beforeAll(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => { });
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockClear();
+  });
+
+  afterAll(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  test('when command has required value not specified then eror', () => {
+    const program = new commander.Command();
+    program
+      .exitOverride()
+      .command('sub')
+      .requiredOption('--subby <type>', 'description')
+      .action((cmd) => {});
+
+    expect(() => {
+      program.parse(['node', 'test', 'sub']);
+    }).toThrow();
+  });
+
+  test('when command has required value but not called then no error', () => {
+    const program = new commander.Command();
+    program
+      .exitOverride()
+      .command('sub')
+      .requiredOption('--subby <type>', 'description')
+      .action((cmd) => {});
+
+    expect(() => {
+      program.parse(['node', 'test']);
+    }).not.toThrow();
+  });
+});

--- a/typings/commander-tests.ts
+++ b/typings/commander-tests.ts
@@ -90,6 +90,16 @@ program
     });
 
 program
+  .requiredOption('-a,--aaa', 'description')
+  .requiredOption('-b,--bbb <value>', 'description')
+  .requiredOption('-c,--ccc [value]', 'description')
+  .requiredOption('-d,--ddd <value>', 'description', 'default value')
+  .requiredOption('-e,--eee <value>', 'description', (value, memo) => { return value; })
+  .requiredOption('-f,--fff <value>', 'description', (value, memo) => { return value; }, 'starting value')
+  .requiredOption('-g,--ggg <value>', 'description')
+  .requiredOption('-G,--no-ggg <value>', 'description for negation');
+
+program
     .version('0.0.1')
     .arguments('<cmd> [env]')
     .action((cmd, env) => {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -18,8 +18,9 @@ declare namespace local {
 
   class Option {
     flags: string;
-    required: boolean;
-    optional: boolean;
+    required: boolean; // A value must be supplied when the option is specified.
+    optional: boolean; // A value is optional when the option is specified.
+    mandatory: boolean; // The option must have a value after parsing, which usually means it must be specified on command line.
     bool: boolean;
     short?: string;
     long: string;
@@ -185,6 +186,15 @@ declare namespace local {
      */
     option(flags: string, description?: string, fn?: ((arg1: any, arg2: any) => void) | RegExp, defaultValue?: any): Command;
     option(flags: string, description?: string, defaultValue?: any): Command;
+
+    /**
+     * Define a required option, which must have a value after parsing. This usually means
+     * the option must be specified on the command line. (Otherwise the same as .option().)
+     *
+     * The `flags` string should contain both the short and long flags, separated by comma, a pipe or space.
+     */
+    requiredOption(flags: string, description?: string, fn?: ((arg1: any, arg2: any) => void) | RegExp, defaultValue?: any): Command;
+    requiredOption(flags: string, description?: string, defaultValue?: any): Command;
 
     /**
      * Allow unknown options on the command line.


### PR DESCRIPTION
# Pull Request

## Problem

Some programs have options which are mandatory. This usually means they must be specified on the command line. This is not directly supported by Commander, and is a popular request. (It is often confused with options which have a required value when the option is specified.)

Issues: #230 #1038

## Solution

The most popular form for the API (#1038) is to add a method called `.requiredOption()`. For simplicity it is has the same signature as `.option()` and supports all the same parameters.

(This new functionality is in addition to the existing support for options with a required value when the option is specified, like `'-f,--foo <requiredValue>'`.)

Commander will check that each mandatory option has a value after parsing, and display an error if the option value has not been supplied. Requiring a value rather than requiring the option on the command line allows use of environment variables to optionally supply default values.