### PR TITLE
Add missing diff link for 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -417,6 +417,7 @@ program
 [#1118]: https://github.com/tj/commander.js/pull/1118
 
 [Unreleased]: https://github.com/tj/commander.js/compare/master...develop
+[4.1.0]: https://github.com/tj/commander.js/compare/v4.1.0..v4.0.1
 [4.0.1]: https://github.com/tj/commander.js/compare/v4.0.0..v4.0.1
 [4.0.0]: https://github.com/tj/commander.js/compare/v3.0.2..v4.0.0
 [4.0.0-1]: https://github.com/tj/commander.js/compare/v4.0.0-0..v4.0.0-1


### PR DESCRIPTION
# Pull Request

## Problem

The Headline of version 4.1.0 is not linking to the version diff as other versions do.
![image](https://user-images.githubusercontent.com/135657/71866663-44fa2e00-3107-11ea-9fa8-c734367b668c.png)

## Solution

I added the link to the CHANGELOG

![image](https://user-images.githubusercontent.com/135657/71866704-7246dc00-3107-11ea-9c9f-67069fe15b81.png)

> Don't update the CHANGELOG or command version number. That gets done by maintainers when preparing the release.

So maybe you want to solve this differently, it's all yours :)