### PR TITLE
Clarify require in examples

### DIFF
--- a/examples/custom-help
+++ b/examples/custom-help
@@ -1,10 +1,7 @@
 #!/usr/bin/env node
 
-/**
- * Module dependencies.
- */
-
-var program = require('../');
+// const program = require('commander'); // (normal include)
+const program = require('../'); // include commander in git clone of commander repo
 
 program
   .version('0.0.1')

--- a/examples/custom-help-description
+++ b/examples/custom-help-description
@@ -1,10 +1,7 @@
 #!/usr/bin/env node
 
-/**
- * Module dependencies.
- */
-
-var program = require('../');
+// const program = require('commander'); // (normal include)
+const program = require('../'); // include commander in git clone of commander repo
 
 program
   .helpOption('-c, --HELP', 'custom help message')

--- a/examples/custom-version
+++ b/examples/custom-version
@@ -1,10 +1,7 @@
 #!/usr/bin/env node
 
-/**
- * Module dependencies.
- */
-
-var program = require('../');
+// const program = require('commander'); // (normal include)
+const program = require('../'); // include commander in git clone of commander repo
 
 program
   .version('0.0.1', '-v, --VERSION', 'new version message')

--- a/examples/defaults
+++ b/examples/defaults
@@ -1,10 +1,7 @@
 #!/usr/bin/env node
 
