### PR TITLE
Add program to exports

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -56,7 +56,7 @@ Commander exports a global object which is convenient for quick programs.
 This is used in the examples in this README for brevity.
 
 ```js
-const program = require('commander');
+const program = require('commander').program;
 program.version('0.0.1');
 ```
 

--- a/index.js
+++ b/index.js
@@ -1523,6 +1523,7 @@ class Command extends EventEmitter {
  */
 
 exports = module.exports = new Command();
+exports.program = exports; // More explicit access to global command.
 
 /**
  * Expose classes

--- a/tests/program.test.js
+++ b/tests/program.test.js
@@ -1,0 +1,20 @@
+const commander = require('../');
+
+// Do some testing of the default export(s).
+
+test('when require commander then is a Command (default export of global)', () => {
+  // Legacy global command
+  const program = commander;
+  expect(program.constructor.name).toBe('Command');
+});
+
+test('when require commander then has program (named export of global)', () => {
+  // program added in v5
+  const program = commander.program;
+  expect(program.constructor.name).toBe('Command');
+});
+
+test('when require commander then has newable Command', () => {
+  const cmd = new commander.Command();
+  expect(cmd.constructor.name).toBe('Command');
+});


### PR DESCRIPTION
# Pull Request

Trying out an idea. See what you think...

## Problem

commander started out with just a default export of a root command. The ability to create a new Command was added later in a backwards compatible way, and is now the recommended way to use commander. 

The combination of a global default export of the root command and named export of Command is a little clumsy.

```
const program = require('commander');

vs

const commander = require('commander');
const program = new commander.Command();
```

## Solution

Add a named export for `program` so a more explicit way of using the global root command and more symmetry with named exports.

```
const program = require('commander').program;
```

(Might eventually make this the only way of accessing the global, one day...)