### PR TITLE
Define option multiple times on command line

### DIFF
--- a/index.js
+++ b/index.js
@@ -609,7 +609,7 @@ class Command extends EventEmitter {
   /**
    * Store option value
    *
-   * @param {String} key
+   * @param {string} key
    * @param {Object} value
    * @param {boolean} multiple
    * @api private
@@ -629,7 +629,7 @@ class Command extends EventEmitter {
   /**
    * Remove option value from storage
    *
-   * @param {String} key
+   * @param {string} key
    * @param {Object} value
    * @api private
    */
@@ -846,7 +846,7 @@ class Command extends EventEmitter {
  - if '${subcommand._name}' is not meant to be an executable command, remove description parameter from '.command()' and use '.description()' instead
  - if the default executable name is not suitable, use the executableFile option to supply a custom name`;
         throw new Error(executableMissing);
-        // @ts-ignore
+      // @ts-ignore
       } else if (err.code === 'EACCES') {
         throw new Error(`'${bin}' not executable`);
       }
@@ -1299,9 +1299,9 @@ class Command extends EventEmitter {
 
       return [
         cmd._name +
-        (cmd._alias ? '|' + cmd._alias : '') +
-        (cmd.options.length ? ' [options]' : '') +
-        (args ? ' ' + args : ''),
+          (cmd._alias ? '|' + cmd._alias : '') +
+          (cmd.options.length ? ' [options]' : '') +
+          (args ? ' ' + args : ''),
         cmd._description
       ];
     });

--- a/tests/options.mandatory.multiple.test.js
+++ b/tests/options.mandatory.multiple.test.js
@@ -1,0 +1,100 @@
+const commander = require('..');
+
+// Assuming mandatory options behave as normal options apart from the mandatory aspect, not retesting all behaviour.
+// Likewise, not redoing all tests on subcommand after testing on program.
+
+describe('required program option with multiple mandatory values specified', () => {
+  test('when program has required value specified then value as specified', () => {
+    const program = new commander.Command();
+    program
+      .exitOverride()
+      .requiredOption('--cheese <type>+', 'cheese type');
+    program.parse(['node', 'test', '--cheese', 'blue']);
+    expect(program.cheese).toEqual(['blue']);
+  });
+
+  test('when program has option with name different than property then still recognised', () => {
+    const program = new commander.Command();
+    program
+      .exitOverride()
+      .requiredOption('--cheese-type <type>+', 'cheese type');
+    program.parse(['node', 'test', '--cheese-type', 'blue']);
+    expect(program.cheeseType).toEqual(['blue']);
+  });
+
+  test('when program has required value default then default value', () => {
+    const program = new commander.Command();
+    program
+      .exitOverride()
+      .requiredOption('--cheese <type>+', 'cheese type', 'default');
+    program.parse(['node', 'test']);
+    expect(program.cheese).toEqual(['default']);
+  });
+
+  test('when program has optional value flag specified then true', () => {
+    const program = new commander.Command();
+    program
+      .exitOverride()
+      .requiredOption('--cheese [type]+', 'cheese type');
+    program.parse(['node', 'test', '--cheese']);
+    expect(program.cheese).toEqual([true]);
+  });
+
+  test('when program has optional value default then default value', () => {
+    const program = new commander.Command();
+    program
+      .exitOverride()
+      .requiredOption('--cheese [type]+', 'cheese type', 'default');
+    program.parse(['node', 'test']);
+    expect(program.cheese).toEqual(['default']);
+  });
+
+  test('when program has value/no flag specified with value then specified value', () => {
+    const program = new commander.Command();
+    program
+      .exitOverride()
+      .requiredOption('--cheese <type>+', 'cheese type')
+      .requiredOption('--no-cheese', 'no cheese thanks');
+    program.parse(['node', 'test', '--cheese', 'blue']);
+    expect(program.cheese).toEqual(['blue']);
+  });
+
+  test('when program has yes/no flag specified negated then false', () => {
+    const program = new commander.Command();
+    program
+      .exitOverride()
+      .requiredOption('--cheese <type>+', 'cheese type')
+      .option('--no-cheese', 'no cheese thanks');
+    program.parse(['node', 'test', '--no-cheese']);
+    expect(program.cheese).toBe(false);
+  });
+
+  test('when program has required value specified and subcommand then specified value', () => {
+    const program = new commander.Command();
+    program
+      .exitOverride()
+      .requiredOption('--cheese <type>+', 'cheese type')
+      .command('sub')
+      .action(() => { });
+    program.parse(['node', 'test', '--cheese', 'blue', 'sub']);
+    expect(program.cheese).toEqual(['blue']);
+  });
+});
+
+describe('required command option with multiple mandatory values specified', () => {
+  test('when command has required value specified then specified value', () => {
+    const program = new commander.Command();
+    let cmdOptions;
+    program
+      .exitOverride()
+      .command('sub')
+      .requiredOption('--subby <type>+', 'description')
+      .action((cmd) => {
+        cmdOptions = cmd;
+      });
+
+    program.parse(['node', 'test', 'sub', '--subby', 'blue']);
+
+    expect(cmdOptions.subby).toEqual(['blue']);
+  });
+});

--- a/tests/options.optional.multiple.test.js
+++ b/tests/options.optional.multiple.test.js
@@ -1,0 +1,70 @@
+const commander = require('../');
+
+// option with multiple optional values, no default
+describe('option with multiple optional values, no default', () => {
+  test('when option not specified then value is undefined', () => {
+    const program = new commander.Command();
+    program
+      .option('--cheese [type]+', 'cheese type');
+    program.parse(['node', 'test']);
+    expect(program.cheese).toBeUndefined();
+  });
+
+  test('when option specified then value is as specified', () => {
+    const program = new commander.Command();
+    program
+      .option('--cheese [type]+', 'cheese type');
+    const cheeseType = 'blue';
+    program.parse(['node', 'test', '--cheese', cheeseType]);
+    expect(program.cheese).toEqual([cheeseType]);
+  });
+
+  test('when option specified without value then value is true', () => {
+    const program = new commander.Command();
+    program
+      .option('--cheese [type]+', 'cheese type');
+    program.parse(['node', 'test', '--cheese']);
+    expect(program.cheese).toEqual([true]);
+  });
+
+  test('when option specified without value and following option then value is true', () => {
+    // optional options do not eat values with dashes
+    const program = new commander.Command();
+    program
+      .option('--cheese [type]+', 'cheese type')
+      .option('--some-option');
+    program.parse(['node', 'test', '--cheese', '--some-option']);
+    expect(program.cheese).toEqual([true]);
+  });
+});
+
+// option with multiple optional values, with default
+describe('option with multiple optional value, with default', () => {
+  test('when option not specified then value is default', () => {
+    const defaultValue = 'default';
+    const program = new commander.Command();
+    program
+      .option('--cheese [type]+', 'cheese type', defaultValue);
+    program.parse(['node', 'test']);
+    expect(program.cheese).toEqual([defaultValue]);
+  });
+
+  test('when option specified then value is as specified', () => {
+    const defaultValue = 'default';
+    const program = new commander.Command();
+    program
+      .option('--cheese [type]+', 'cheese type', defaultValue);
+    const cheeseType = 'blue';
+    program.parse(['node', 'test', '--cheese', cheeseType]);
+    expect(program.cheese).toEqual([cheeseType]);
+  });
+
+  test('when option specified without value then value is default', () => {
+    const defaultValue = 'default';
+    const program = new commander.Command();
+    program
+      .option('--cheese [type]+', 'cheese type', defaultValue);
+    program.parse(['node', 'test', '--cheese']);
+    expect(program.cheese).toEqual([defaultValue]);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Problem

This is not related to any issue, since I'd rather file a PR with a (proposed) solution than creating an issue.

I looked for the possibility to define multiple options of the same type/name, like this:

```bash
$ pizza-options --cheese stilton --cheese cheddar --cheese gouda
```

Currently the only way to define multiple values for an options is this way:

```bash
$ pizza-options --cheese stilton, cheddar, gouda
```

The rationale behind my idea is that it way cleaner and easier to use on the command line if you can define an option/parameter multiple times (with different values) rather than define an array of values for one option. A real-world example would be the `-e` option of `docker run`.

## Solution

My (proposed) solution is to create a new `this` attribute, called `multiple`. It is switched to true with this syntax:

```js
program
  .option('--cheese <flavour>+', 'cheese flavour')
  .option('--cheese[flavour]+', 'cheese flavour')
```

I'm not sure if this syntax (and especially the plus sign) is the best way to express this behaviour; I followed regular expression syntax, where a plus sign means basically _one or more occurrences of a token_.

This PR is to be considered as "focus on concept"-first.

## ChangeLog

That's hard. My first try:

```
### Added

* plus sign (`+`) after an option argument indicates that this option can be used multiple times
```
