### PR TITLE
Add cli keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "commander",
     "command",
     "option",
-    "parser"
+    "parser",
+    "cli"
   ],
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "command",
     "option",
     "parser",
-    "cli"
+    "cli",
+    "argument",
+    "args",
+    "argv"
   ],
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "license": "MIT",


### PR DESCRIPTION
# Pull Request

## Problem

npmjs has a "cli" link on the home page: https://www.npmjs.com

which lists the packages with `cli` keyword: https://www.npmjs.com/search?q=keywords:cli&page=0&ranking=optimal

Commander is not listed.

## Solution

Add `cli` to keywords