### PR TITLE
Combine normalize and parseoptions, and update combined option handling

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -67,7 +67,7 @@ For larger programs which may use commander in multiple ways, including unit tes
 
 ## Options
 
-Options are defined with the `.option()` method, also serving as documentation for the options. Each option can have a short flag (single character) and a long name, separated by a comma or space or bar ('|').
+Options are defined with the `.option()` method, also serving as documentation for the options. Each option can have a short flag (single character) and a long name, separated by a comma or space or vertical bar ('|').
 
 The options can be accessed as properties on the Command object. Multi-word options such as "--template-engine" are camel-cased, becoming `program.templateEngine` etc. See also optional new behaviour to [avoid name clashes](#avoiding-option-name-clashes).
 

--- a/Readme.md
+++ b/Readme.md
@@ -67,11 +67,16 @@ For larger programs which may use commander in multiple ways, including unit tes
 
 ## Options
 
-Options are defined with the `.option()` method, also serving as documentation for the options. Each option can have a short flag (single character) and a long name, separated by a comma or space.
+Options are defined with the `.option()` method, also serving as documentation for the options. Each option can have a short flag (single character) and a long name, separated by a comma or space or bar ('|').
 
-The options can be accessed as properties on the Command object. Multi-word options such as "--template-engine" are camel-cased, becoming `program.templateEngine` etc. Multiple short flags may be combined as a single arg, for example `-abc` is equivalent to `-a -b -c`.
+The options can be accessed as properties on the Command object. Multi-word options such as "--template-engine" are camel-cased, becoming `program.templateEngine` etc. See also optional new behaviour to [avoid name clashes](#avoiding-option-name-clashes).
 
-See also optional new behaviour to [avoid name clashes](#avoiding-option-name-clashes).
+Multiple short flags may optionally be combined in a single argument following the dash: boolean flags, the last flag may take a value, and the value.
+For example `-a -b -p 80` may be written as `-ab -p80` or even `-abp80`.
+
+You can use `--` to indicate the end of the options, and any remaining arguments will be used without being interpreted.
+This is particularly useful for passing options through to another
+command, like: `do -- git --version`.
 
 ### Common option types, boolean and value
 
@@ -251,7 +256,7 @@ $ custom --list x,y,z
 
 ### Required option
 
-You may specify a required (mandatory) option using `.requiredOption`. The option must be specified on the command line, or by having a default value. The method is otherwise the same as `.option` in format, taking flags and description, and optional default value or custom processing.
+You may specify a required (mandatory) option using `.requiredOption`. The option must have a value after parsing, usually specified on the command line, or perhaps from a default value (say from environment). The method is otherwise the same as `.option` in format, taking flags and description, and optional default value or custom processing.
 
 ```js
 const program = require('commander');

--- a/Readme.md
+++ b/Readme.md
@@ -78,6 +78,8 @@ You can use `--` to indicate the end of the options, and any remaining arguments
 This is particularly useful for passing options through to another
 command, like: `do -- git --version`.
 
+Options on the command line are not positional, and can be specified before or after other command arguments.
+
 ### Common option types, boolean and value
 
 The two most used option types are a boolean flag, and an option which takes a value (declared using angle brackets). Both are `undefined` unless specified on command line.

--- a/index.js
+++ b/index.js
@@ -637,9 +637,8 @@ Command.prototype.parse = function(argv) {
     argv.push(this._helpLongFlag);
   }
 
-  // process argv
-  const normalized = this.normalize(argv.slice(2));
-  const parsed = this.parseOptions(normalized);
+  // process argv, leaving off first two args which are app and scriptname.
+  const parsed = this.parseOptions(argv.slice(2));
   const args = parsed.operands.concat(parsed.unknown);
   this.args = args.slice();
 
@@ -823,57 +822,6 @@ Command.prototype.executeSubCommand = function(argv, args, executableFile) {
 };
 
 /**
- * Normalize `args`, splitting joined short flags. For example
- * the arg "-abc" is equivalent to "-a -b -c".
- * This also normalizes equal sign and splits "--abc=def" into "--abc def".
- *
- * @param {Array} args
- * @return {Array}
- * @api private
- */
-
-Command.prototype.normalize = function(args) {
-  var ret = [],
-    arg,
-    lastOpt,
-    index,
-    short,
-    opt;
-
-  for (var i = 0, len = args.length; i < len; ++i) {
-    arg = args[i];
-    if (i > 0) {
-      lastOpt = this.optionFor(args[i - 1]);
-    }
-
-    if (arg === '--') {
-      // Honor option terminator
-      ret = ret.concat(args.slice(i));
-      break;
-    } else if (lastOpt && lastOpt.required) {
-      ret.push(arg);
-    } else if (arg.length > 2 && arg[0] === '-' && arg[1] !== '-') {
-      short = arg.slice(0, 2);
-      opt = this.optionFor(short);
-      if (opt && (opt.required || opt.optional)) {
-        ret.push(short);
-        ret.push(arg.slice(2));
-      } else {
-        arg.slice(1).split('').forEach(function(c) {
-          ret.push('-' + c);
-        });
-      }
-    } else if (/^--/.test(arg) && ~(index = arg.indexOf('='))) {
-      ret.push(arg.slice(0, index), arg.slice(index + 1));
-    } else {
-      ret.push(arg);
-    }
-  }
-
-  return ret;
-};
-
-/**
  * Parse command `args`.
  *
  * When listener(s) are available those
@@ -960,23 +908,17 @@ Command.prototype._checkForMissingMandatoryOptions = function() {
 Command.prototype.parseOptions = function(argv) {
   const operands = []; // operands, not options or values
   const unknown = []; // first unknown option and remaining unknown args
-  let literal = false;
   let dest = operands;
+  const args = argv.slice();
 
   // parse options
-  for (var i = 0; i < argv.length; ++i) {
-    const arg = argv[i];
-
-    // literal args after --
-    if (literal) {
-      dest.push(arg);
-      continue;
-    }
+  while (args.length) {
+    const arg = args.shift();
 
     if (arg === '--') {
-      literal = true;
-      if (dest === unknown) dest.push('--');
-      continue;
+      if (dest === unknown) dest.push(arg);
+      dest.push(...args);
+      break;
     }
 
     // find matching Option
@@ -985,31 +927,54 @@ Command.prototype.parseOptions = function(argv) {
     // recognised option, call listener to assign value with possible custom processing
     if (option) {
       if (option.required) {
-        const value = argv[++i];
+        const value = args.shift();
         if (value === undefined) this.optionMissingArgument(option);
         this.emit('option:' + option.name(), value);
       } else if (option.optional) {
-        let value = argv[i + 1];
-        // do not use a following option as a value
-        if (value === undefined || (value[0] === '-' && value !== '-')) {
-          value = null;
-        } else {
-          ++i;
+        let value = null;
+        // historical behaviour is value is following arg unless an option
+        if (args.length && (args[0][0] !== '-' || args[0] === '-')) {
+          value = args.shift();
         }
         this.emit('option:' + option.name(), value);
-      // flag
-      } else {
+      } else { // boolean flag
         this.emit('option:' + option.name());
       }
       continue;
     }
 
-    // looks like an option, unknowns from here
+    // Look for combo options following single dash, eat first one if known.
+    if (arg.length > 2 && arg[0] === '-' && arg[1] !== '-') {
+      const option = this.optionFor(`-${arg[1]}`);
+      if (option) {
+        if (option.required || option.optional) {
+          // option with value following in same argument
+          this.emit(`option:${option.name()}`, arg.slice(2));
+        } else {
+          // boolean option, emit and put back remainder of arg for further processing
+          this.emit(`option:${option.name()}`);
+          args.unshift(`-${arg.slice(2)}`);
+        }
+        continue;
+      }
+    }
+
+    // Look for known long flag with value, like --foo=bar
+    if (/^--[^=]+=/.test(arg)) {
+      const index = arg.indexOf('=');
+      const option = this.optionFor(arg.slice(0, index));
+      if (option && (option.required || option.optional)) {
+        this.emit(`option:${option.name()}`, arg.slice(index + 1));
+        continue;
+      }
+    }
+
+    // looks like an option but unknown, unknowns from here
     if (arg.length > 1 && arg[0] === '-') {
       dest = unknown;
     }
 
-    // arg
+    // add arg
     dest.push(arg);
   }
 

--- a/index.js
+++ b/index.js
@@ -933,16 +933,16 @@ Command.prototype.parseOptions = function(argv) {
         if (option.required) {
           const value = args.shift();
           if (value === undefined) this.optionMissingArgument(option);
-          this.emit('option:' + option.name(), value);
+          this.emit(`option:${option.name()}`, value);
         } else if (option.optional) {
           let value = null;
           // historical behaviour is optional value is following arg unless an option
           if (args.length > 0 && !maybeOption(args[0])) {
             value = args.shift();
           }
-          this.emit('option:' + option.name(), value);
+          this.emit(`option:${option.name()}`, value);
         } else { // boolean flag
-          this.emit('option:' + option.name());
+          this.emit(`option:${option.name()}`);
         }
         continue;
       }

--- a/tests/args.literal.test.js
+++ b/tests/args.literal.test.js
@@ -1,9 +1,9 @@
 const commander = require('../');
 
-// Guideline 10:
-// The first -- argument that is not an option-argument should be accepted as a delimiter indicating the end of options. Any following arguments should be treated as operands, even if they begin with the '-' character.
+// Utility Conventions: http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html#tag_12_02
 //
-// http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html#tag_12_02
+// 12.2 Utility Syntax Guidelines, Guideline 10:
+// The first -- argument that is not an option-argument should be accepted as a delimiter indicating the end of options. Any following arguments should be treated as operands, even if they begin with the '-' character.
 
 test('when arguments includes -- then stop processing options', () => {
   const program = new commander.Command();

--- a/tests/command.parseOptions.test.js
+++ b/tests/command.parseOptions.test.js
@@ -245,64 +245,56 @@ describe('Utility Conventions', () => {
 
   test('when program has combo known boolean short flags then arg removed', () => {
     const program = createProgram();
-    const normalized = program.normalize(['-ab']);
-    const result = program.parseOptions(normalized);
+    const result = program.parseOptions(['-ab']);
     expect(result).toEqual({ operands: [], unknown: [] });
     expect(program.opts()).toEqual({ aaa: true, bbb: true });
   });
 
   test('when program has combo unknown short flags then arg preserved', () => {
     const program = createProgram();
-    const normalized = program.normalize(['-pq']);
-    const result = program.parseOptions(normalized);
+    const result = program.parseOptions(['-pq']);
     expect(result).toEqual({ operands: [], unknown: ['-pq'] });
     expect(program.opts()).toEqual({ });
   });
 
   test('when program has combo known short option and required value then arg removed', () => {
     const program = createProgram();
-    const normalized = program.normalize(['-cvalue']);
-    const result = program.parseOptions(normalized);
+    const result = program.parseOptions(['-cvalue']);
     expect(result).toEqual({ operands: [], unknown: [] });
     expect(program.opts()).toEqual({ ccc: 'value' });
   });
 
   test('when program has combo known short option and optional value then arg removed', () => {
     const program = createProgram();
-    const normalized = program.normalize(['-dvalue']);
-    const result = program.parseOptions(normalized);
+    const result = program.parseOptions(['-dvalue']);
     expect(result).toEqual({ operands: [], unknown: [] });
     expect(program.opts()).toEqual({ ddd: 'value' });
   });
 
   test('when program has known combo short boolean flags and required value then arg removed', () => {
     const program = createProgram();
-    const normalized = program.normalize(['-abcvalue']);
-    const result = program.parseOptions(normalized);
+    const result = program.parseOptions(['-abcvalue']);
     expect(result).toEqual({ operands: [], unknown: [] });
     expect(program.opts()).toEqual({ aaa: true, bbb: true, ccc: 'value' });
   });
 
   test('when program has known combo short boolean flags and optional value then arg removed', () => {
     const program = createProgram();
-    const normalized = program.normalize(['-abdvalue']);
-    const result = program.parseOptions(normalized);
+    const result = program.parseOptions(['-abdvalue']);
     expect(result).toEqual({ operands: [], unknown: [] });
     expect(program.opts()).toEqual({ aaa: true, bbb: true, ddd: 'value' });
   });
 
   test('when program has known long flag=value then arg removed', () => {
     const program = createProgram();
-    const normalized = program.normalize(['--ccc=value']);
-    const result = program.parseOptions(normalized);
+    const result = program.parseOptions(['--ccc=value']);
     expect(result).toEqual({ operands: [], unknown: [] });
     expect(program.opts()).toEqual({ ccc: 'value' });
   });
 
   test('when program has unknown long flag=value then arg preserved', () => {
     const program = createProgram();
-    const normalized = program.normalize(['--rrr=value']);
-    const result = program.parseOptions(normalized);
+    const result = program.parseOptions(['--rrr=value']);
     expect(result).toEqual({ operands: [], unknown: ['--rrr=value'] });
     expect(program.opts()).toEqual({ });
   });

--- a/tests/command.parseOptions.test.js
+++ b/tests/command.parseOptions.test.js
@@ -7,20 +7,6 @@ const path = require('path');
 
 // Tests created from reported bugs
 describe('regression tests', () => {
-  // https://github.com/tj/commander.js/issues/1039
-  // https://github.com/tj/commander.js/issues/561
-  test('when unknown option and multiple arguments then unknown option detected', () => {
-    // Optional. Use internal knowledge to suppress output to keep test output clean.
-    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => { });
-    const program = new commander.Command();
-    program
-      .exitOverride();
-    expect(() => {
-      program.parse(['node', 'text', '--bug', '0', '1', '2', '3']);
-    }).toThrow();
-    consoleErrorSpy.mockRestore();
-  });
-
   // https://github.com/tj/commander.js/issues/1032
   function createProgram1032() {
     const program = new commander.Command();

--- a/tests/command.parseOptions.test.js
+++ b/tests/command.parseOptions.test.js
@@ -196,3 +196,114 @@ describe('parse and program.args', () => {
     expect(program.args).toEqual(['sub', '--sub-flag', 'arg']);
   });
 });
+
+// Utility Conventions: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html#tag_12_01
+//
+// 12.1 Utility Argument Syntax
+// 2. Option-arguments are shown separated from their options by <blank> characters, except when the option-argument is
+// enclosed in the '[' and ']' notation to indicate that it is optional. This reflects the situation in which an
+// optional option-argument (if present) is included within the same argument string as the option; for a mandatory option-argument,
+// it is the next argument. The Utility Syntax Guidelines in Utility Syntax Guidelines require that the option be a separate argument
+// from its option-argument and that option-arguments not be optional, but there are some exceptions in POSIX.1-2017 to ensure
+// continued operation of historical applications:
+//
+// a. If the SYNOPSIS of a standard utility shows an option with a mandatory option-argument (as with [ -c option_argument] in the example),
+//    a conforming application shall use separate arguments for that option and its option-argument. However, a conforming implementation shall
+//    also permit applications to specify the option and option-argument in the same argument string without intervening <blank> characters.
+//
+// b. If the SYNOPSIS shows an optional option-argument (as with [ -f[ option_argument]] in the example), a conforming application
+//    shall place any option-argument for that option directly adjacent to the option in the same argument string, without intervening
+//    <blank> characters. If the utility receives an argument containing only the option, it shall behave as specified in its description
+//    for an omitted option-argument; it shall not treat the next argument (if any) as the option-argument for that option.
+//
+// 12.2 Utility Syntax Guidelines, Guideline 5:
+// One or more options without option-arguments, followed by at most one option that takes an option-argument, should be accepted when
+// grouped behind one '-' delimiter.
+
+// Commander conformance:
+// - allows separate argument for required option-argument
+// - allows value in same argument for short flag with required option-argument
+// - non-conforming: allows separate argument for optional option-argument if does not start with '-'
+// - allows value in same argument for short flag with optional option-argument
+// - allows short flags as per 12.2
+//
+// The focus in this file is testing the behaviours with known vs unknown options.
+// See options.values.test.js for more general testing of known options.
+
+describe('Utility Conventions', () => {
+  function createProgram() {
+    const program = new commander.Command();
+    program
+      .option('-a,--aaa')
+      .option('-b,--bbb')
+      .option('-c,--ccc <value>')
+      .option('-d,--ddd [value]');
+    program
+      .action(() => { });
+    return program;
+  };
+
+  test('when program has combo known boolean short flags then arg removed', () => {
+    const program = createProgram();
+    const normalized = program.normalize(['-ab']);
+    const result = program.parseOptions(normalized);
+    expect(result).toEqual({ operands: [], unknown: [] });
+    expect(program.opts()).toEqual({ aaa: true, bbb: true });
+  });
+
+  test('when program has combo unknown short flags then arg preserved', () => {
+    const program = createProgram();
+    const normalized = program.normalize(['-pq']);
+    const result = program.parseOptions(normalized);
+    expect(result).toEqual({ operands: [], unknown: ['-pq'] });
+    expect(program.opts()).toEqual({ });
+  });
+
+  test('when program has combo known short option and required value then arg removed', () => {
+    const program = createProgram();
+    const normalized = program.normalize(['-cvalue']);
+    const result = program.parseOptions(normalized);
+    expect(result).toEqual({ operands: [], unknown: [] });
+    expect(program.opts()).toEqual({ ccc: 'value' });
+  });
+
+  test('when program has combo known short option and optional value then arg removed', () => {
+    const program = createProgram();
+    const normalized = program.normalize(['-dvalue']);
+    const result = program.parseOptions(normalized);
+    expect(result).toEqual({ operands: [], unknown: [] });
+    expect(program.opts()).toEqual({ ddd: 'value' });
+  });
+
+  test('when program has known combo short boolean flags and required value then arg removed', () => {
+    const program = createProgram();
+    const normalized = program.normalize(['-abcvalue']);
+    const result = program.parseOptions(normalized);
+    expect(result).toEqual({ operands: [], unknown: [] });
+    expect(program.opts()).toEqual({ aaa: true, bbb: true, ccc: 'value' });
+  });
+
+  test('when program has known combo short boolean flags and optional value then arg removed', () => {
+    const program = createProgram();
+    const normalized = program.normalize(['-abdvalue']);
+    const result = program.parseOptions(normalized);
+    expect(result).toEqual({ operands: [], unknown: [] });
+    expect(program.opts()).toEqual({ aaa: true, bbb: true, ddd: 'value' });
+  });
+
+  test('when program has known long flag=value then arg removed', () => {
+    const program = createProgram();
+    const normalized = program.normalize(['--ccc=value']);
+    const result = program.parseOptions(normalized);
+    expect(result).toEqual({ operands: [], unknown: [] });
+    expect(program.opts()).toEqual({ ccc: 'value' });
+  });
+
+  test('when program has unknown long flag=value then arg preserved', () => {
+    const program = createProgram();
+    const normalized = program.normalize(['--rrr=value']);
+    const result = program.parseOptions(normalized);
+    expect(result).toEqual({ operands: [], unknown: ['--rrr=value'] });
+    expect(program.opts()).toEqual({ });
+  });
+});

--- a/tests/command.parseOptions.test.js
+++ b/tests/command.parseOptions.test.js
@@ -10,12 +10,15 @@ describe('regression tests', () => {
   // https://github.com/tj/commander.js/issues/1039
   // https://github.com/tj/commander.js/issues/561
   test('when unknown option and multiple arguments then unknown option detected', () => {
+    // Optional. Use internal knowledge to suppress output to keep test output clean.
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => { });
     const program = new commander.Command();
     program
       .exitOverride();
     expect(() => {
       program.parse(['node', 'text', '--bug', '0', '1', '2', '3']);
     }).toThrow();
+    consoleErrorSpy.mockRestore();
   });
 
   // https://github.com/tj/commander.js/issues/1032

--- a/tests/openIssues.test.js.skip
+++ b/tests/openIssues.test.js.skip
@@ -1,4 +1,16 @@
 const commander = require('../');
 
 describe('open issues', () => {
+  // https://github.com/tj/commander.js/issues/561
+  test('#561: when specify argument and unknown option with no action handler then error', () => {
+    const program = new commander.Command();
+    program
+      .exitOverride()
+      .option('-x, --x-flag', 'A flag')
+      .arguments('<file>');
+
+    expect(() => {
+      program.parse(['node', 'test', '1', '--NONSENSE', '2', '3']);
+    }).toThrow();
+  });
 });

--- a/tests/options.values.test.js
+++ b/tests/options.values.test.js
@@ -1,6 +1,7 @@
 const commander = require('../');
 
 // Test the ways values can be specified for options.
+// See also references on "Utility Conventions" in command.parseOptions.test.js
 
 // options with required values can eat values starting with a dash, including just dash sometimes used as alias for stdin
 //


### PR DESCRIPTION
# Pull Request

(This is the same PR as #1145, but rebased to clean up the commits listed.)

## Problem

`.parse()` called a private routine `.normalize()` to split short options, turn `--long=value` into `--long value`, et al. This caused a few subtle problems:

- the extra functionality was not available when called public routine `.parseOptions()`
- the expansion was done before the types of the flags for subcommands were known, so support for including value in argument like `-fValue` (added in #599) only worked for top level command 
- an argument into a subcommand option could get incorrectly processed as a global flag due to early expansion, like `do sub --flag=--version`

## Solution

1. roll the support into `.parseOptions` and delete `.normalise`
2. expand arguments only for known options
3. as a bonus, add support for multiple boolean short flags followed by a flag expecting an argument (in subcommands as well as top command)

So for example:
```
program
  .command('sub')
  .option('-w,--www')
  .option('-s,--secure')
  .option('-p,--port <number>')
  .action((cmd) => {
    console.log(cmd.opts());
  });
program.parse(process.argv);
```

Can now call like:
```
# my-program sub -wsp443
{ www: true, secure: true, port: '443' }
```

## ChangeLog

### Added

- combined short options as single argument may include boolean flags and value flag and value (e.g. `-a -b -p 80` can be written as `-abp80`) (#1145)
- `.parseOption()` includes short flag and long flag expansions (#1145)

### Changed

- only recognised option short flags and long flags are expanded (e.g. `-ab` or `--foo=bar`) (#1145)

### Fixed

- combining option short flag and value in single argument now work for subcommands (e.g. `-p80`) (#1145)

### Removed

- private function `normalize` (the functionality has been integrated into `parseOptions`)
