### PR TITLE
Add VSCode tip and rework debugging section

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -35,7 +35,7 @@ Read this in other languages: English | [简体中文](./Readme_zh-CN.md)
     - [Avoiding option name clashes](#avoiding-option-name-clashes)
     - [TypeScript](#typescript)
     - [Node options such as `--harmony`](#node-options-such-as---harmony)
-    - [Node debugging](#node-debugging)
+    - [Debugging executable subcommands](#debugging-executable-subcommands)
     - [Override exit handling](#override-exit-handling)
   - [Examples](#examples)
   - [License](#license)
@@ -652,10 +652,14 @@ You can enable `--harmony` option in two ways:
 - Use `#! /usr/bin/env node --harmony` in the sub-commands scripts. (Note Windows does not support this pattern.)
 - Use the `--harmony` option when call the command, like `node --harmony examples/pm publish`. The `--harmony` option will be preserved when spawning sub-command process.
 
-### Node debugging
+### Debugging executable subcommands
 
-If you are using the node inspector for [debugging](https://nodejs.org/en/docs/guides/debugging-getting-started/) git-style executable (sub)commands using `node --inspect` et al,
+An executable subcommand is launched as a separate child process.
+
+If you are using the node inspector for [debugging](https://nodejs.org/en/docs/guides/debugging-getting-started/) executable subcommands using `node --inspect` et al,
 the inspector port is incremented by 1 for the spawned subcommand.
+
+If you are using VSCode to debug executable subcommands you need to set the `"autoAttachChildProcesses": true` flag in your launch.json configuration.
 
 ### Override exit handling
 


### PR DESCRIPTION
# Pull Request

## Problem

Debugging executable subcommands is tricky.

## Solution

Add VSCode tip from #1156 (with co-author attribution).
Rework and rename debugging section.