### PR TITLE
Add support for multiple aliases

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ class Command extends EventEmitter {
     this._executableFile = null; // custom name for executable
     this._defaultCommandName = null;
     this._exitCallback = null;
-    this._alias = null;
+    this._alias = [];
 
     this._hidden = false;
     this._helpFlags = '-h, --help';
@@ -937,7 +937,7 @@ class Command extends EventEmitter {
    */
   _findCommand(name) {
     if (!name) return undefined;
-    return this.commands.find(cmd => cmd._name === name || cmd._alias === name);
+    return this.commands.find(cmd => cmd._name === name || cmd._alias.includes(name));
   };
 
   /**
@@ -1201,7 +1201,7 @@ class Command extends EventEmitter {
    *
    * @param {string} str
    * @param {Object} [argsDescription]
-   * @return {String|Command}
+   * @return {string|Command}
    * @api public
    */
 
@@ -1213,10 +1213,12 @@ class Command extends EventEmitter {
   };
 
   /**
-   * Set an alias for the command
+   * Set an alias for the command.
    *
-   * @param {string} alias
-   * @return {String|Command}
+   * You may call more than once to add multiple aliases, Only the first alias is shown in the auto-generated help.
+   *
+   * @param {string} [alias]
+   * @return {string|Command}
    * @api public
    */
 
@@ -1226,11 +1228,11 @@ class Command extends EventEmitter {
       command = this.commands[this.commands.length - 1];
     }
 
-    if (arguments.length === 0) return command._alias;
+    if (arguments.length === 0) return command._alias[0]; // just return first, and return string not array for backwards compatibility
 
     if (alias === command._name) throw new Error('Command alias can\'t be the same as its name');
 
-    command._alias = alias;
+    command._alias.push(alias);
     return this;
   };
 
@@ -1288,7 +1290,7 @@ class Command extends EventEmitter {
 
       return [
         cmd._name +
-          (cmd._alias ? '|' + cmd._alias : '') +
+          (cmd._alias[0] ? '|' + cmd._alias[0] : '') +
           (cmd.options.length ? ' [options]' : '') +
           (args ? ' ' + args : ''),
         cmd._description
@@ -1448,8 +1450,8 @@ class Command extends EventEmitter {
     }
 
     let cmdName = this._name;
-    if (this._alias) {
-      cmdName = cmdName + '|' + this._alias;
+    if (this._alias[0]) {
+      cmdName = cmdName + '|' + this._alias[0];
     }
     let parentCmdNames = '';
     for (let parentCmd = this.parent; parentCmd; parentCmd = parentCmd.parent) {

--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ class Command extends EventEmitter {
     this._executableFile = null; // custom name for executable
     this._defaultCommandName = null;
     this._exitCallback = null;
-    this._alias = [];
+    this._aliases = [];
 
     this._hidden = false;
     this._helpFlags = '-h, --help';
@@ -937,7 +937,7 @@ class Command extends EventEmitter {
    */
   _findCommand(name) {
     if (!name) return undefined;
-    return this.commands.find(cmd => cmd._name === name || cmd._alias.includes(name));
+    return this.commands.find(cmd => cmd._name === name || cmd._aliases.includes(name));
   };
 
   /**
@@ -1215,7 +1215,7 @@ class Command extends EventEmitter {
   /**
    * Set an alias for the command.
    *
-   * You may call more than once to add multiple aliases, Only the first alias is shown in the auto-generated help.
+   * You may call more than once to add multiple aliases. Only the first alias is shown in the auto-generated help.
    *
    * @param {string} [alias]
    * @return {string|Command}
@@ -1223,7 +1223,7 @@ class Command extends EventEmitter {
    */
 
   alias(alias) {
-    if (alias === undefined) return this._alias[0]; // just return first, for backwards compatibility
+    if (alias === undefined) return this._aliases[0]; // just return first, for backwards compatibility
 
     let command = this;
     if (this.commands.length !== 0 && this.commands[this.commands.length - 1]._executableHandler) {
@@ -1233,7 +1233,25 @@ class Command extends EventEmitter {
 
     if (alias === command._name) throw new Error('Command alias can\'t be the same as its name');
 
-    command._alias.push(alias);
+    command._aliases.push(alias);
+    return this;
+  };
+
+  /**
+   * Set aliases for the command.
+   *
+   * Only the first alias is shown in the auto-generated help.
+   *
+   * @param {string[]} [aliases]
+   * @return {string[]|Command}
+   * @api public
+   */
+
+  aliases(aliases) {
+    // Getter for the array of aliases is the main reason for having aliases() in addition to alias().
+    if (aliases === undefined) return this._aliases;
+
+    aliases.forEach((alias) => this.alias(alias));
     return this;
   };
 
@@ -1292,7 +1310,7 @@ class Command extends EventEmitter {
 
       return [
         cmd._name +
-          (cmd._alias[0] ? '|' + cmd._alias[0] : '') +
+          (cmd._aliases[0] ? '|' + cmd._aliases[0] : '') +
           (cmd.options.length ? ' [options]' : '') +
           (args ? ' ' + args : ''),
         cmd._description
@@ -1452,8 +1470,8 @@ class Command extends EventEmitter {
     }
 
     let cmdName = this._name;
-    if (this._alias[0]) {
-      cmdName = cmdName + '|' + this._alias[0];
+    if (this._aliases[0]) {
+      cmdName = cmdName + '|' + this._aliases[0];
     }
     let parentCmdNames = '';
     for (let parentCmd = this.parent; parentCmd; parentCmd = parentCmd.parent) {

--- a/tests/command.alias.test.js
+++ b/tests/command.alias.test.js
@@ -68,7 +68,7 @@ test('when use second of aliases then action handler called', () => {
   const actionMock = jest.fn();
   program
     .command('list')
-    .alias(['ls', 'dir'])
+    .aliases(['ls', 'dir'])
     .action(actionMock);
   program.parse(['dir'], { from: 'user' });
   expect(actionMock).toHaveBeenCalled();

--- a/tests/command.alias.test.js
+++ b/tests/command.alias.test.js
@@ -12,12 +12,21 @@ test('when command has alias then appears in help', () => {
   expect(helpInformation).toMatch('info|i');
 });
 
-test('when command has more than one alias then only first appears in help', () => {
+test('when command has aliases added separately then only first appears in help', () => {
   const program = new commander.Command();
   program
     .command('list [thing]')
     .alias('ls')
     .alias('dir');
+  const helpInformation = program.helpInformation();
+  expect(helpInformation).toMatch('list|ls ');
+});
+
+test('when command has aliases then only first appears in help', () => {
+  const program = new commander.Command();
+  program
+    .command('list [thing]')
+    .aliases(['ls', 'dir']);
   const helpInformation = program.helpInformation();
   expect(helpInformation).toMatch('list|ls ');
 });
@@ -42,13 +51,24 @@ test('when use alias then action handler called', () => {
   expect(actionMock).toHaveBeenCalled();
 });
 
-test('when use second alias then action handler called', () => {
+test('when use second alias added separately then action handler called', () => {
   const program = new commander.Command();
   const actionMock = jest.fn();
   program
     .command('list')
     .alias('ls')
     .alias('dir')
+    .action(actionMock);
+  program.parse(['dir'], { from: 'user' });
+  expect(actionMock).toHaveBeenCalled();
+});
+
+test('when use second of aliases then action handler called', () => {
+  const program = new commander.Command();
+  const actionMock = jest.fn();
+  program
+    .command('list')
+    .alias(['ls', 'dir'])
     .action(actionMock);
   program.parse(['dir'], { from: 'user' });
   expect(actionMock).toHaveBeenCalled();

--- a/tests/command.alias.test.js
+++ b/tests/command.alias.test.js
@@ -12,11 +12,44 @@ test('when command has alias then appears in help', () => {
   expect(helpInformation).toMatch('info|i');
 });
 
-test('when command = alias then error', () => {
+test('when command has more than one alias then only first appears in help', () => {
+  const program = new commander.Command();
+  program
+    .command('list [thing]')
+    .alias('ls')
+    .alias('dir');
+  const helpInformation = program.helpInformation();
+  expect(helpInformation).toMatch('list|ls ');
+});
+
+test('when command name = alias then error', () => {
   const program = new commander.Command();
   expect(() => {
     program
       .command('fail')
       .alias('fail');
   }).toThrow("Command alias can't be the same as its name");
+});
+
+test('when use alias then action handler called', () => {
+  const program = new commander.Command();
+  const actionMock = jest.fn();
+  program
+    .command('list')
+    .alias('ls')
+    .action(actionMock);
+  program.parse(['ls'], { from: 'user' });
+  expect(actionMock).toHaveBeenCalled();
+});
+
+test('when use second alias then action handler called', () => {
+  const program = new commander.Command();
+  const actionMock = jest.fn();
+  program
+    .command('list')
+    .alias('ls')
+    .alias('dir')
+    .action(actionMock);
+  program.parse(['dir'], { from: 'user' });
+  expect(actionMock).toHaveBeenCalled();
 });

--- a/typings/commander-tests.ts
+++ b/typings/commander-tests.ts
@@ -169,6 +169,10 @@ const descriptionValue: string = program.description();
 const aliasThis: commander.Command = program.alias('my alias');
 const aliasValue: string = program.alias();
 
+// aliases
+const aliasesThis: commander.Command = program.aliases(['first-alias', 'second-alias']);
+const aliasesValue: string[] = program.aliases();
+
 // usage
 const usageThis: commander.Command = program.usage('my usage');
 const usageValue: string = program.usage();

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -275,6 +275,8 @@ declare namespace commander {
     /**
      * Set an alias for the command.
      *
+     * You may call more than once to add multiple aliases, Only the first alias is shown in the auto-generated help.
+     *
      * @returns `this` command for chaining
      */
     alias(alias: string): this;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -275,7 +275,7 @@ declare namespace commander {
     /**
      * Set an alias for the command.
      *
-     * You may call more than once to add multiple aliases, Only the first alias is shown in the auto-generated help.
+     * You may call more than once to add multiple aliases. Only the first alias is shown in the auto-generated help.
      *
      * @returns `this` command for chaining
      */
@@ -284,6 +284,19 @@ declare namespace commander {
      * Get alias for the command.
      */
     alias(): string;
+
+    /**
+     * Set aliases for the command.
+     *
+     * Only the first alias is shown in the auto-generated help.
+     *
+     * @returns `this` command for chaining
+     */
+    aliases(aliases: string[]): this;
+    /**
+     * Get aliases for the command.
+     */
+    aliases(): string[];
 
     /**
      * Set the command usage.


### PR DESCRIPTION
# Pull Request

See #531

## Problem

Some people would like to add more than one alias for a command, but not have them all visible in the help.

## Solution

Allow adding multiple aliases. Only display the first one in the built-in help, and leave any mention of the rest up to the caller.

This is intended to be backwards compatible. There is a small change from v5.0 behaviour, calling `.alias()` when there is no alias will now return `undefined` instead of `null`, but seems unlikely to affect much code and can be made fully backwards compatible if necessary.

To provide public access to the possibly multiple aliases, added `.aliases()` which works with array rather than string.

## ChangeLog

- add support for multiple aliases
