### PR TITLE
Refactor Option from prototype to class

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,66 +27,68 @@ exports = module.exports = new Command();
 
 exports.Command = Command;
 
+class Option {
+  /**
+   * Initialize a new `Option` with the given `flags` and `description`.
+   *
+   * @param {String} flags
+   * @param {String} description
+   * @api public
+   */
+
+  constructor(flags, description) {
+    this.flags = flags;
+    this.required = flags.indexOf('<') >= 0; // A value must be supplied when the option is specified.
+    this.optional = flags.indexOf('[') >= 0; // A value is optional when the option is specified.
+    this.mandatory = false; // The option must have a value after parsing, which usually means it must be specified on command line.
+    this.negate = flags.indexOf('-no-') !== -1;
+    flags = flags.split(/[ ,|]+/);
+    if (flags.length > 1 && !/^[[<]/.test(flags[1])) this.short = flags.shift();
+    this.long = flags.shift();
+    this.description = description || '';
+  }
+
+  /**
+   * Return option name.
+   *
+   * @return {String}
+   * @api private
+   */
+
+  name() {
+    return this.long.replace(/^--/, '');
+  };
+
+  /**
+   * Return option name, in a camelcase format that can be used
+   * as a object attribute key.
+   *
+   * @return {String}
+   * @api private
+   */
+
+  attributeName() {
+    return camelcase(this.name().replace(/^no-/, ''));
+  };
+
+  /**
+   * Check if `arg` matches the short or long flag.
+   *
+   * @param {String} arg
+   * @return {Boolean}
+   * @api private
+   */
+
+  is(arg) {
+    return this.short === arg || this.long === arg;
+  };
+}
+
 /**
  * Expose `Option`.
  */
 
 exports.Option = Option;
-
-/**
- * Initialize a new `Option` with the given `flags` and `description`.
- *
- * @param {String} flags
- * @param {String} description
- * @api public
- */
-
-function Option(flags, description) {
-  this.flags = flags;
-  this.required = flags.indexOf('<') >= 0; // A value must be supplied when the option is specified.
-  this.optional = flags.indexOf('[') >= 0; // A value is optional when the option is specified.
-  this.mandatory = false; // The option must have a value after parsing, which usually means it must be specified on command line.
-  this.negate = flags.indexOf('-no-') !== -1;
-  flags = flags.split(/[ ,|]+/);
-  if (flags.length > 1 && !/^[[<]/.test(flags[1])) this.short = flags.shift();
-  this.long = flags.shift();
-  this.description = description || '';
-}
-
-/**
- * Return option name.
- *
- * @return {String}
- * @api private
- */
-
-Option.prototype.name = function() {
-  return this.long.replace(/^--/, '');
-};
-
-/**
- * Return option name, in a camelcase format that can be used
- * as a object attribute key.
- *
- * @return {String}
- * @api private
- */
-
-Option.prototype.attributeName = function() {
-  return camelcase(this.name().replace(/^no-/, ''));
-};
-
-/**
- * Check if `arg` matches the short or long flag.
- *
- * @param {String} arg
- * @return {Boolean}
- * @api private
- */
-
-Option.prototype.is = function(arg) {
-  return this.short === arg || this.long === arg;
-};
 
 /**
  * CommanderError class


### PR DESCRIPTION
# Pull Request

We have long been wanting to adopt more modern conventions including ES2015 additions, and can start doing so as we have dropped support for older versions of node.

I am starting small with Option to discuss any questions this raises.

## Problem

Using prototype for implementing Option class is unfamiliar to new programmers, and noisy.

## Solution

Refactor code using `class`.