-/**
- * Module dependencies.
- */
-
-var program = require('../');
+// const program = require('commander'); // (normal include)
+const program = require('../'); // include commander in git clone of commander repo
 
 function list(val) {
   return val.split(',').map(Number);

--- a/examples/deploy
+++ b/examples/deploy
@@ -1,10 +1,7 @@
 #!/usr/bin/env node
 
-/**
- * Module dependencies.
- */
-
-var program = require('../');
+// const program = require('commander'); // (normal include)
+const program = require('../'); // include commander in git clone of commander repo
 
 program
   .version('0.0.1')

--- a/examples/description
+++ b/examples/description
@@ -1,10 +1,7 @@
 #!/usr/bin/env node
 
-/**
- * Module dependencies.
- */
-
-var program = require('../');
+// const program = require('commander'); // (normal include)
+const program = require('../'); // include commander in git clone of commander repo
 
 program
   .version('0.0.1')

--- a/examples/env
+++ b/examples/env
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
-var program = require('../');
+// const program = require('commander'); // (normal include)
+const program = require('../'); // include commander in git clone of commander repo
 
 let cmdValue;
 let envValue;

--- a/examples/express
+++ b/examples/express
@@ -1,10 +1,7 @@
 #!/usr/bin/env node
 
-/**
- * Module dependencies.
- */
-
-var program = require('../');
+// const program = require('commander'); // (normal include)
+const program = require('../'); // include commander in git clone of commander repo
 
 program
   .version('0.0.1')

--- a/examples/help
+++ b/examples/help
@@ -1,10 +1,7 @@
 #!/usr/bin/env node
 
-/**
- * Module dependencies.
- */
-
-var program = require('../');
+// const program = require('commander'); // (normal include)
+const program = require('../'); // include commander in git clone of commander repo
 
 program
   .version('0.0.1')

--- a/examples/options-common.js
+++ b/examples/options-common.js
@@ -20,7 +20,8 @@
 // pizza details:
 // - cheese
 
-const commander = require('../');
+// const commander = require('commander'); // (normal include)
+const commander = require('../'); // include commander in git clone of commander repo
 const program = new commander.Command();
 
 program

--- a/examples/options-custom-processing.js
+++ b/examples/options-custom-processing.js
@@ -17,7 +17,8 @@
 // $ custom --list x,y,z
 // [ 'x', 'y', 'z' ]
 
-const commander = require('../');
+// const commander = require('commander'); // (normal include)
+const commander = require('../'); // include commander in git clone of commander repo
 const program = new commander.Command();
 
 function myParseInt(value, dummyPrevious) {

--- a/examples/options-defaults.js
+++ b/examples/options-defaults.js
@@ -11,7 +11,8 @@
 // $ pizza-options --cheese stilton
 // cheese: stilton
 
-const commander = require('../');
+// const commander = require('commander'); // (normal include)
+const commander = require('../'); // include commander in git clone of commander repo
 const program = new commander.Command();
 
 program

--- a/examples/options-flag-or-value.js
+++ b/examples/options-flag-or-value.js
@@ -13,7 +13,8 @@
 // $ pizza-options --cheese mozzarella
 // add cheese type mozzarella
 
-const commander = require('../');
+// const commander = require('commander'); // (normal include)
+const commander = require('../'); // include commander in git clone of commander repo
 const program = new commander.Command();
 
 program

--- a/examples/options-negatable.js
+++ b/examples/options-negatable.js
@@ -15,7 +15,8 @@
 // $ pizza-options --no-sauce --no-cheese
 // You ordered a pizza with no sauce and no cheese
 
-const commander = require('../');
+// const commander = require('commander'); // (normal include)
+const commander = require('../'); // include commander in git clone of commander repo
 const program = new commander.Command();
 
 program

--- a/examples/options-required.js
+++ b/examples/options-required.js
@@ -10,7 +10,8 @@
 // $ pizza
 // error: required option '-c, --cheese <type>' not specified
 
-const commander = require('..'); // For running direct from git clone of commander repo
+// const commander = require('commander'); // (normal include)
+const commander = require('../'); // include commander in git clone of commander repo
 const program = new commander.Command();
 
 program

--- a/examples/pizza
+++ b/examples/pizza
@@ -1,10 +1,7 @@
 #!/usr/bin/env node
 
-/**
- * Module dependencies.
- */
-
-var program = require('../');
+// const program = require('commander'); // (normal include)
+const program = require('../'); // include commander in git clone of commander repo
 
 program
   .version('0.0.1')

--- a/examples/pm
+++ b/examples/pm
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
-var program = require('..');
+// const program = require('commander'); // (normal include)
+const program = require('../'); // include commander in git clone of commander repo
 
 program
   .version('0.0.1')

--- a/examples/pm-install
+++ b/examples/pm-install
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
-var program = require('..');
+// const program = require('commander'); // (normal include)
+const program = require('../'); // include commander in git clone of commander repo
 
 program
   .option('-f, --force', 'force installation')

--- a/examples/storeOptionsAsProperties-action.js
+++ b/examples/storeOptionsAsProperties-action.js
@@ -16,7 +16,8 @@
 // jump
 // foo
 
-const commander = require('../');
+// const commander = require('commander'); // (normal include)
+const commander = require('../'); // include commander in git clone of commander repo
 const program = new commander.Command();
 
 program

--- a/examples/storeOptionsAsProperties-opts.js
+++ b/examples/storeOptionsAsProperties-opts.js
@@ -14,7 +14,8 @@
 // jump
 // foo
 
-const commander = require('../');
+// const commander = require('commander'); // (normal include)
+const commander = require('../'); // include commander in git clone of commander repo
 const program = new commander.Command();
 
 program

--- a/examples/storeOptionsAsProperties-problem.js
+++ b/examples/storeOptionsAsProperties-problem.js
@@ -16,7 +16,8 @@
 // jump
 // foo
 
-const commander = require('../');
+// const commander = require('commander'); // (normal include)
+const commander = require('../'); // include commander in git clone of commander repo
 const program = new commander.Command();
 
 program


### PR DESCRIPTION
# Pull Request

## Problem

The `require` used for running examples directly in a git clone is different than in a normal program.

```
var program = require('../');
```

## Solution

Add a commented out normal `require` and explanation:

```
// const program = require('commander'); // (normal include)
const program = require('../'); // include commander in git clone of commander repo
```

(Also switched from `var` to `const` in the older examples.)