### PR TITLE
Remove EventEmitter from TypeScript definition file

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -605,12 +605,7 @@ console.log(programOptions.name);
 
 ### TypeScript
 
-The Commander package includes its TypeScript Definition file, but also requires the node types which you need to install yourself. e.g.
-
-```bash
-npm install commander
-npm install --save-dev @types/node
-```
+The Commander package includes its TypeScript Definition file.
 
 If you use `ts-node` and  git-style sub-commands written as `.ts` files, you need to call your program through node to get the sub-commands called correctly. e.g.
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -294,7 +294,7 @@ declare namespace commander {
      *         console.log('See web site for more information.');
      *     });
      */
-    on(event: string, listener: (...args: any[]) => void): Command;
+    on(event: string | symbol, listener: (...args: any[]) => void): Command;
   }
   type CommandConstructor = { new (name?: string): Command };
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,8 +1,6 @@
 // Type definitions for commander
 // Original definitions by: Alan Agius <https://github.com/alan-agius4>, Marcelo Dezem <https://github.com/mdezem>, vvakame <https://github.com/vvakame>, Jules Randolph <https://github.com/sveinburne>
 
-///<reference types="node" />
-
 declare namespace commander {
 
   interface CommanderError extends Error {
@@ -25,7 +23,7 @@ declare namespace commander {
   }
   type OptionConstructor = { new (flags: string, description?: string): Option };
 
-  interface Command extends NodeJS.EventEmitter {
+  interface Command {
     [key: string]: any; // options as properties
 
     args: string[];
@@ -286,6 +284,17 @@ declare namespace commander {
      * Output help information and exit.
      */
     help(cb?: (str: string) => string): never;
+
+    /**
+     * Add a listener (callback) for when events occur. (Implemented using EventEmitter.)
+     * 
+     * @example
+     *     program
+     *       .on('--help', () -> {
+     *         console.log('See web site for more information.');
+     *     });
+     */
+    on(event: string, listener: (...args: any[]) => void): Command;
   }
   type CommandConstructor = { new (name?: string): Command };
 


### PR DESCRIPTION
# Pull Request

## Problem

Need to also install `@types/node` or get an error due to explicit inheritance of Command from EventEmitter.

Related: #646 #974 #1105

## Solution

Don't say Command extends `EventEmitter`! Instead list the `.on()` function manually.

A reason for not doing this would be if there are likely use cases where people are using more of the methods from EventEmitter on Command, or passing around a Command as an EventEmitter. I have not encountered this in any programs or examples. For rare cases it is easy enough to override the type so this does not prevent use.

Ideally I would like to actually change Command so it _has-a_ EventEmitter and not _is-a_ EventEmitter (#1105 ), but that is a much bigger change. This PR is a simple typings change to achieve a similar outcome for TypeScript now without changing the implementation at all.

## ChangeLog

### Changed

- removed EventEmitter from TypeScript definition for Command
