### PR TITLE
WIP: Add support for nested commands (without executables)

### DIFF
--- a/index.js
+++ b/index.js
@@ -199,6 +199,18 @@ Command.prototype.command = function(nameAndArgs, actionOptsOrExecDesc, execOpts
 };
 
 /**
+ * @api public
+ */
+Command.prototype.addCommand = function(cmd) {
+  if (!cmd._name) throw Error('addCommand name is not specified for command');
+
+  this.commands.push(cmd);
+  cmd.parent = this;
+  cmd._addCommandListener();
+  return this;
+};
+
+/**
  * Define argument syntax for the top-level command.
  *
  * @api public

--- a/index.js
+++ b/index.js
@@ -914,8 +914,10 @@ Command.prototype.parseArgs = function(args, unknown) {
     if (this.listeners('command:' + name).length) {
       this.emit('command:' + args.shift(), args, unknown);
     } else {
-      this.emit('program-command', args, unknown);
       this.emit('command:*', args, unknown);
+      if (!this.parent) {
+        this.emit('program-command', args, unknown);
+      }
     }
   } else {
     outputHelpIfNecessary(this, unknown);
@@ -925,7 +927,7 @@ Command.prototype.parseArgs = function(args, unknown) {
       this.unknownOption(unknown[0]);
     }
     // Call the program action handler, unless it has a (missing) required parameter and signature does not match.
-    if (this._args.filter(function(a) { return a.required; }).length === 0) {
+    if (!this.parent && this._args.filter(function(a) { return a.required; }).length === 0) {
       this.emit('program-command');
     }
   }


### PR DESCRIPTION
# Pull Request

## Problem

Commander does not support nested commands (without using git-style executables).

Issue: #1 #63 #655 #764 
Related PR: #245 #1024 

## Solution

Rework command dispatching to allow chaining subcommands, and add routine to add a previously defined Command (particularly for adding commands defined in other modules).

This is as an experiment inspired by the recent work in #1024 and older work in #245.