### PR TITLE
Remove trailing blanks from wrapped help text

### DIFF
--- a/index.js
+++ b/index.js
@@ -1429,7 +1429,7 @@ function wrap(str, width, indent) {
     if (line.slice(-1) === '\n') {
       line = line.slice(0, line.length - 1);
     }
-    return ((i > 0 && indent) ? Array(indent + 1).join(' ') : '') + line;
+    return ((i > 0 && indent) ? Array(indent + 1).join(' ') : '') + line.trimRight();
   }).join('\n');
 }
 

--- a/tests/helpwrap.test.js
+++ b/tests/helpwrap.test.js
@@ -13,8 +13,8 @@ test('when long option description then wrap and indent', () => {
 `Usage:  [options]
 
 Options:
-  -x -extra-long-option-switch  kjsahdkajshkahd kajhsd akhds kashd kajhs dkha 
-                                dkh aksd ka dkha kdh kasd ka kahs dkh sdkh 
+  -x -extra-long-option-switch  kjsahdkajshkahd kajhsd akhds kashd kajhs dkha
+                                dkh aksd ka dkha kdh kasd ka kahs dkh sdkh
                                 askdh aksd kashdk ahsd kahs dkha skdh
   -h, --help                    output usage information
 `;
@@ -34,7 +34,7 @@ test('when long option description and default then wrap and indent', () => {
 `Usage:  [options]
 
 Options:
-  -x -extra-long-option <value>  kjsahdkajshkahd kajhsd akhds (default: "aaa 
+  -x -extra-long-option <value>  kjsahdkajshkahd kajhsd akhds (default: "aaa
                                  bbb ccc ddd eee fff ggg")
   -h, --help                     output usage information
 `;
@@ -59,7 +59,7 @@ Options:
   -h, --help                    output usage information
 
 Commands:
-  alpha                         Lorem mollit quis dolor ex do eu quis ad insa 
+  alpha                         Lorem mollit quis dolor ex do eu quis ad insa
                                 a commodo esse.
 `;
 


### PR DESCRIPTION
# Pull Request

## Problem

Auto-wrapped lines in the generated help text have an extra space character at the end. This leads to unwanted empty lines in the help text display at the console, when a resulting line is exactly 80 characters long.

The trailing space characters can be seen in the changes of this PR for tests/helpwrap.test.js.

## Solution

A trimRight() is added in wrap().