### PR TITLE
Display help despite missing required option

### DIFF
--- a/tests/options.mandatory.test.js
+++ b/tests/options.mandatory.test.js
@@ -1,6 +1,7 @@
 const commander = require('../');
 
 // Assuming mandatory options behave as normal options apart from the mandatory aspect, not retesting all behaviour.
+// Likewise, not redoing all tests on subcommand after testing on program.
 
 describe('required program option with mandatory value specified', () => {
   test('when program has required value specified then value as specified', () => {
@@ -222,5 +223,56 @@ describe('required command option with mandatory value not specified', () => {
     expect(() => {
       program.parse(['node', 'test']);
     }).not.toThrow();
+  });
+});
+
+describe('missing mandatory option but help requested', () => {
+  // Optional. Use internal knowledge to suppress output to keep test output clean.
+  let writeSpy;
+
+  beforeAll(() => {
+    writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => { });
+  });
+
+  afterEach(() => {
+    writeSpy.mockClear();
+  });
+
+  afterAll(() => {
+    writeSpy.mockRestore();
+  });
+
+  test('when program has required option not specified and --help then help', () => {
+    const program = new commander.Command();
+    program
+      .exitOverride()
+      .requiredOption('--cheese <type>', 'cheese type');
+
+    let caughtErr;
+    try {
+      program.parse(['node', 'test', '--help']);
+    } catch (err) {
+      caughtErr = err;
+    }
+
+    expect(caughtErr.code).toEqual('commander.helpDisplayed');
+  });
+
+  test('when program has required option not specified and subcommand --help then help', () => {
+    const program = new commander.Command();
+    program
+      .exitOverride()
+      .requiredOption('--cheese <type>', 'cheese type')
+      .command('sub')
+      .action(() => {});
+
+    let caughtErr;
+    try {
+      program.parse(['node', 'test', 'sub', '--help']);
+    } catch (err) {
+      caughtErr = err;
+    }
+
+    expect(caughtErr.code).toEqual('commander.helpDisplayed');
   });
 });


### PR DESCRIPTION
# Pull Request

Fixes #1089 #1092

## Problem

When ask for help but there is a missing required option, getting error instead of help, so can't find out more.

e.g.
```
$ node test.js -h
error: required option '-s, --small' not specified
```

## Solution

Check for missing required options after checking for displaying help. This fix covers help for commands with action handlers, and help on the main program.

(It does not cover program with a required option and calling help on an executable subcommand, which seems an unlikely case. Deal with it if and when it comes up.)