### PR TITLE
add failing test for argument labels with spaces

### DIFF
--- a/tests/command.help.test.js
+++ b/tests/command.help.test.js
@@ -94,3 +94,11 @@ test('when command sets noHelp then not displayed in helpInformation', () => {
   const helpInformation = program.helpInformation();
   expect(helpInformation).not.toMatch('secret');
 });
+
+test('when argument name includes space it should be printed correctly in helpInformation', () => {
+  const program = new commander.Command();
+  program
+    .arguments('<some argument name>');
+  const helpInformation = program.helpInformation();
+  expect(helpInformation).toMatch(/^Usage: +\[options\] <some argument name>$/m);
+});


### PR DESCRIPTION
# Pull Request

## Problem

The argument label is cut off in the help information.

```
 FAIL  tests/command.help.test.js
  ● when argument name includes space it should be printed correctly in helpInformation

    expect(received).toMatch(expected)

    Expected pattern: /^Usage: +\[options\] <some argument name>$/m
    Received string:  "Usage:  [options] <som>·
    Options:
      -h, --help  output usage information
    "

      101 |     .arguments('<some argument name>');
      102 |   const helpInformation = program.helpInformation();
    > 103 |   expect(helpInformation).toMatch(/^Usage: +\[options\] <some argument name>$/m);
          |                           ^
      104 | });
      105 | 

      at Object.toMatch (tests/command.help.test.js:103:27)
```