### PR TITLE
Update README example for .on('command:*')

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -554,11 +554,13 @@ program.on('option:verbose', function () {
   process.env.VERBOSE = this.verbose;
 });
 
-// custom error on unknown command
 program.on('command:*', function (operands) {
-  console.error(`Invalid command '${operands[0]}'. Did you mean:`);
-  console.error(mySuggestions(operands[0]));
-  process.exit(1);
+  console.error(`error: unknown command '${operands[0]}'`);
+  const availableCommands = program.commands.map(cmd => cmd.name());
+  const suggestion = didYouMean(operands[0], availableCommands);
+  if (suggestion)
+    console.error(`Did you mean '${suggestion}'?`);
+  process.exitCode = 1;
 });
 ```
 


### PR DESCRIPTION
# Pull Request

## Problem

A handler for `.on('command:*')` is no longer needed just to show an error message, as we do that by default, so would like a new example in the README.

It was suggested we add built-in support to recommend matching command, but do not want to that for now since it would add a dependency: #1015 

The example code directly calls `process.exit()` which is not recommended.

Was:
```
// error on unknown commands
program.on('command:*', function () {
  console.error('Invalid command: %s\nSee --help for a list of available commands.', program.args.join(' '));
  process.exit(1);
});
```

## Solution

Use actual code for `didYouMean` as the example.

Follow best practice and do not directly call `.exit()`

```
program.on('command:*', function (operands) {
  console.error(`error: unknown command '${operands[0]}'`);
  const availableCommands = program.commands.map(cmd => cmd.name());
  const suggestion = didYouMean(operands[0], availableCommands);
  if (suggestion)
    console.error(`Did you mean '${suggestion}'?`);
  process.exitCode = 1;
});
```