### PR TITLE
Transfer settings in addCommand

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -90,7 +90,7 @@ declare namespace commander {
      * 
      * @returns parent command for chaining
      */
-    addCommand(cmd: Command): this;
+    addCommand(cmd: Command, opts?: commander.AddCommandOptions): this;
 
     /**
      * Define argument syntax for the top-level command.
@@ -338,6 +338,13 @@ declare namespace commander {
         noHelp?: boolean;
         isDefault?: boolean;
         executableFile?: string;
+    }
+
+    interface AddCommandOptions {
+        noHelp?: boolean;
+        isDefault?: boolean;
+        inheritHelp?: boolean;
+        inheritExit?: boolean;
     }
 
     interface ParseOptionsResult {


### PR DESCRIPTION
# Pull Request

## Problem

Currently there is no way to transfer private settings (related to help, where options are stored, exit callback and so on) to a command added through `addCommand`. (Connected to discussion in #1185.)

## Solution

Transfer settings in `addCommand`. Can add an option to `CommandOptions` (`inheritSettings` or something) to conditionally transfer this settings with it being true by default in `command()` and false in direct call to `addCommand`.
