### PR TITLE
Using helpOption with only long flag did not clear short flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -1518,6 +1518,7 @@ class Command extends EventEmitter {
 
     const splitFlags = this._helpFlags.split(/[ ,|]+/);
 
+    this._helpShortFlag = undefined;
     if (splitFlags.length > 1) this._helpShortFlag = splitFlags.shift();
 
     this._helpLongFlag = splitFlags.shift();


### PR DESCRIPTION
# Pull Request

## Problem

Defining just a long flag would change the displayed help but leave the short flag defined and active.

```
const { program } = require('commander');
program.helpOption('--please');
program.parse();
```

```
$ node resetShort.js -h
... help displayed ...
```

## Solution

Clear short flag in case not set.

