### PR TITLE
Add translation links in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,6 +7,8 @@
 
 The complete solution for [node.js](http://nodejs.org) command-line interfaces, inspired by Ruby's [commander](https://github.com/commander-rb/commander).
 
+Read this in other languages: English | [简体中文](./Readme_zh-CN.md)
+
 - [Commander.js](#commanderjs)
   - [Installation](#installation)
   - [Declaring _program_ variable](#declaring-program-variable)

--- a/Readme_zh-CN.md
+++ b/Readme_zh-CN.md
@@ -7,6 +7,8 @@
 
 [node.js](http://nodejs.org) 命令行接口的完整解决方案，灵感来自 Ruby 的 [commander](https://github.com/commander-rb/commander)。
 
+用其他语言阅读 [English](./Readme.md) | 简体中文
+
 - [Commander.js](#commanderjs)
   - [安装](#%e5%ae%89%e8%a3%85)
   - [声明program变量](#%e5%a3%b0%e6%98%8eprogram%e5%8f%98%e9%87%8f)

--- a/Readme_zh-CN.md
+++ b/Readme_zh-CN.md
@@ -7,7 +7,7 @@
 
 [node.js](http://nodejs.org) 命令行接口的完整解决方案，灵感来自 Ruby 的 [commander](https://github.com/commander-rb/commander)。
 
-用其他语言阅读 [English](./Readme.md) | 简体中文
+用其他语言阅读：[English](./Readme.md) | 简体中文
 
 - [Commander.js](#commanderjs)
   - [安装](#%e5%ae%89%e8%a3%85)


### PR DESCRIPTION
As suggested by @oGsLP, add translation links at top of README.

I combined ideas from these two sites:
- https://github.com/tiimgreen/github-cheat-sheet/blob/master/README.md
- https://github.com/alvarotrigo/fullPage.js#fullpagejs

I used Google Translate for the leader text (用其他语言阅读), but the site I was copying had different text (其他语言版本), and feel free to suggest something different.
