### PR TITLE
Use `npm ci` with CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
     # Use separate run commands so command status handled correctly on Windows
     - name: npm install
-      run: npm install
+      run: npm ci
     - name: npm test
       run: npm test
     - name: npm run lint


### PR DESCRIPTION
# Pull Request

<!--
The text in these markdown comments is instructions that will not appear in the displayed pull request,
and can be deleted.

Please submit pull requests against the develop branch.

Follow the existing code style. Check the tests succeed, including lint.
  npm run test
  npm run lint

Don't update the CHANGELOG or command version number. That gets done by maintainers when preparing the release.

Commander currently has zero production dependencies. That isn't a hard requirement, but is a simple story. Requests which 
add a dependency are much less likely to be accepted, and we are likely to ask if there alternative approaches to avoid the dependency.
-->

## Problem

Better use `npm ci`.
https://docs.npmjs.com/cli/ci.html

## Solution

Change CI setting from `install` to `ci`

## ChangeLog
