### PR TITLE
Explicitly require node 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
     "ts-node": "^8.4.1",
     "typescript": "^3.6.3"
   },
-  "typings": "typings/index.d.ts"
+  "typings": "typings/index.d.ts",
+  "engines": {
+    "node": ">= 6"
+  }
 }


### PR DESCRIPTION
# Pull Request

Related issue is #1045. 

## Problem

I was already suggested we only officially support from node 8, but concerned that people might be broken when we started using new features in later versions of Commander 4.x unless we enforced it from the start. However, it is relevant straight away! I used `class` for addition of `CommanderError` which requires node 6.

## Solution

Specify that node 6 is required in `engines` field of `package.json` so user should hopefully get a warning when install if using an older versions of node. (There were bugs in some versions of npm which meant the warning is not displayed, fixed in npm 6.12.0 and higher.)