### PR TITLE
Add construct option to customise creation of a command

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,7 +160,8 @@ class Command extends EventEmitter {
     }
     opts = opts || {};
     const args = nameAndArgs.split(/ +/);
-    const cmd = new Command(args.shift());
+    const name = args.shift();
+    const cmd = opts.construct ? opts.construct(name) : new Command(name);
 
     if (desc) {
       cmd.description(desc);

--- a/tests/command.construct.test.js
+++ b/tests/command.construct.test.js
@@ -1,0 +1,13 @@
+const commander = require('../');
+
+test('when pass construct option then it is used for creating command', () => {
+  const program = new commander.Command();
+  const construct = (name) => {
+    const cmd = new commander.Command(name);
+    cmd.custom = 'value';
+    return cmd;
+  };
+  const cmd = program
+    .command('secret', { construct });
+  expect(cmd).toHaveProperty('custom', 'value');
+});

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -336,6 +336,7 @@ declare namespace commander {
         noHelp?: boolean;
         isDefault?: boolean;
         executableFile?: string;
+        construct?: (name: string) => Command;
     }
 
     interface ParseOptionsResult {


### PR DESCRIPTION
# Pull Request

## Problem

Want a way to customise creation of a subcommand through `command` method, mainly to use my subclass as a constructor. Without this option i would have to override `command` method and copy-paste code from original `command` method which is definitely not an optimal way.

## Solution

Add `construct` option which if present is responsible for creating a command instance.

Can also make types more specific with generics, changing these lines:
```ts
interface Command {

  // from
  command(nameAndArgs: string, opts?: CommandOptions): Command;
  // to
  command<T extends Command = Command>(nameAndArgs: string, opts?: CommandOptions<T>): T;

}

// from
interface CommandOptions {
  construct?: (name: string) => Command;
}
// to
interface CommandOptions<T extends Command = Command> {
  construct?: (name: string) => T;
}
```

But wanted to keep changes small, so not included these changes to types.