### PR TITLE
Type commands property

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -32,6 +32,8 @@ declare namespace commander {
 
     args: string[];
 
+    commands: Command[];
+
     /**
      * Set the program version to `str`. 
      *


### PR DESCRIPTION
# Pull Request

## Problem

Since `parent` and `commands` properties do not start with underscore i assume that they are not private. And i see no potential issue with adding types for them, unless i am mistaken in my initial assumption.

## Solution

Added types for them, marking them as readonly to show that a user needs to use `addCommand` if he wants to modify them. 