### PR TITLE
Reword supported node versions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -648,7 +648,8 @@ More Demos can be found in the [examples](https://github.com/tj/commander.js/tre
 
 ## Support
 
-Commander is supported on Node 8 and above. (Commander is likely to still work on older versions of Node, but is not tested below Node 8.)
+Commander 4.x is supported on Node 8 and above, and is likely to work with Node 6 but not tested.
+(For versions of Node below Node 6, use Commander 3.x or 2.x.)
 
 The main forum for free and community support is the project [Issues](https://github.com/tj/commander.js/issues) on GitHub.
 


### PR DESCRIPTION
Reword supported Node versions so people using older versions have better idea which version of Commander to pick.