### PR TITLE
Change to six months support, rather than n-1

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,11 +2,14 @@
 
 ## Supported Versions
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 4.x     | :white_check_mark: |
-| 3.x     | :white_check_mark: |
-| < 3     | :x:                |
+Old versions receive security updates for six months.
+
+| Version | Supported                                  |
+| ------- | ------------------------------------------ |
+| 4.x     | :white_check_mark:                         |
+| 3.x     | :white_check_mark: support ends 2020-05-01 |
+| 2.x     | :white_check_mark: support ends 2020-02-03 |
+| < 2     | :x:                                        |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
# Pull Request

## Problem

I had said we should support the current major version and the previous major version. But I realise now that does not work very well when we have close major releases, like we did with v3 and v4 to clear the backlog of Pull Requests.

## Solution

I suggest instead we support old versions from six months from when the new version is released. Then if we release new major versions fast then users of older versions still get time to upgrade, and if it is a long time between major releases we do not support the old version indefinitely.