### PR TITLE
Parse argument conventions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -32,6 +32,7 @@ Read this in other languages: English | [简体中文](./Readme_zh-CN.md)
     - [.help(cb)](#helpcb)
   - [Custom event listeners](#custom-event-listeners)
   - [Bits and pieces](#bits-and-pieces)
+    - [.parse() and .parseAsync()](#parse-and-parseasync)
     - [Avoiding option name clashes](#avoiding-option-name-clashes)
     - [TypeScript](#typescript)
     - [Node options such as `--harmony`](#node-options-such-as---harmony)
@@ -597,6 +598,25 @@ program.on('command:*', function (operands) {
 ```
 
 ## Bits and pieces
+
+### .parse() and .parseAsync()
+
+The first argument to `.parse` is the array of strings to parse. You may omit the parameter to implicitly use `process.argv`.
+
+If the arguments follow different conventions than node you can pass a `from` option in the second parameter:
+
+- 'node': default, `argv[0]` is the application and `argv[1]` is the script being run, with user parameters after that
+- 'electron': `argv[1]` varies depending on whether the electron application is packaged
+- 'user': all of the arguments from the user
+
+For example:
+
+```js
+program.parse(process.argv); // Explicit, node conventions
+program.parse(); // Implicit, and auto-detect electron
+program.parse(['-f', 'filename'], { from: 'user' });
+```
+
 
 ### Avoiding option name clashes
 

--- a/Readme.md
+++ b/Readme.md
@@ -617,7 +617,6 @@ program.parse(); // Implicit, and auto-detect electron
 program.parse(['-f', 'filename'], { from: 'user' });
 ```
 
-
 ### Avoiding option name clashes
 
 The original and default behaviour is that the option values are stored

--- a/index.js
+++ b/index.js
@@ -627,8 +627,8 @@ class Command extends EventEmitter {
    *
    * Examples:
    *
-   *      program.parse(); // implicitly use process.argv and auto-detect node vs electron conventions
    *      program.parse(process.argv);
+   *      program.parse(); // implicitly use process.argv and auto-detect node vs electron conventions
    *      program.parse(my-args, { from: 'user' }); // just user supplied arguments, nothing special about argv[0]
    *
    * @param {string[]} [argv] - optional, defaults to process.argv
@@ -693,7 +693,14 @@ class Command extends EventEmitter {
    *
    * Use parseAsync instead of parse if any of your action handlers are async. Returns a Promise.
    *
-   * (See .parse for additional details and examples.)
+   * The default expectation is that the arguments are from node and have the application as argv[0]
+   * and the script being run in argv[1], with user parameters after that.
+   *
+   * Examples:
+   *
+   *      program.parseAsync(process.argv);
+   *      program.parseAsync(); // implicitly use process.argv and auto-detect node vs electron conventions
+   *      program.parseAsync(my-args, { from: 'user' }); // just user supplied arguments, nothing special about argv[0]
    *
    * @param {string[]} [argv]
    * @param {Object} [parseOptions]

--- a/index.js
+++ b/index.js
@@ -622,8 +622,17 @@ class Command extends EventEmitter {
   /**
    * Parse `argv`, setting options and invoking commands when defined.
    *
-   * @param {string[]} [argv]
-   * @param {Object} [parseOptions]
+   * The default expectation is that the arguments are from node and have the application as argv[0]
+   * and the script being run in argv[1], with user parameters after that.
+   *
+   * Examples:
+   *
+   *      program.parse(); // implicitly use process.argv and auto-detect node vs electron conventions
+   *      program.parse(process.argv);
+   *      program.parse(my-args, { from: 'user' }); // just user supplied arguments, nothing special about argv[0]
+   *
+   * @param {string[]} [argv] - optional, defaults to process.argv
+   * @param {Object} [parseOptions] - optionally specify style of options with from: node/user/electron
    * @param {string} parseOptions.from - where the args are from: 'node', 'user', 'electron'
    * @return {Command} for chaining
    * @api public
@@ -683,6 +692,8 @@ class Command extends EventEmitter {
    * Parse `argv`, setting options and invoking commands when defined.
    *
    * Use parseAsync instead of parse if any of your action handlers are async. Returns a Promise.
+   *
+   * (See .parse for additional details and examples.)
    *
    * @param {string[]} [argv]
    * @param {Object} [parseOptions]

--- a/tests/command.parse.test.js
+++ b/tests/command.parse.test.js
@@ -1,0 +1,54 @@
+const commander = require('../');
+
+// Testing some Electron conventions but not directly using Electron to avoid overheads.
+// https://github.com/electron/electron/issues/4690#issuecomment-217435222
+// https://www.electronjs.org/docs/api/process#processdefaultapp-readonly
+
+describe('.parse() user args', () => {
+  test('when no args then use process.argv and app/script/args', () => {
+    const program = new commander.Command();
+    const hold = process.argv;
+    process.argv = 'node script.js user'.split(' ');
+    program.parse();
+    process.argv = hold;
+    expect(program.args).toEqual(['user']);
+  });
+
+  // implicit also supports detecting electron but more implementation knowledge required than useful to test
+
+  test('when args then app/script/args', () => {
+    const program = new commander.Command();
+    program.parse('node script.js user'.split(' '));
+    expect(program.args).toEqual(['user']);
+  });
+
+  test('when args from "node" then app/script/args', () => {
+    const program = new commander.Command();
+    program.parse('node script.js user'.split(' '), { from: 'node' });
+    expect(program.args).toEqual(['user']);
+  });
+
+  test('when args from "electron" and not default app then app/args', () => {
+    const program = new commander.Command();
+    const hold = process.defaultApp;
+    process.defaultApp = undefined;
+    program.parse('customApp user'.split(' '), { from: 'electron' });
+    process.defaultApp = hold;
+    expect(program.args).toEqual(['user']);
+  });
+
+  test('when args from "electron" and default app then app/script/args', () => {
+    const program = new commander.Command();
+    const hold = process.defaultApp;
+    process.defaultApp = true;
+    program.parse('electron script user'.split(' '), { from: 'electron' });
+    process.defaultApp = hold;
+    expect(program.args).toEqual(['user']);
+  });
+
+  test('when args from "user" then args', () => {
+    const program = new commander.Command();
+    program.parse('user'.split(' '), { from: 'user' });
+    expect(program.args).toEqual(['user']);
+  });
+});

--- a/typings/commander-tests.ts
+++ b/typings/commander-tests.ts
@@ -145,6 +145,8 @@ program.exitOverride((err):void => {
 });
 
 program.parse(process.argv);
+program.parse();
+program.parse(["foo"], { from: "user" });
 
 program.parseAsync(process.argv).then(() => {
   console.log('parseAsync success');

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -23,6 +23,10 @@ declare namespace commander {
   }
   type OptionConstructor = { new (flags: string, description?: string): Option };
 
+  interface ParseOptions {
+    from: "node" | "electron" | "user";
+  }
+
   interface Command {
     [key: string]: any; // options as properties
 
@@ -196,19 +200,30 @@ declare namespace commander {
 
     /**
      * Parse `argv`, setting options and invoking commands when defined.
+     * 
+     * The default expectation is that the arguments are from node and have the application as argv[0]
+     * and the script being run in argv[1], with user parameters after that.
      *
+     * Examples:
+     *
+     *      program.parse(); // implicitly use process.argv and auto-detect node vs electron conventions
+     *      program.parse(process.argv);
+     *      program.parse(my-args, { from: 'user' }); // just user supplied arguments, nothing special about argv[0]
+     * 
      * @returns Command for chaining
      */
-    parse(argv: string[]): Command;
+    parse(argv?: string[], options?: ParseOptions): Command;
 
     /**
     * Parse `argv`, setting options and invoking commands when defined.
     * 
     * Use parseAsync instead of parse if any of your action handlers are async. Returns a Promise.
+    * 
+    * (See .parse for additional details and examples.)
     *
     * @returns Promise
     */
-    parseAsync(argv: string[]): Promise<any>;
+    parseAsync(argv?: string[], options?: ParseOptions): Promise<any>;
 
     /**
      * Parse options from `argv` removing known options,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -206,8 +206,8 @@ declare namespace commander {
      *
      * Examples:
      *
-     *      program.parse(); // implicitly use process.argv and auto-detect node vs electron conventions
      *      program.parse(process.argv);
+     *      program.parse(); // implicitly use process.argv and auto-detect node vs electron conventions
      *      program.parse(my-args, { from: 'user' }); // just user supplied arguments, nothing special about argv[0]
      * 
      * @returns Command for chaining
@@ -215,14 +215,21 @@ declare namespace commander {
     parse(argv?: string[], options?: ParseOptions): Command;
 
     /**
-    * Parse `argv`, setting options and invoking commands when defined.
-    * 
-    * Use parseAsync instead of parse if any of your action handlers are async. Returns a Promise.
-    * 
-    * (See .parse for additional details and examples.)
-    *
-    * @returns Promise
-    */
+     * Parse `argv`, setting options and invoking commands when defined.
+     * 
+     * Use parseAsync instead of parse if any of your action handlers are async. Returns a Promise.
+     * 
+     * The default expectation is that the arguments are from node and have the application as argv[0]
+     * and the script being run in argv[1], with user parameters after that.
+     *
+     * Examples:
+     *
+     *      program.parseAsync(process.argv);
+     *      program.parseAsync(); // implicitly use process.argv and auto-detect node vs electron conventions
+     *      program.parseAsync(my-args, { from: 'user' }); // just user supplied arguments, nothing special about argv[0]
+     *
+     * @returns Promise
+     */
     parseAsync(argv?: string[], options?: ParseOptions): Promise<any>;
 
     /**


### PR DESCRIPTION
# Pull Request

## Problem

When the parse arguments are not from node, it is somewhat clumsy massaging the arguments to match the expected conventions. The case I encounter myself is when writing tests. A case that has been reported is when hosting in electron.

Separately, in most casual cases the argument to parse is `process.argv`.

Related: #512

## Solution

- default to `process.argv` when arguments array not supplied
- add `from` option to make it easy to  handle other conventions

---

More code and longer README than I hoped, but useful and straight forward, see whether you think it it is useful enough. Could shift content from README to an example  to make it shorter.