### PR TITLE
Add FUNDING file prior to enabling GitHub Sponsor on repo

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: [tj, shadowspawn, abetomo]
+tidelift: npm/commander


### PR DESCRIPTION
# Pull Request

## Problem

Visibility of the possibility to sponsor tj, current Commander maintainers, or get TideLift support.

## Solution

I quite like the GitHub Sponsors button as a visible but optional way of finding out about sponsoring projects and people. I see all three of us are signed up with GitHub Sponsors, and Tidelift recommend adding a listing in `FUNDING.yml` too.

I deliberately have not `@mentioned` tj yet, to see what you think first @abetomo ?

(It will be tj who turns on the Sponsor button as repo owner, this PR just sets up the file ready.)