### PR TITLE
Extend timeout to hopefully reduce test failures

### DIFF
--- a/tests/command.executableSubcommand.lookup.test.js
+++ b/tests/command.executableSubcommand.lookup.test.js
@@ -89,6 +89,7 @@ testOrSkipOnWindows('when subcommand file is double symlink then lookup succeeds
 });
 
 test('when subcommand suffix is .ts then lookup succeeds', (done) => {
+  jest.setTimeout(20000); // Extend timeout for GitHub Actions
   const binLinkTs = path.join(__dirname, 'fixtures-ts', 'pm.ts');
   childProcess.execFile('node', ['-r', 'ts-node/register', binLinkTs, 'install'], function(_error, stdout, stderr) {
     expect(stdout).toBe('install\n');


### PR DESCRIPTION
The ts-node test has been unreliable and failing timeouts. Try extending timeout to see if fixes the problem.

- https://github.com/tj/commander.js/pull/1102#issuecomment-557740445
- https://github.com/tj/commander.js/pull/1095#issuecomment-552376208