### PR TITLE
[Docs]: require didyoumean.js lib before use

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -550,6 +550,8 @@ program.addHelpCommand('assist [command]', 'show assistance');
 You can execute custom actions by listening to command and option events.
 
 ```js
+const didYouMean = require('didyoumean');
+
 program.on('option:verbose', function () {
   process.env.VERBOSE = this.verbose;
 });


### PR DESCRIPTION
# Pull Request

## Problem

`didyoumean.js` was used directly in the example without importing the respective package.

Follow up of #1176 
Addresses #1015 

## Solution

Added the necessary `require` statement.