### PR TITLE
Suggest help when unknown command

### DIFF
--- a/index.js
+++ b/index.js
@@ -1124,7 +1124,12 @@ class Command extends EventEmitter {
    */
 
   unknownCommand() {
-    const message = `error: unknown command '${this.args[0]}'`;
+    const partCommands = [this.name()];
+    for (let parentCmd = this.parent; parentCmd; parentCmd = parentCmd.parent) {
+      partCommands.unshift(parentCmd.name());
+    }
+    const fullCommand = partCommands.join(' ');
+    const message = `error: unknown command '${this.args[0]}'. See '${fullCommand} --help'.`;
     console.error(message);
     this._exit(1, 'commander.unknownCommand', message);
   };

--- a/index.js
+++ b/index.js
@@ -1129,7 +1129,7 @@ class Command extends EventEmitter {
       partCommands.unshift(parentCmd.name());
     }
     const fullCommand = partCommands.join(' ');
-    const message = `error: unknown command '${this.args[0]}'. See '${fullCommand} --help'.`;
+    const message = `error: unknown command '${this.args[0]}'. See '${fullCommand} ${this._helpLongFlag}'.`;
     console.error(message);
     this._exit(1, 'commander.unknownCommand', message);
   };

--- a/tests/command.exitOverride.test.js
+++ b/tests/command.exitOverride.test.js
@@ -54,6 +54,7 @@ describe('.exitOverride and error details', () => {
   test('when specify unknown command then throw CommanderError', () => {
     const program = new commander.Command();
     program
+      .name('prog')
       .exitOverride()
       .command('sub');
 
@@ -65,7 +66,7 @@ describe('.exitOverride and error details', () => {
     }
 
     expect(consoleErrorSpy).toHaveBeenCalled();
-    expectCommanderError(caughtErr, 1, 'commander.unknownCommand', "error: unknown command 'oops'");
+    expectCommanderError(caughtErr, 1, 'commander.unknownCommand', "error: unknown command 'oops'. See 'prog --help'.");
   });
 
   // Same error as above, but with custom handler.


### PR DESCRIPTION
# Pull Request

## Problem

New users may not know how to get help. We have a new error in Command v5 for unknown commands so a good place to try an improvement.

We have:
```
$ node nested.js silly     
error: unknown command 'silly'
```

Other programs:

```
$ git unrecognised
git: 'unrecognised' is not a git command. See 'git --help'.
$ hg unrecognised
hg: unknown command 'unrecognised'
(use 'hg help' for a list of commands)
$ docker unrecognised
docker: 'unrecognised' is not a docker command.
See 'docker --help'
```

## Solution

Suggest `--help`. 

Notes:
- suggesting help option rather than implicit help command, since always available

```
$ node nested.js silly
error: unknown command 'silly'. See 'nested --help'.
```

