### PR TITLE
Fixing lint errors in TypeScript

### DIFF
--- a/typings/commander-tests.ts
+++ b/typings/commander-tests.ts
@@ -1,11 +1,16 @@
 import * as commander from './index';
-import { Script } from 'vm';
 
 // Test Commander usage with TypeScript.
 // This is NOT a usable program, just used to test for compile errors!
 
+// We declare lots of variables just to check types of right-side of expression, so disable this:
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+// This conflicts with esline rule saying no space!
+/* eslint-disable @typescript-eslint/space-before-function-paren */
+
 // Defined stricter type, as the options as properties `[key: string]: any`
-// makes the type checking very weak. 
+// makes the type checking very weak.
 // https://github.com/Microsoft/TypeScript/issues/25987#issuecomment-441224690
 type KnownKeys<T> = {
   [K in keyof T]: string extends K ? never : number extends K ? never : K
@@ -28,6 +33,7 @@ const errorInstance = new commander.CommanderError(1, 'code', 'message');
 
 // Command properties
 console.log(programWithOptions.someOption);
+// eslint-disable-next-line dot-notation
 console.log(programWithOptions['someOption']);
 const theArgs = program.args;
 const theCommands: commander.Command[] = program.commands;
@@ -47,14 +53,14 @@ const commandThis2: commander.Command = program.command('exec', 'exec descriptio
 const addCommandThis: commander.Command = program.addCommand(new commander.Command('abc'));
 
 // arguments
-const argumentsThis: commander.Command = program.arguments('<cmd> [env]')
+const argumentsThis: commander.Command = program.arguments('<cmd> [env]');
 
 // exitOverride
 const exitThis1: commander.Command = program.exitOverride();
-const exitThis2: commander.Command = program.exitOverride((err):never => {
+const exitThis2: commander.Command = program.exitOverride((err): never => {
   return process.exit(err.exitCode);
 });
-const exitThis3: commander.Command = program.exitOverride((err):void => {
+const exitThis3: commander.Command = program.exitOverride((err): void => {
   if (err.code !== 'commander.executeSubCommandAsync') {
     throw err;
   } else {
@@ -63,57 +69,61 @@ const exitThis3: commander.Command = program.exitOverride((err):void => {
 });
 
 // action
-const actionThis1: commander.Command = program.action(() => { });
-const actionThis2: commander.Command = program.action(async () => { });
+const actionThis1: commander.Command = program.action(() => {
+  // do nothing.
+});
+const actionThis2: commander.Command = program.action(async() => {
+  // do nothing.
+});
 
 // option
 const optionThis1: commander.Command = program.option('-a,--alpha');
-const optionThis2: commander.Command = program.option('-p, --peppers', 'Add peppers')
-const optionThis3: commander.Command = program.option('-s, --string [value]', 'default string', 'value')
+const optionThis2: commander.Command = program.option('-p, --peppers', 'Add peppers');
+const optionThis3: commander.Command = program.option('-s, --string [value]', 'default string', 'value');
 const optionThis4: commander.Command = program.option('-b, --boolean', 'default boolean', false);
 
 // example coercion functions from README
 
-function range(val: string) {
+function range(val: string): Number[] {
   return val.split('..').map(Number);
 }
 
-function myParseInt(value: string, dummyPrevious: number) {
+function myParseInt(value: string, dummyPrevious: number): number {
   return parseInt(value);
 }
 
-function increaseVerbosity(dummyValue: string, previous: number) {
+function increaseVerbosity(dummyValue: string, previous: number): number {
   return previous + 1;
 }
 
-function collect(value: string, previous: string[]) {
+function collect(value: string, previous: string[]): string[] {
   return previous.concat([value]);
 }
 
-function commaSeparatedList(value: string, dummyPrevious: string[]) {
+function commaSeparatedList(value: string, dummyPrevious: string[]): string[] {
   return value.split(',');
 }
 
-const optionThis5: commander.Command = program.option('-f, --float <number>', 'float argument', parseFloat)
-const optionThis6: commander.Command = program.option('-f, --float <number>', 'float argument', parseFloat, 3.2)
-const optionThis7: commander.Command = program.option('-i, --integer <number>', 'integer argument', myParseInt)
-const optionThis8: commander.Command = program.option('-i, --integer <number>', 'integer argument', myParseInt, 5)
-const optionThis9: commander.Command = program.option('-v, --verbose', 'verbosity that can be increased', increaseVerbosity, 0)
-const optionThis10: commander.Command = program.option('-c, --collect <value>', 'repeatable value', collect, [])
+const optionThis5: commander.Command = program.option('-f, --float <number>', 'float argument', parseFloat);
+const optionThis6: commander.Command = program.option('-f, --float <number>', 'float argument', parseFloat, 3.2);
+const optionThis7: commander.Command = program.option('-i, --integer <number>', 'integer argument', myParseInt);
+const optionThis8: commander.Command = program.option('-i, --integer <number>', 'integer argument', myParseInt, 5);
+const optionThis9: commander.Command = program.option('-v, --verbose', 'verbosity that can be increased', increaseVerbosity, 0);
+const optionThis10: commander.Command = program.option('-c, --collect <value>', 'repeatable value', collect, []);
 const optionThis11: commander.Command = program.option('-l, --list <items>', 'comma separated list', commaSeparatedList);
 
 // requiredOption, same tests as option
 const requiredOptionThis1: commander.Command = program.requiredOption('-a,--alpha');
-const requiredOptionThis2: commander.Command = program.requiredOption('-p, --peppers', 'Add peppers')
-const requiredOptionThis3: commander.Command = program.requiredOption('-s, --string [value]', 'default string', 'value')
+const requiredOptionThis2: commander.Command = program.requiredOption('-p, --peppers', 'Add peppers');
+const requiredOptionThis3: commander.Command = program.requiredOption('-s, --string [value]', 'default string', 'value');
 const requiredOptionThis4: commander.Command = program.requiredOption('-b, --boolean', 'default boolean', false);
 
-const requiredOptionThis5: commander.Command = program.requiredOption('-f, --float <number>', 'float argument', parseFloat)
-const requiredOptionThis6: commander.Command = program.requiredOption('-f, --float <number>', 'float argument', parseFloat, 3.2)
-const requiredOptionThis7: commander.Command = program.requiredOption('-i, --integer <number>', 'integer argument', myParseInt)
-const requiredOptionThis8: commander.Command = program.requiredOption('-i, --integer <number>', 'integer argument', myParseInt, 5)
-const requiredOptionThis9: commander.Command = program.requiredOption('-v, --verbose', 'verbosity that can be increased', increaseVerbosity, 0)
-const requiredOptionThis10: commander.Command = program.requiredOption('-c, --collect <value>', 'repeatable value', collect, [])
+const requiredOptionThis5: commander.Command = program.requiredOption('-f, --float <number>', 'float argument', parseFloat);
+const requiredOptionThis6: commander.Command = program.requiredOption('-f, --float <number>', 'float argument', parseFloat, 3.2);
+const requiredOptionThis7: commander.Command = program.requiredOption('-i, --integer <number>', 'integer argument', myParseInt);
+const requiredOptionThis8: commander.Command = program.requiredOption('-i, --integer <number>', 'integer argument', myParseInt, 5);
+const requiredOptionThis9: commander.Command = program.requiredOption('-v, --verbose', 'verbosity that can be increased', increaseVerbosity, 0);
+const requiredOptionThis10: commander.Command = program.requiredOption('-c, --collect <value>', 'repeatable value', collect, []);
 const requiredOptionThis11: commander.Command = program.requiredOption('-l, --list <items>', 'comma separated list', commaSeparatedList);
 
 // storeOptionsAsProperties
@@ -133,14 +143,14 @@ const parseThis1: commander.Command = program.parse();
 const parseThis2: commander.Command = program.parse(process.argv);
 const parseThis3: commander.Command = program.parse(['node', 'script.js'], { from: 'node' });
 const parseThis4: commander.Command = program.parse(['node', 'script.js'], { from: 'electron' });
-const parseThis5: commander.Command = program.parse(['--option'], { from: "user" });
+const parseThis5: commander.Command = program.parse(['--option'], { from: 'user' });
 
 // parseAsync, same tests as parse
 const parseAsyncThis1: Promise<commander.Command> = program.parseAsync();
 const parseAsyncThis2: Promise<commander.Command> = program.parseAsync(process.argv);
 const parseAsyncThis3: Promise<commander.Command> = program.parseAsync(['node', 'script.js'], { from: 'node' });
 const parseAsyncThis4: Promise<commander.Command> = program.parseAsync(['node', 'script.js'], { from: 'electron' });
-const parseAsyncThis5: Promise<commander.Command> = program.parseAsync(['--option'], { from: "user" });
+const parseAsyncThis5: Promise<commander.Command> = program.parseAsync(['--option'], { from: 'user' });
 
 // parseOptions (and ParseOptionsResult)
 const { operands, unknown } = program.parseOptions(['node', 'script.js', 'hello']);
@@ -148,32 +158,32 @@ const { operands, unknown } = program.parseOptions(['node', 'script.js', 'hello'
 // opts
 const opts = program.opts();
 const optsVal1 = opts.foo;
+// eslint-disable-next-line dot-notation
 const opstVale2 = opts['bar'];
 
 // description
-const descriptionThis: commander.Command = program.description("my description");
+const descriptionThis: commander.Command = program.description('my description');
 const descriptionValue: string = program.description();
 
 // alias
-const aliasThis: commander.Command = program.alias("my alias");
+const aliasThis: commander.Command = program.alias('my alias');
 const aliasValue: string = program.alias();
 
 // usage
-const usageThis: commander.Command = program.usage("my usage");
+const usageThis: commander.Command = program.usage('my usage');
 const usageValue: string = program.usage();
 
 // name
-const nameThis: commander.Command = program.name("my-name");
+const nameThis: commander.Command = program.name('my-name');
 const nameValue: string = program.name();
 
 // outputHelp
 program.outputHelp();
-program.outputHelp((str: string) => { return str });
+program.outputHelp((str: string) => { return str; });
 
 // help
 program.help();
-program.help((str: string) => { return str });
-
+program.help((str: string) => { return str; });
 
 // helpInformation
 const helpInformnationValue: string = program.helpInformation();
@@ -184,7 +194,9 @@ const helpOptionThis2: commander.Command = program.helpOption('-h,--help', 'cust
 const helpOptionThis3: commander.Command = program.helpOption(undefined, 'custom description');
 
 // on
-const onThis: commander.Command = program.on('--help', () => { })
+const onThis: commander.Command = program.on('--help', () => {
+  // do nothing.
+});
 
 // createCommand
 
@@ -192,10 +204,13 @@ const createInstance1: commander.Command = program.createCommand();
 const createInstance2: commander.Command = program.createCommand('name');
 
 class MyCommand extends commander.Command {
-   createCommand(name?: string) {
+  createCommand(name?: string): MyCommand {
     return new MyCommand(name);
   }
-  myFunction() {}
+
+  myFunction(): void {
+    // do nothing.
+  }
 }
 const myProgram = new MyCommand();
 myProgram.myFunction();

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -9,7 +9,7 @@ declare namespace commander {
     message: string;
     nestedError?: string;
   }
-  type CommanderErrorConstructor = new (exitCode: number, code: string, message: string)=> CommanderError;
+  type CommanderErrorConstructor = new (exitCode: number, code: string, message: string) => CommanderError;
 
   interface Option {
     flags: string;
@@ -21,7 +21,7 @@ declare namespace commander {
     long: string;
     description: string;
   }
-  type OptionConstructor = new (flags: string, description?: string)=> Option;
+  type OptionConstructor = new (flags: string, description?: string) => Option;
 
   interface ParseOptions {
     from: 'node' | 'electron' | 'user';
@@ -340,7 +340,7 @@ declare namespace commander {
      */
     on(event: string | symbol, listener: (...args: any[]) => void): this;
   }
-  type CommandConstructor = new (name?: string)=> Command;
+  type CommandConstructor = new (name?: string) => Command;
 
   interface CommandOptions {
     noHelp?: boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -362,5 +362,7 @@ declare namespace commander {
 
 }
 
+// Declaring namespace AND global
+// eslint-disable-next-line no-redeclare
 declare const commander: commander.CommanderStatic;
 export = commander;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -9,7 +9,7 @@ declare namespace commander {
     message: string;
     nestedError?: string;
   }
-  type CommanderErrorConstructor = { new (exitCode: number, code: string, message: string): CommanderError };
+  type CommanderErrorConstructor = new (exitCode: number, code: string, message: string)=> CommanderError;
 
   interface Option {
     flags: string;
@@ -21,7 +21,7 @@ declare namespace commander {
     long: string;
     description: string;
   }
-  type OptionConstructor = { new (flags: string, description?: string): Option };
+  type OptionConstructor = new (flags: string, description?: string)=> Option;
 
   interface ParseOptions {
     from: 'node' | 'electron' | 'user';
@@ -340,7 +340,7 @@ declare namespace commander {
      */
     on(event: string | symbol, listener: (...args: any[]) => void): this;
   }
-  type CommandConstructor = { new (name?: string): Command };
+  type CommandConstructor = new (name?: string)=> Command;
 
   interface CommandOptions {
     noHelp?: boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -35,21 +35,21 @@ declare namespace commander {
     commands: Command[];
 
     /**
-     * Set the program version to `str`. 
+     * Set the program version to `str`.
      *
      * This method auto-registers the "-V, --version" flag
      * which will print the version number when passed.
-     * 
+     *
      * You can optionally supply the  flags and description to override the defaults.
      */
     version(str: string, flags?: string, description?: string): this;
 
     /**
      * Define a command, implemented using an action handler.
-     * 
+     *
      * @remarks
      * The command description is supplied using `.description`, not as a parameter to `.command`.
-     * 
+     *
      * @example
      * ```ts
      *  program
@@ -59,7 +59,7 @@ declare namespace commander {
      *      console.log('clone command called');
      *    });
      * ```
-     * 
+     *
      * @param nameAndArgs - command name and arguments, args are  `<required>` or `[optional]` and last may also be `variadic...`
      * @param opts - configuration options
      * @returns new command
@@ -67,17 +67,17 @@ declare namespace commander {
     command(nameAndArgs: string, opts?: CommandOptions): ReturnType<this['createCommand']>;
     /**
      * Define a command, implemented in a separate executable file.
-     * 
+     *
      * @remarks
      * The command description is supplied as the second parameter to `.command`.
-     * 
+     *
      * @example
      * ```ts
      *  program
      *    .command('start <service>', 'start named service')
      *    .command('stop [service]', 'stop named serice, or all if no name supplied');
      * ```
-     * 
+     *
      * @param nameAndArgs - command name and arguments, args are  `<required>` or `[optional]` and last may also be `variadic...`
      * @param description - description of executable command
      * @param opts - configuration options
@@ -92,12 +92,12 @@ declare namespace commander {
      * create the command. You can override createCommand to customise subcommands.
      */
     createCommand(name?: string): Command;
-    
+
     /**
      * Add a prepared subcommand.
-     * 
+     *
      * See .command() for creating an attached subcommand which inherits settings from its parent.
-     * 
+     *
      * @returns parent command for chaining
      */
     addCommand(cmd: Command): this;
@@ -185,7 +185,6 @@ declare namespace commander {
     requiredOption(flags: string, description: string, regexp: RegExp, defaultValue?: string | boolean): this;
     requiredOption<T>(flags: string, description: string, fn: (value: string, previous: T) => T, defaultValue?: T): this;
 
-
     /**
      * Whether to store option values as properties on command object,
      * or store separately (specify false). In both cases the option values can be accessed using .opts().
@@ -197,7 +196,7 @@ declare namespace commander {
     /**
      * Whether to pass command to action handler,
      * or just the options (specify false).
-     * 
+     *
      * @return Command for chaining
      */
     passCommandToAction(value?: boolean): this;
@@ -212,7 +211,7 @@ declare namespace commander {
 
     /**
      * Parse `argv`, setting options and invoking commands when defined.
-     * 
+     *
      * The default expectation is that the arguments are from node and have the application as argv[0]
      * and the script being run in argv[1], with user parameters after that.
      *
@@ -221,16 +220,16 @@ declare namespace commander {
      *      program.parse(process.argv);
      *      program.parse(); // implicitly use process.argv and auto-detect node vs electron conventions
      *      program.parse(my-args, { from: 'user' }); // just user supplied arguments, nothing special about argv[0]
-     * 
+     *
      * @returns Command for chaining
      */
     parse(argv?: string[], options?: ParseOptions): this;
 
     /**
      * Parse `argv`, setting options and invoking commands when defined.
-     * 
+     *
      * Use parseAsync instead of parse if any of your action handlers are async. Returns a Promise.
-     * 
+     *
      * The default expectation is that the arguments are from node and have the application as argv[0]
      * and the script being run in argv[1], with user parameters after that.
      *
@@ -264,7 +263,7 @@ declare namespace commander {
 
     /**
      * Set the description.
-     * 
+     *
      * @returns Command for chaining
      */
     description(str: string, argsDescription?: {[argName: string]: string}): this;
@@ -275,7 +274,7 @@ declare namespace commander {
 
     /**
      * Set an alias for the command.
-     * 
+     *
      * @returns Command for chaining
      */
     alias(alias: string): this;
@@ -286,7 +285,7 @@ declare namespace commander {
 
     /**
      * Set the command usage.
-     * 
+     *
      * @returns Command for chaining
      */
     usage(str: string): this;
@@ -297,7 +296,7 @@ declare namespace commander {
 
     /**
      * Set the name of the command.
-     * 
+     *
      * @returns Command for chaining
      */
     name(str: string): this;
@@ -318,21 +317,21 @@ declare namespace commander {
      * Return command help documentation.
      */
     helpInformation(): string;
-    
+
     /**
      * You can pass in flags and a description to override the help
      * flags and help description for your command.
      */
     helpOption(flags?: string, description?: string): this;
 
-    /** 
+    /**
      * Output help information and exit.
      */
     help(cb?: (str: string) => string): never;
 
     /**
      * Add a listener (callback) for when events occur. (Implemented using EventEmitter.)
-     * 
+     *
      * @example
      *     program
      *       .on('--help', () -> {
@@ -343,24 +342,23 @@ declare namespace commander {
   }
   type CommandConstructor = { new (name?: string): Command };
 
+  interface CommandOptions {
+    noHelp?: boolean;
+    isDefault?: boolean;
+    executableFile?: string;
+  }
 
-    interface CommandOptions {
-        noHelp?: boolean;
-        isDefault?: boolean;
-        executableFile?: string;
-    }
+  interface ParseOptionsResult {
+    operands: string[];
+    unknown: string[];
+  }
 
-    interface ParseOptionsResult {
-        operands: string[];
-        unknown: string[];
-    }
-
-    interface CommanderStatic extends Command {
-        program: Command;
-        Command: CommandConstructor;
-        Option: OptionConstructor;
-        CommanderError:CommanderErrorConstructor;
-      }
+  interface CommanderStatic extends Command {
+    program: Command;
+    Command: CommandConstructor;
+    Option: OptionConstructor;
+    CommanderError: CommanderErrorConstructor;
+  }
 
 }
 


### PR DESCRIPTION
# Pull Request

## Problem

With lint now set up for TypeScript, there are lots of lint errors!

## Solution

- fix lots of lint errors for style issues
- add return types to match `standard` rules
- disable some tests where the code is deliberate

Down to zero errors, but planning to leave until after 5.0.