### PR TITLE
Throw for author errors and improve

### DIFF
--- a/tests/args.variadic.test.js
+++ b/tests/args.variadic.test.js
@@ -70,25 +70,17 @@ describe('variadic argument', () => {
 
   test('when program variadic argument not last then error', () => {
     const program = new commander.Command();
-    program
-      .exitOverride()
-      .arguments('<variadicArg...> [optionalArg]')
-      .action(jest.fn);
 
     expect(() => {
-      program.parse(['node', 'test', 'a']);
-    }).toThrow("error: variadic arguments must be last 'variadicArg'");
+      program.arguments('<variadicArg...> [optionalArg]');
+    }).toThrow("only the last argument can be variadic 'variadicArg'");
   });
 
   test('when command variadic argument not last then error', () => {
     const program = new commander.Command();
-    program
-      .exitOverride()
-      .command('sub <variadicArg...> [optionalArg]')
-      .action(jest.fn);
 
     expect(() => {
-      program.parse(['node', 'test', 'sub', 'a']);
-    }).toThrow("error: variadic arguments must be last 'variadicArg'");
+      program.command('sub <variadicArg...> [optionalArg]');
+    }).toThrow("only the last argument can be variadic 'variadicArg'");
   });
 });

--- a/tests/command.executableSubcommand.lookup.test.js
+++ b/tests/command.executableSubcommand.lookup.test.js
@@ -12,7 +12,7 @@ test('when subcommand file missing then error', (done) => {
       // Get uncaught thrown error on Windows
       expect(stderr.length).toBeGreaterThan(0);
     } else {
-      expect(stderr).toBe('error: pm-list(1) does not exist\n');
+      expect(stderr).toMatch(new RegExp(/Error: 'pm-list' does not exist/));
     }
     done();
   });
@@ -24,7 +24,7 @@ test('when alias subcommand file missing then error', (done) => {
       // Get uncaught thrown error on Windows
       expect(stderr.length).toBeGreaterThan(0);
     } else {
-      expect(stderr).toBe('error: pm-list(1) does not exist\n');
+      expect(stderr).toMatch(new RegExp(/Error: 'pm-list' does not exist/));
     }
     done();
   });


### PR DESCRIPTION
# Pull Request

## Problem

Inconsistent handling of author errors (log vs throw).
Accidental executable subcommand is a common error.
Problems with variadic argument are detected when used, not earlier when added.

## Solution

- use throw for author errors
- detect misplaced variadic argument as added, rather than later when used
- add tips to missing executable error

Example of the extended error message for missing executable subcommand:

```
const program = require("commander");
program
  .command('sub', 'description')
  .action(() => { 'Intended action handler'});
program.parse(process.argv);
```

```
% node missing.js sub
/Users/john/Documents/Sandpits/commander/my-fork/index.js:746
        throw new Error(executableMissing);
        ^

Error: 'missing-sub' does not exist
 - if 'sub' is not meant to be an executable command, remove description parameter from '.command()' and use '.description()' instead
 - if the default executable name is not suitable, use the executableFile option to supply a custom name
    at ChildProcess.<anonymous> (/Users/john/Documents/Sandpits/commander/my-fork/index.js:746:15)
    at ChildProcess.emit (events.js:321:20)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:273:12)
    at onErrorNT (internal/child_process.js:467:16)
    at processTicksAndRejections (internal/process/task_queues.js:84:21)
```