### PR TITLE
Add parse result test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 * TypeScript fluent return types changed to be more subclass friendly, return `this` rather than `Command` ([#1180])
+* `.parseAsync` returns `Promise<this>` to be consistent with `.parse()` ([#1180])
 
 ## [5.0.0-1] (2020-02-08)
 

--- a/tests/command.parse.test.js
+++ b/tests/command.parse.test.js
@@ -52,3 +52,23 @@ describe('.parse() user args', () => {
     expect(program.args).toEqual(['user']);
   });
 });
+
+describe('return type', () => {
+  test('when call .parse then returns program', () => {
+    const program = new commander.Command();
+    program
+      .action(() => { });
+
+    const result = program.parse(['node', 'test']);
+    expect(result).toBe(program);
+  });
+
+  test('when await .parseAsync then returns program', async() => {
+    const program = new commander.Command();
+    program
+      .action(() => { });
+
+    const result = await program.parseAsync(['node', 'test']);
+    expect(result).toBe(program);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Problem

No tests on what `.parse()` and `.parseAsync()`  return, and we recently changed what `.parseAsync()` returns.

## Solution

Add simple tests.
