### PR TITLE
createCommand factory routine

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -633,14 +633,14 @@ node -r ts-node/register pm.ts
 
 ### createCommand()
 
-This factory function creates a new command rather than a subcommand. It is exported and may be used instead of using `new`, like:
+This factory function creates a new command. It is exported and may be used instead of using `new`, like:
 
 ```js
 const { createCommand } = require('commander');
 const program = createCommand();
 ```
 
-`createCommand` is also a method of the Command object. This gets used internally
+`createCommand` is also a method of the Command object, and creates a new command rather than a subcommand. This gets used internally
 when creating subcommands using `.command()`, and you may override it to
 customise the new subcommand (examples using [subclass](./examples/custom-command-class.js) and [function](./examples/custom-command-function.js)).
 

--- a/Readme.md
+++ b/Readme.md
@@ -36,6 +36,7 @@ Read this in other languages: English | [简体中文](./Readme_zh-CN.md)
     - [.parse() and .parseAsync()](#parse-and-parseasync)
     - [Avoiding option name clashes](#avoiding-option-name-clashes)
     - [TypeScript](#typescript)
+    - [createCommand()](#createcommand)
     - [Node options such as `--harmony`](#node-options-such-as---harmony)
     - [Debugging stand-alone executable subcommands](#debugging-stand-alone-executable-subcommands)
     - [Override exit handling](#override-exit-handling)
@@ -629,6 +630,19 @@ If you use `ts-node` and  stand-alone executable subcommands written as `.ts` fi
 ```bash
 node -r ts-node/register pm.ts
 ```
+
+### createCommand()
+
+This factory function creates a new command rather than a subcommand. It is exported and may be used instead of using `new`, like:
+
+```js
+const { createCommand } = require('commander');
+const program = createCommand();
+```
+
+`createCommand` is also a method of the Command object. This gets used internally
+when creating subcommands using `.command()`, and you may override it to
+customise the new subcommand (examples using [subclass](./examples/custom-command-class.js) and [function](./examples/custom-command-function.js)).
 
 ### Node options such as `--harmony`
 

--- a/examples/custom-command-class.js
+++ b/examples/custom-command-class.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+
+// const commander = require('commander'); // (normal include)
+const commander = require('../'); // include commander in git clone of commander repo
+
+class MyCommand extends commander.Command {
+  createCommand(name) {
+    const cmd = new MyCommand(name);
+    cmd.option('-d,--debug', 'output options');
+    return cmd;
+  }
+};
+
+const program = new MyCommand();
+program
+  .command('demo')
+  .option('--port <port-number>', 'specify port number', 80)
+  .action((cmd) => {
+    if (cmd.debug) {
+      console.log('Options:');
+      console.log(cmd.opts());
+      console.log();
+    }
+
+    console.log(`Start serve on port ${cmd.port}`);
+  });
+
+program.parse();
+
+// Try the following:
+//    node custom-command-class.js help demo
+//    node custom-command-class.js demo --debug
+//    node custom-command-class.js demo --debug --port 8080

--- a/examples/custom-command-class.js
+++ b/examples/custom-command-class.js
@@ -3,6 +3,9 @@
 // const commander = require('commander'); // (normal include)
 const commander = require('../'); // include commander in git clone of commander repo
 
+// Use a class override of createCommand to customise subcommands,
+// in this example by adding --debug option.
+
 class MyCommand extends commander.Command {
   createCommand(name) {
     const cmd = new MyCommand(name);
@@ -13,7 +16,7 @@ class MyCommand extends commander.Command {
 
 const program = new MyCommand();
 program
-  .command('demo')
+  .command('serve')
   .option('--port <port-number>', 'specify port number', 80)
   .action((cmd) => {
     if (cmd.debug) {
@@ -28,6 +31,6 @@ program
 program.parse();
 
 // Try the following:
-//    node custom-command-class.js help demo
-//    node custom-command-class.js demo --debug
-//    node custom-command-class.js demo --debug --port 8080
+//    node custom-command-class.js help serve
+//    node custom-command-class.js serve --debug
+//    node custom-command-class.js serve --debug --port 8080

--- a/examples/custom-command-function.js
+++ b/examples/custom-command-function.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+
+// const commander = require('commander'); // (normal include)
+const commander = require('../'); // include commander in git clone of commander repo
+
+const program = commander.createCommand();
+
+// Customise subcommand creation
+program.createCommand = (name) => {
+  const cmd = commander.createCommand(name);
+  cmd.option('-d,--debug', 'output options');
+  return cmd;
+};
+
+program
+  .command('demo')
+  .option('--port <port-number>', 'specify port number', 80)
+  .action((cmd) => {
+    if (cmd.debug) {
+      console.log('Options:');
+      console.log(cmd.opts());
+      console.log();
+    }
+
+    console.log(`Start serve on port ${cmd.port}`);
+  });
+
+program.parse();
+
+// Try the following:
+//    node custom-command-function.js help demo
+//    node custom-command-function.js demo --debug
+//    node custom-command-function.js demo --debug --port 8080

--- a/examples/custom-command-function.js
+++ b/examples/custom-command-function.js
@@ -3,6 +3,9 @@
 // const commander = require('commander'); // (normal include)
 const commander = require('../'); // include commander in git clone of commander repo
 
+// Override createCommand directly to customise subcommands,
+// in this example by adding --debug option.
+
 const program = commander.createCommand();
 
 // Customise subcommand creation
@@ -13,7 +16,7 @@ program.createCommand = (name) => {
 };
 
 program
-  .command('demo')
+  .command('serve')
   .option('--port <port-number>', 'specify port number', 80)
   .action((cmd) => {
     if (cmd.debug) {
@@ -28,6 +31,6 @@ program
 program.parse();
 
 // Try the following:
-//    node custom-command-function.js help demo
-//    node custom-command-function.js demo --debug
-//    node custom-command-function.js demo --debug --port 8080
+//    node custom-command-function.js help serve
+//    node custom-command-function.js serve --debug
+//    node custom-command-function.js serve --debug --port 8080

--- a/index.js
+++ b/index.js
@@ -160,7 +160,7 @@ class Command extends EventEmitter {
     }
     opts = opts || {};
     const args = nameAndArgs.split(/ +/);
-    const cmd = new Command(args.shift());
+    const cmd = this.createCommand(args.shift());
 
     if (desc) {
       cmd.description(desc);
@@ -187,6 +187,21 @@ class Command extends EventEmitter {
 
     if (desc) return this;
     return cmd;
+  };
+
+  /**
+   * Factory routine to create a new command.
+   *
+   * Used internally to create subcommands. May be overridden to
+   * customise subcommands.
+   *
+   * @param {string} [name]
+   * @return {Command} parent command for chaining
+   * @api public
+   */
+
+  createCommand(name) {
+    return new Command(name);
   };
 
   /**

--- a/index.js
+++ b/index.js
@@ -196,10 +196,10 @@ class Command extends EventEmitter {
   };
 
   /**
-   * Factory routine to create a new command.
+   * Factory routine to create a new unattached command.
    *
-   * Used internally to create subcommands. May be overridden to
-   * customise subcommands.
+   * See .command() for creating an attached subcommand, which uses this routine to 
+   * create the command. You can override createCommand to customise subcommands.
    *
    * @param {string} [name]
    * @return {Command} new command

--- a/index.js
+++ b/index.js
@@ -213,6 +213,8 @@ class Command extends EventEmitter {
   /**
    * Add a prepared subcommand.
    *
+   * See .command() for creating an attached subcommand which inherits settings from its parent.
+   *
    * @param {Command} cmd - new subcommand
    * @return {Command} parent command for chaining
    * @api public

--- a/index.js
+++ b/index.js
@@ -198,7 +198,7 @@ class Command extends EventEmitter {
   /**
    * Factory routine to create a new unattached command.
    *
-   * See .command() for creating an attached subcommand, which uses this routine to 
+   * See .command() for creating an attached subcommand, which uses this routine to
    * create the command. You can override createCommand to customise subcommands.
    *
    * @param {string} [name]

--- a/index.js
+++ b/index.js
@@ -196,7 +196,7 @@ class Command extends EventEmitter {
    * customise subcommands.
    *
    * @param {string} [name]
-   * @return {Command} parent command for chaining
+   * @return {Command} new command
    * @api public
    */
 

--- a/tests/createCommand.test.js
+++ b/tests/createCommand.test.js
@@ -1,0 +1,36 @@
+const commander = require('../');
+
+test('when createCommand then unattached', () => {
+  const program = new commander.Command();
+  const cmd = program.createCommand();
+  expect(program.commands.length).toBe(0);
+  expect(cmd.parent).toBeUndefined();
+});
+
+test('when subclass overrides createCommand then subcommand is subclass', () => {
+  class MyClass extends commander.Command {
+    constructor(name) {
+      super();
+      this.myProperty = 'myClass';
+    };
+
+    createCommand(name) {
+      return new MyClass(name);
+    };
+  };
+  const program = new MyClass();
+  const sub = program.command('sub');
+  expect(sub.myProperty).toEqual('myClass');
+});
+
+test('when override createCommand then subcommand is custom', () => {
+  function createCustom(name) {
+    const cmd = new commander.Command();
+    cmd.myProperty = 'custom';
+    return cmd;
+  }
+  const program = createCustom();
+  program.createCommand = createCustom;
+  const sub = program.command('sub');
+  expect(sub.myProperty).toEqual('custom');
+});

--- a/tests/createCommand.test.js
+++ b/tests/createCommand.test.js
@@ -4,7 +4,7 @@ test('when createCommand then unattached', () => {
   const program = new commander.Command();
   const cmd = program.createCommand();
   expect(program.commands.length).toBe(0);
-  expect(cmd.parent).toBeUndefined();
+  expect(cmd.parent).toBeFalsy(); // (actually null, but use weaker test for unattached)
 });
 
 test('when subclass overrides createCommand then subcommand is subclass', () => {

--- a/typings/commander-tests.ts
+++ b/typings/commander-tests.ts
@@ -126,6 +126,9 @@ program
 const preparedCommand = new program.Command('prepared');
 program.addCommand(preparedCommand);
 
+const c1 = program.createCommand();
+const c2 = c1.createCommand();
+
 program
     .exitOverride();
 

--- a/typings/commander-tests.ts
+++ b/typings/commander-tests.ts
@@ -127,7 +127,29 @@ const preparedCommand = new program.Command('prepared');
 program.addCommand(preparedCommand);
 
 const c1 = program.createCommand();
-const c2 = c1.createCommand();
+c1.version('1.2.3');
+
+class MyCommand extends program.Command {
+  constructor(name?: string) {
+    super(name);
+  }
+
+  createCommand(name?: string) {
+    return new MyCommand(name);
+  }
+  myFunction() {}
+
+  // Modify return type for command (experimenting)
+  command(nameAndArgs: string, opts?: program.CommandOptions): MyCommand;
+  command(nameAndArgs: string, description: string, opts?: program.CommandOptions): this;
+  command(nameAndArgs: string, actionOptsOrExecDesc?: any, execOpts?: program.CommandOptions): MyCommand | this {
+    return super.command(nameAndArgs, actionOptsOrExecDesc, execOpts);
+  }
+}
+const myProgram = new MyCommand();
+myProgram.myFunction();
+const mySub = myProgram.command('sub');
+mySub.myFunction();
 
 program
     .exitOverride();

--- a/typings/commander-tests.ts
+++ b/typings/commander-tests.ts
@@ -191,10 +191,6 @@ const onThis: commander.Command = program.on('--help', () => { })
 const createInstance: commander.Command = program.createCommand();
 
 class MyCommand extends commander.Command {
-  constructor(name?: string) {
-    super(name);
-  }
-
    createCommand(name?: string) {
     return new MyCommand(name);
   }
@@ -202,5 +198,5 @@ class MyCommand extends commander.Command {
 }
 const myProgram = new MyCommand();
 myProgram.myFunction();
-const mySub: CommandWithoutOptionsAsProperties = myProgram.command('sub');
+const mySub = myProgram.command('sub');
 mySub.myFunction();

--- a/typings/commander-tests.ts
+++ b/typings/commander-tests.ts
@@ -188,7 +188,8 @@ const onThis: commander.Command = program.on('--help', () => { })
 
 // createCommand
 
-const createInstance: commander.Command = program.createCommand();
+const createInstance1: commander.Command = program.createCommand();
+const createInstance2: commander.Command = program.createCommand('name');
 
 class MyCommand extends commander.Command {
    createCommand(name?: string) {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -86,10 +86,10 @@ declare namespace commander {
     command(nameAndArgs: string, description: string, opts?: commander.CommandOptions): this;
 
     /**
-     * Factory routine to create a new command.
+     * Factory routine to create a new unattached command.
      *
-     * Used internally to create subcommands. May be overridden to
-     * customise subcommands.
+     * See .command() for creating an attached subcommand, which uses this routine to 
+     * create the command. You can override createCommand to customise subcommands.
      */
     createCommand(name?: string): Command;
     

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -91,7 +91,7 @@ declare namespace commander {
      * Used internally to create subcommands. May be overridden to
      * customise subcommands.
      */
-    createCommand(name?: string): this;
+    createCommand(name?: string): Command;
     
     /**
      * Add a prepared subcommand.

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -96,6 +96,8 @@ declare namespace commander {
     /**
      * Add a prepared subcommand.
      * 
+     * See .command() for creating an attached subcommand which inherits settings from its parent.
+     * 
      * @returns parent command for chaining
      */
     addCommand(cmd: Command): this;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -88,7 +88,7 @@ declare namespace commander {
     /**
      * Factory routine to create a new unattached command.
      *
-     * See .command() for creating an attached subcommand, which uses this routine to 
+     * See .command() for creating an attached subcommand, which uses this routine to
      * create the command. You can override createCommand to customise subcommands.
      */
     createCommand(name?: string): Command;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -64,7 +64,7 @@ declare namespace commander {
      * @param opts - configuration options
      * @returns new command
      */
-    command(nameAndArgs: string, opts?: CommandOptions): Command;
+    command(nameAndArgs: string, opts?: CommandOptions): ReturnType< this[ 'createCommand' ] >;
     /**
      * Define a command, implemented in a separate executable file.
      * 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -24,7 +24,7 @@ declare namespace commander {
   type OptionConstructor = { new (flags: string, description?: string): Option };
 
   interface ParseOptions {
-    from: "node" | "electron" | "user";
+    from: 'node' | 'electron' | 'user';
   }
 
   interface Command {
@@ -64,7 +64,7 @@ declare namespace commander {
      * @param opts - configuration options
      * @returns new command
      */
-    command(nameAndArgs: string, opts?: CommandOptions): ReturnType< this[ 'createCommand' ] >;
+    command(nameAndArgs: string, opts?: CommandOptions): ReturnType<this['createCommand']>;
     /**
      * Define a command, implemented in a separate executable file.
      * 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -86,6 +86,14 @@ declare namespace commander {
     command(nameAndArgs: string, description: string, opts?: commander.CommandOptions): this;
 
     /**
+     * Factory routine to create a new command.
+     *
+     * Used internally to create subcommands. May be overridden to
+     * customise subcommands.
+     */
+    createCommand(name?: string): this;
+    
+    /**
      * Add a prepared subcommand.
      * 
      * @returns parent command for chaining


### PR DESCRIPTION
# Pull Request

Related: #1002 #1185 

## Problem

- some people prefer factory routine to using `new`
- awkward to subclass Command
- awkward to customise Command (without using subclass)

## Solution

Add a factory routine, which can be overridden.