### PR TITLE
Describe fully supported node as LTS

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -711,7 +711,7 @@ More Demos can be found in the [examples](https://github.com/tj/commander.js/tre
 
 ## Support
 
-Commander 4.x is supported on Node 8 and above, and is likely to work with Node 6 but not tested.
+Commander 5.x is fully supported on Long Term Support versions of Node, and is likely to work with Node 6 but not tested.
 (For versions of Node below Node 6, use Commander 3.x or 2.x.)
 
 The main forum for free and community support is the project [Issues](https://github.com/tj/commander.js/issues) on GitHub.


### PR DESCRIPTION
# Pull Request

Update support description for Commander from 4.x to 5.x.

## Problem

Node 8 is no longer  supported by nodejs.org. Although we can currently test against it, eventually it won't be supported by Jest and our other development libraries.

## Solution

Say we fully support LTS versions of node to describe versions we will be able to test against long term without needing to update node version numbers as they move out of LTS.