### PR TITLE
Shorten example fragment and make obvious which code to supply

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -557,9 +557,7 @@ program.on('option:verbose', function () {
 program.on('command:*', function (operands) {
   console.error(`error: unknown command '${operands[0]}'`);
   const availableCommands = program.commands.map(cmd => cmd.name());
-  const suggestion = didYouMean(operands[0], availableCommands);
-  if (suggestion)
-    console.error(`Did you mean '${suggestion}'?`);
+  mySuggestBestMatch(operands[0], availableCommands);
   process.exitCode = 1;
 });
 ```


### PR DESCRIPTION
# Pull Request

## Problem

The new example had more code than was needed, and was (deliberately) missing a `require` for the real module being used in the code fragment.

Added in #1176

## Solution

Use an obvious placeholder for the "suggest" part of the code, and shorten the example.

