### PR TITLE
Fixing loading sub-commands with typescript

### DIFF
--- a/index.js
+++ b/index.js
@@ -791,8 +791,8 @@ class Command extends EventEmitter {
         args.unshift(bin);
         // add executable arguments to spawn
         args = incrementNodeInspectorPort(process.execArgv).concat(args);
-
-        proc = spawn(process.argv[0], args, { stdio: 'inherit' });
+        
+        proc = spawn(args.shift(), args, { stdio: 'inherit' });
       } else {
         proc = spawn(bin, args, { stdio: 'inherit' });
       }


### PR DESCRIPTION
This method does not need you to remove the extension from your subcommand files and also the shebang lines is not necessary.

# Pull Request

## Problem
I'm trying to use sub-commands with typescript files which do not have shebang lines. The script is run using `ts-node --files /path/to/main.ts`

Without this patch, nothing was getting executed and no errors were thrown.

## Solution
NOTE: I'm not an expert at all the different ways that you can run typescript code, so I don't know if this could break something else, but this solution worked for me.

Changing [line 795](https://github.com/tj/commander.js/blob/master/index.js#L795) from
```js
proc = spawn(process.argv[0], args, { stdio: 'inherit' });
```
to
```js
proc = spawn(args.shift(), args, { stdio: 'inherit' });
```

### nom run test
Some tests fail but it would be surprising that it is related to the PR.
```js
npm run test

> commander@5.0.0 test /Users/david/workspace/commander.js
> jest && npm run test-typings

 FAIL  tests/options.custom-processing.test.js
  ● when option specified multiple times then callback called with value and previousValue

    TypeError: expect(...).toHaveBeenNthCalledWith is not a function
      
      at Object.<anonymous>.test (tests/options.custom-processing.test.js:97:24)
          at new Promise (<anonymous>)
      at processTicksAndRejections (internal/process/next_tick.js:81:5)

 PASS  tests/options.bool.combo.test.js
 PASS  tests/options.version.test.js
 PASS  tests/options.mandatory.test.js
 PASS  tests/command.action.test.js
 PASS  tests/options.bool.test.js
 PASS  tests/command.helpCommand.test.js
 PASS  tests/command.asterisk.test.js
 PASS  tests/helpwrap.test.js
 FAIL  tests/options.values.test.js
  ● Test suite failed to run

    TypeError: describe.each is not a function
      
      at Object.<anonymous> (tests/options.values.test.js:9:10)
      at process.emit (events.js:197:13)
      at emit (internal/child_process.js:828:12)
      at processTicksAndRejections (internal/process/next_tick.js:76:17)

 FAIL  tests/options.opts.test.js
  ● Test suite failed to run

    TypeError: describe.each is not a function
      
      at Object.<anonymous> (tests/options.opts.test.js:26:10)
      at process.emit (events.js:197:13)
      at emit (internal/child_process.js:828:12)
      at processTicksAndRejections (internal/process/next_tick.js:76:17)

 PASS  tests/command.help.test.js
 PASS  tests/options.required.test.js
 PASS  tests/commander.configureCommand.test.js
 PASS  tests/args.variadic.test.js
 PASS  tests/command.exitOverride.test.js
 PASS  tests/options.flags.test.js
 PASS  tests/command.parse.test.js
 PASS  tests/options.optional.test.js
 PASS  tests/command.unknownOption.test.js
 PASS  tests/command.addCommand.test.js
 PASS  tests/options.camelcase.test.js
 PASS  tests/command.allowUnknownOptions.test.js
 FAIL  tests/command.executableSubcommand.signals.test.js
  ● Test suite failed to run

    TypeError: describeOrSkipOnWindows.each is not a function
      
      at Object.<anonymous> (tests/command.executableSubcommand.signals.test.js:17:25)
      at process.emit (events.js:197:13)
      at emit (internal/child_process.js:828:12)
      at processTicksAndRejections (internal/process/next_tick.js:76:17)

 PASS  tests/command.unknownCommand.test.js
 PASS  tests/options.regex.test.js
 PASS  tests/command.usage.test.js
 PASS  tests/args.literal.test.js
 PASS  tests/createCommand.test.js
 PASS  tests/command.name.test.js
 PASS  tests/command.helpOption.test.js
 PASS  tests/command.commandHelp.test.js
 PASS  tests/command.parseOptions.test.js
 PASS  tests/command.alias.test.js
 PASS  tests/command.executableSubcommand.test.js
 PASS  tests/options.bool.small.combined.test.js
 PASS  tests/program.test.js
 PASS  tests/command.nested.test.js
 PASS  tests/command.default.test.js
 PASS  tests/command.executableSubcommand.inspect.test.js
 PASS  tests/command.executableSubcommand.lookup.test.js

Summary of all failing tests
 FAIL  tests/options.custom-processing.test.js
  ● when option specified multiple times then callback called with value and previousValue

    TypeError: expect(...).toHaveBeenNthCalledWith is not a function
      
      at Object.<anonymous>.test (tests/options.custom-processing.test.js:97:24)
          at new Promise (<anonymous>)
      at processTicksAndRejections (internal/process/next_tick.js:81:5)

 FAIL  tests/options.values.test.js
  ● Test suite failed to run

    TypeError: describe.each is not a function
      
      at Object.<anonymous> (tests/options.values.test.js:9:10)
      at process.emit (events.js:197:13)
      at emit (internal/child_process.js:828:12)
      at processTicksAndRejections (internal/process/next_tick.js:76:17)

 FAIL  tests/options.opts.test.js
  ● Test suite failed to run

    TypeError: describe.each is not a function
      
      at Object.<anonymous> (tests/options.opts.test.js:26:10)
      at process.emit (events.js:197:13)
      at emit (internal/child_process.js:828:12)
      at processTicksAndRejections (internal/process/next_tick.js:76:17)

 FAIL  tests/command.executableSubcommand.signals.test.js
  ● Test suite failed to run

    TypeError: describeOrSkipOnWindows.each is not a function
      
      at Object.<anonymous> (tests/command.executableSubcommand.signals.test.js:17:25)
      at process.emit (events.js:197:13)
      at emit (internal/child_process.js:828:12)
      at processTicksAndRejections (internal/process/next_tick.js:76:17)


Test Suites: 4 failed, 37 passed, 41 total
Tests:       1 failed, 267 passed, 268 total
Snapshots:   0 total
Time:        5.828s
```
