### PR TITLE
Update docs for chainable return type

### DIFF
--- a/index.js
+++ b/index.js
@@ -216,7 +216,7 @@ class Command extends EventEmitter {
    * See .command() for creating an attached subcommand which inherits settings from its parent.
    *
    * @param {Command} cmd - new subcommand
-   * @return {Command} parent command for chaining
+   * @return {Command} `this` command for chaining
    * @api public
    */
 
@@ -257,7 +257,7 @@ class Command extends EventEmitter {
    *    addHelpCommand(false); // force off
    *    addHelpCommand('help [cmd]', 'display help for [cmd]'); // force on with custom detais
    *
-   * @return {Command} for chaining
+   * @return {Command} `this` command for chaining
    * @api public
    */
 
@@ -293,7 +293,7 @@ class Command extends EventEmitter {
    * For example `["[type]"]` becomes `[{ required: false, name: 'type' }]`.
    *
    * @param {Array} args
-   * @return {Command} for chaining
+   * @return {Command} `this` command for chaining
    * @api private
    */
 
@@ -336,7 +336,7 @@ class Command extends EventEmitter {
    * Register callback to use as replacement for calling process.exit.
    *
    * @param {Function} [fn] optional callback which will be passed a CommanderError, defaults to throwing
-   * @return {Command} for chaining
+   * @return {Command} `this` command for chaining
    * @api public
    */
 
@@ -386,7 +386,7 @@ class Command extends EventEmitter {
    *        });
    *
    * @param {Function} fn
-   * @return {Command} for chaining
+   * @return {Command} `this` command for chaining
    * @api public
    */
 
@@ -425,7 +425,7 @@ class Command extends EventEmitter {
    * @param {string} description
    * @param {Function|*} [fn] - custom option processing function or default vaue
    * @param {*} [defaultValue]
-   * @return {Command} for chaining
+   * @return {Command} `this` command for chaining
    * @api private
    */
 
@@ -543,7 +543,7 @@ class Command extends EventEmitter {
    * @param {string} description
    * @param {Function|*} [fn] - custom option processing function or default vaue
    * @param {*} [defaultValue]
-   * @return {Command} for chaining
+   * @return {Command} `this` command for chaining
    * @api public
    */
 
@@ -561,7 +561,7 @@ class Command extends EventEmitter {
   * @param {string} description
   * @param {Function|*} [fn] - custom option processing function or default vaue
   * @param {*} [defaultValue]
-  * @return {Command} for chaining
+  * @return {Command} `this` command for chaining
   * @api public
   */
 
@@ -586,7 +586,7 @@ class Command extends EventEmitter {
     * or store separately (specify false). In both cases the option values can be accessed using .opts().
     *
     * @param {boolean} value
-    * @return {Command} Command for chaining
+    * @return {Command} `this` command for chaining
     * @api public
     */
 
@@ -603,7 +603,7 @@ class Command extends EventEmitter {
     * or just the options (specify false).
     *
     * @param {boolean} value
-    * @return {Command} Command for chaining
+    * @return {Command} `this` command for chaining
     * @api public
     */
 
@@ -658,7 +658,7 @@ class Command extends EventEmitter {
    * @param {string[]} [argv] - optional, defaults to process.argv
    * @param {Object} [parseOptions] - optionally specify style of options with from: node/user/electron
    * @param {string} [parseOptions.from] - where the args are from: 'node', 'user', 'electron'
-   * @return {Command} for chaining
+   * @return {Command} `this` command for chaining
    * @api public
    */
 
@@ -1172,7 +1172,7 @@ class Command extends EventEmitter {
    * @param {string} str
    * @param {string} [flags]
    * @param {string} [description]
-   * @return {Command | string} this for chaining
+   * @return {this | string} `this` command for chaining, or version string if no arguments
    * @api public
    */
 
@@ -1501,7 +1501,7 @@ class Command extends EventEmitter {
    *
    * @param {string} [flags]
    * @param {string} [description]
-   * @return {Command}
+   * @return {Command} `this` command for chaining
    * @api public
    */
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -81,7 +81,7 @@ declare namespace commander {
      * @param nameAndArgs - command name and arguments, args are  `<required>` or `[optional]` and last may also be `variadic...`
      * @param description - description of executable command
      * @param opts - configuration options
-     * @returns top level command for chaining more command definitions
+     * @returns `this` command for chaining
      */
     command(nameAndArgs: string, description: string, opts?: commander.CommandOptions): this;
 
@@ -98,14 +98,14 @@ declare namespace commander {
      *
      * See .command() for creating an attached subcommand which inherits settings from its parent.
      *
-     * @returns parent command for chaining
+     * @returns `this` command for chaining
      */
     addCommand(cmd: Command): this;
 
     /**
      * Define argument syntax for the top-level command.
      *
-     * @returns Command for chaining
+     * @returns `this` command for chaining
      */
     arguments(desc: string): this;
 
@@ -125,7 +125,7 @@ declare namespace commander {
      *           // output help here
      *        });
      *
-     * @returns Command for chaining
+     * @returns `this` command for chaining
      */
     action(fn: (...args: any[]) => void | Promise<void>): this;
 
@@ -169,7 +169,7 @@ declare namespace commander {
      *     // optional argument
      *     program.option('-c, --cheese [type]', 'add cheese [marble]');
      *
-     * @returns Command for chaining
+     * @returns `this` command for chaining
      */
     option(flags: string, description?: string, defaultValue?: string | boolean): this;
     option(flags: string, description: string, regexp: RegExp, defaultValue?: string | boolean): this;
@@ -189,7 +189,7 @@ declare namespace commander {
      * Whether to store option values as properties on command object,
      * or store separately (specify false). In both cases the option values can be accessed using .opts().
      *
-     * @return Command for chaining
+     * @returns `this` command for chaining
      */
     storeOptionsAsProperties(value?: boolean): this;
 
@@ -197,7 +197,7 @@ declare namespace commander {
      * Whether to pass command to action handler,
      * or just the options (specify false).
      *
-     * @return Command for chaining
+     * @returns `this` command for chaining
      */
     passCommandToAction(value?: boolean): this;
 
@@ -205,7 +205,7 @@ declare namespace commander {
      * Allow unknown options on the command line.
      *
      * @param [arg] if `true` or omitted, no error will be thrown for unknown options.
-     * @returns Command for chaining
+     * @returns `this` command for chaining
      */
     allowUnknownOption(arg?: boolean): this;
 
@@ -221,7 +221,7 @@ declare namespace commander {
      *      program.parse(); // implicitly use process.argv and auto-detect node vs electron conventions
      *      program.parse(my-args, { from: 'user' }); // just user supplied arguments, nothing special about argv[0]
      *
-     * @returns Command for chaining
+     * @returns `this` command for chaining
      */
     parse(argv?: string[], options?: ParseOptions): this;
 
@@ -264,7 +264,7 @@ declare namespace commander {
     /**
      * Set the description.
      *
-     * @returns Command for chaining
+     * @returns `this` command for chaining
      */
     description(str: string, argsDescription?: {[argName: string]: string}): this;
     /**
@@ -275,7 +275,7 @@ declare namespace commander {
     /**
      * Set an alias for the command.
      *
-     * @returns Command for chaining
+     * @returns `this` command for chaining
      */
     alias(alias: string): this;
     /**
@@ -286,7 +286,7 @@ declare namespace commander {
     /**
      * Set the command usage.
      *
-     * @returns Command for chaining
+     * @returns `this` command for chaining
      */
     usage(str: string): this;
     /**
@@ -297,7 +297,7 @@ declare namespace commander {
     /**
      * Set the name of the command.
      *
-     * @returns Command for chaining
+     * @returns `this` command for chaining
      */
     name(str: string): this;
     /**


### PR DESCRIPTION
We had mixed descriptions for the return type of chainable routines. The TSDoc now has an actual return type of `this` which is not officially supported by the JSDoc, but that is still a useful way of referring to the return type in the text.

Consistently refer to returning "`this` command for chaining" in the JSDoc and TSDoc.