### PR TITLE
Add support for variadic options

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,6 +44,9 @@ const typescriptSettings = {
 
 module.exports = {
   plugins: ['jest'],
+  parserOptions: {
+    ecmaVersion: 8
+  },
   overrides: [
     javascriptSettings,
     typescriptSettings

--- a/Readme.md
+++ b/Readme.md
@@ -18,6 +18,7 @@ Read this in other languages: English | [简体中文](./Readme_zh-CN.md)
     - [Other option types, negatable boolean and flag|value](#other-option-types-negatable-boolean-and-flagvalue)
     - [Custom option processing](#custom-option-processing)
     - [Required option](#required-option)
+    - [Variadic option](#variadic-option)
     - [Version option](#version-option)
   - [Commands](#commands)
     - [Specify the argument syntax](#specify-the-argument-syntax)
@@ -276,6 +277,38 @@ program.parse(process.argv);
 ```bash
 $ pizza
 error: required option '-c, --cheese <type>' not specified
+```
+
+### Variadic option
+
+You may make an option variadic by appending `...` to the value placeholder when declaring the option. On the command line you
+can then specify multiple option arguments, and the parsed option value will be an array. The extra arguments
+are read until the first argument starting with a dash. The special argument `--` stops option processing entirely. If a value
+in specified in the same argument as the option then no further values are read.
+
+Example file: [options-variadic.js](./examples/options-variadic.js)
+
+```js
+program
+  .option('-n, --number <numbers...>', 'specify numbers')
+  .option('-l, --letter [letters...]', 'specify letters');
+
+program.parse();
+
+console.log('Options: ', program.opts());
+console.log('Remaining arguments: ', program.args);
+```
+
+```bash
+$ collect -n 1 2 3 --letter a b c
+Options:  { number: [ '1', '2', '3' ], letter: [ 'a', 'b', 'c' ] }
+Remaining arguments:  []
+$ collect --letter=A -n80 operand
+Options:  { number: [ '80' ], letter: [ 'A' ] }
+Remaining arguments:  [ 'operand' ]
+$ collect --letter -n 1 -n 2 3 -- operand
+Options:  { number: [ '1', '2', '3' ], letter: true }
+Remaining arguments:  [ 'operand' ]
 ```
 
 ### Version option

--- a/Readme.md
+++ b/Readme.md
@@ -284,7 +284,7 @@ error: required option '-c, --cheese <type>' not specified
 You may make an option variadic by appending `...` to the value placeholder when declaring the option. On the command line you
 can then specify multiple option arguments, and the parsed option value will be an array. The extra arguments
 are read until the first argument starting with a dash. The special argument `--` stops option processing entirely. If a value
-in specified in the same argument as the option then no further values are read.
+is specified in the same argument as the option then no further values are read.
 
 Example file: [options-variadic.js](./examples/options-variadic.js)
 

--- a/examples/options-variadic.js
+++ b/examples/options-variadic.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+// This is used as an example in the README for variadic options.
+
+// const commander = require('commander'); // (normal include)
+const commander = require('../'); // include commander in git clone of commander repo
+const program = new commander.Command();
+
+program
+  .option('-n, --number <value...>', 'specify numbers')
+  .option('-l, --letter [value...]', 'specify letters');
+
+program.parse();
+
+console.log('Options: ', program.opts());
+console.log('Remaining arguments: ', program.args);
+
+// Try the following:
+//  node options-variadic.js -n 1 2 3 --letter a b c
+//  node options-variadic.js --letter=A -n80 operand
+//  node options-variadic.js --letter -n 1 -n 2 3 -- operand

--- a/index.js
+++ b/index.js
@@ -489,7 +489,7 @@ class Command extends EventEmitter {
       // custom processing
       if (val !== null && fn) {
         val = fn(val, oldValue === undefined ? defaultValue : oldValue);
-      } else if (option.variadic) {
+      } else if (option.variadic && (val !== null)) {
         if (oldValue === defaultValue || !Array.isArray(oldValue)) {
           val = [val];
         } else {

--- a/index.js
+++ b/index.js
@@ -268,7 +268,7 @@ class Command extends EventEmitter {
    *
    *    addHelpCommand() // force on
    *    addHelpCommand(false); // force off
-   *    addHelpCommand('help [cmd]', 'display help for [cmd]'); // force on with custom detais
+   *    addHelpCommand('help [cmd]', 'display help for [cmd]'); // force on with custom details
    *
    * @return {Command} `this` command for chaining
    * @api public
@@ -436,7 +436,7 @@ class Command extends EventEmitter {
    * @param {Object} config
    * @param {string} flags
    * @param {string} description
-   * @param {Function|*} [fn] - custom option processing function or default vaue
+   * @param {Function|*} [fn] - custom option processing function or default value
    * @param {*} [defaultValue]
    * @return {Command} `this` command for chaining
    * @api private
@@ -562,7 +562,7 @@ class Command extends EventEmitter {
    *
    * @param {string} flags
    * @param {string} description
-   * @param {Function|*} [fn] - custom option processing function or default vaue
+   * @param {Function|*} [fn] - custom option processing function or default value
    * @param {*} [defaultValue]
    * @return {Command} `this` command for chaining
    * @api public
@@ -580,7 +580,7 @@ class Command extends EventEmitter {
   *
   * @param {string} flags
   * @param {string} description
-  * @param {Function|*} [fn] - custom option processing function or default vaue
+  * @param {Function|*} [fn] - custom option processing function or default value
   * @param {*} [defaultValue]
   * @return {Command} `this` command for chaining
   * @api public

--- a/index.js
+++ b/index.js
@@ -489,7 +489,7 @@ class Command extends EventEmitter {
       // custom processing
       if (val !== null && fn) {
         val = fn(val, oldValue === undefined ? defaultValue : oldValue);
-      } else if (option.variadic && (val !== null)) {
+      } else if (val !== null && option.variadic) {
         if (oldValue === defaultValue || !Array.isArray(oldValue)) {
           val = [val];
         } else {

--- a/index.js
+++ b/index.js
@@ -22,7 +22,8 @@ class Option {
     this.flags = flags;
     this.required = flags.indexOf('<') >= 0; // A value must be supplied when the option is specified.
     this.optional = flags.indexOf('[') >= 0; // A value is optional when the option is specified.
-    this.variadic = /((\.\.\.)|…)[>\]]/.test(flags); // The option can take multiple values.
+    // variadic test ignores <value,...> et al which might be used to describe custom splitting of single argument
+    this.variadic = /\w\.\.\.[>\]]$/.test(flags); // The option can take multiple values.
     this.mandatory = false; // The option must have a value after parsing, which usually means it must be specified on command line.
     this.negate = flags.indexOf('-no-') !== -1;
     const flagParts = flags.split(/[ ,|]+/);

--- a/index.js
+++ b/index.js
@@ -483,10 +483,7 @@ class Command extends EventEmitter {
       // custom processing
       if (val !== null && fn) {
         val = fn(val, oldValue === undefined ? defaultValue : oldValue);
-      }
-
-      // variadic processing
-      if (option.variadic) {
+      } else if (option.variadic) {
         if (oldValue === defaultValue || !Array.isArray(oldValue)) {
           val = [val];
         } else {

--- a/tests/command.addCommand.test.js
+++ b/tests/command.addCommand.test.js
@@ -35,7 +35,7 @@ test('when commands added using .addCommand and .command then internals similar'
       case 'boolean':
       case 'number':
       case 'undefined':
-        // Compare vaues in a way that will be readable in test failure message.
+        // Compare values in a way that will be readable in test failure message.
         expect(`${key}:${cmd1[key]}`).toEqual(`${key}:${cmd2[key]}`);
         break;
     }

--- a/tests/command.executableSubcommand.signals.test.js
+++ b/tests/command.executableSubcommand.signals.test.js
@@ -8,7 +8,7 @@ const path = require('path');
 //  https://nodejs.org/api/process.html#process_signal_events
 const describeOrSkipOnWindows = (process.platform === 'win32') ? describe.skip : describe;
 
-// Note: the previous (sinon) test had custom code for SIGUSR1, revist if required:
+// Note: the previous (sinon) test had custom code for SIGUSR1, revisit if required:
 //    As described at https://nodejs.org/api/process.html#process_signal_events
 //    this signal will start a debugger and thus the process might output an
 //    additional error message:

--- a/tests/command.exitOverride.test.js
+++ b/tests/command.exitOverride.test.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 // Test details of the exitOverride errors.
 // The important checks are the exitCode and code which are intended to be stable for
-// semver minor versions. For now, also testing the error.message and that output occured
+// semver minor versions. For now, also testing the error.message and that output occurred
 // to detect accidental changes in behaviour.
 
 /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectCommanderError"] }] */

--- a/tests/command.help.test.js
+++ b/tests/command.help.test.js
@@ -26,7 +26,7 @@ Commands:
   expect(helpInformation).toBe(expectedHelpInformation);
 });
 
-test('when use .description for command then help incudes description', () => {
+test('when use .description for command then help includes description', () => {
   const program = new commander.Command();
   program
     .command('simple-command')

--- a/tests/options.mandatory.test.js
+++ b/tests/options.mandatory.test.js
@@ -199,7 +199,7 @@ describe('required command option with mandatory value not specified', () => {
     consoleErrorSpy.mockRestore();
   });
 
-  test('when command has required value not specified then eror', () => {
+  test('when command has required value not specified then error', () => {
     const program = new commander.Command();
     program
       .exitOverride()

--- a/tests/options.variadic.test.js
+++ b/tests/options.variadic.test.js
@@ -1,0 +1,127 @@
+const commander = require('../');
+
+describe('variadic option with required value', () => {
+  test('when variadic with value missing then error', () => {
+    // Optional. Use internal knowledge to suppress output to keep test output clean.
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => { });
+
+    const program = new commander.Command();
+    program
+      .exitOverride()
+      .option('-r,--required <value...>');
+
+    expect(() => {
+      program.parse(['--required'], { from: 'user' });
+    }).toThrow();
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  test('when variadic with one value then set in array', () => {
+    const program = new commander.Command();
+    program
+      .option('-r,--required <value...>');
+
+    program.parse(['--required', 'one'], { from: 'user' });
+    expect(program.opts().required).toEqual(['one']);
+  });
+
+  test('when variadic with two values then set in array', () => {
+    const program = new commander.Command();
+    program
+      .option('-r,--required <value...>');
+
+    program.parse(['--required', 'one', 'two'], { from: 'user' });
+    expect(program.opts().required).toEqual(['one', 'two']);
+  });
+
+  test('when variadic with repeated values then set in array', () => {
+    const program = new commander.Command();
+    program
+      .option('-r,--required <value...>');
+
+    program.parse(['--required', 'one', '--required', 'two'], { from: 'user' });
+    expect(program.opts().required).toEqual(['one', 'two']);
+  });
+
+  test('when variadic with short combined argument then not variadic', () => {
+    const program = new commander.Command();
+    program
+      .option('-r,--required <value...>')
+      .arguments('[arg]');
+
+    program.parse(['-rone', 'operand'], { from: 'user' });
+    expect(program.opts().required).toEqual(['one']);
+  });
+
+  test('when variadic with long combined argument then not variadic', () => {
+    const program = new commander.Command();
+    program
+      .option('-r,--required <value...>')
+      .arguments('[arg]');
+
+    program.parse(['--required=one', 'operand'], { from: 'user' });
+    expect(program.opts().required).toEqual(['one']);
+  });
+
+  test('when variadic with value followed by option then option not eaten', () => {
+    const program = new commander.Command();
+    program
+      .option('-r,--required <value...>')
+      .option('-f, --flag')
+      .arguments('[arg]');
+
+    program.parse(['-r', 'one', '-f'], { from: 'user' });
+    const opts = program.opts();
+    expect(opts.required).toEqual(['one']);
+    expect(opts.flag).toBe(true);
+  });
+
+  test('when variadic with no value and default then set to default', () => {
+    const program = new commander.Command();
+    program
+      .option('-r,--required <value...>', 'variadic description', 'default');
+
+    program.parse([], { from: 'user' });
+    expect(program.opts().required).toEqual('default');
+  });
+
+  test('when variadic with coercion then coerced value set in array', () => {
+    const program = new commander.Command();
+    program
+      .option('-r,--required <value...>', 'variadic description', parseFloat);
+
+    program.parse(['--required', '1e2'], { from: 'user' });
+    expect(program.opts().required).toEqual([100]);
+  });
+});
+
+// Not retesting everything, but do some tests on variadic with optional
+describe('variadic option with optional value', () => {
+  test('when variadic with zero values then value undefined', () => {
+    const program = new commander.Command();
+    program
+      .option('-o,--optional [value...]');
+
+    program.parse([], { from: 'user' });
+    expect(program.opts().optional).toBeUndefined();
+  });
+
+  test('when variadic with one value then set in array', () => {
+    const program = new commander.Command();
+    program
+      .option('-o,--optional [value...]');
+
+    program.parse(['--optional', 'one'], { from: 'user' });
+    expect(program.opts().optional).toEqual(['one']);
+  });
+
+  test('when variadic with two values then set in array', () => {
+    const program = new commander.Command();
+    program
+      .option('-o,--optional [value...]');
+
+    program.parse(['--optional', 'one', 'two'], { from: 'user' });
+    expect(program.opts().optional).toEqual(['one', 'two']);
+  });
+});

--- a/tests/options.variadic.test.js
+++ b/tests/options.variadic.test.js
@@ -99,13 +99,22 @@ describe('variadic option with required value', () => {
 
 // Not retesting everything, but do some tests on variadic with optional
 describe('variadic option with optional value', () => {
-  test('when variadic with zero values then value undefined', () => {
+  test('when option not specified then value undefined', () => {
     const program = new commander.Command();
     program
       .option('-o,--optional [value...]');
 
     program.parse([], { from: 'user' });
     expect(program.opts().optional).toBeUndefined();
+  });
+
+  test('when option used as boolean flag then value true', () => {
+    const program = new commander.Command();
+    program
+      .option('-o,--optional [value...]');
+
+    program.parse(['--optional'], { from: 'user' });
+    expect(program.opts().optional).toBe(true);
   });
 
   test('when variadic with one value then set in array', () => {

--- a/tests/options.variadic.test.js
+++ b/tests/options.variadic.test.js
@@ -86,13 +86,14 @@ describe('variadic option with required value', () => {
     expect(program.opts().required).toEqual('default');
   });
 
-  test('when variadic with coercion then coerced value set in array', () => {
+  test('when variadic with coercion then coercion sets value', () => {
     const program = new commander.Command();
     program
       .option('-r,--required <value...>', 'variadic description', parseFloat);
 
-    program.parse(['--required', '1e2'], { from: 'user' });
-    expect(program.opts().required).toEqual([100]);
+    // variadic processing reads the multiple values, but up to custom coercion what it does.
+    program.parse(['--required', '1e2', '1e3'], { from: 'user' });
+    expect(program.opts().required).toEqual(1000);
   });
 });
 

--- a/tests/options.variadic.test.js
+++ b/tests/options.variadic.test.js
@@ -99,7 +99,7 @@ describe('variadic option with required value', () => {
 
 // Not retesting everything, but do some tests on variadic with optional
 describe('variadic option with optional value', () => {
-  test('when option not specified then value undefined', () => {
+  test('when variadic not specified then value undefined', () => {
     const program = new commander.Command();
     program
       .option('-o,--optional [value...]');
@@ -108,7 +108,7 @@ describe('variadic option with optional value', () => {
     expect(program.opts().optional).toBeUndefined();
   });
 
-  test('when option used as boolean flag then value true', () => {
+  test('when variadic used as boolean flag then value true', () => {
     const program = new commander.Command();
     program
       .option('-o,--optional [value...]');

--- a/tests/options.variadic.test.js
+++ b/tests/options.variadic.test.js
@@ -125,3 +125,22 @@ describe('variadic option with optional value', () => {
     expect(program.opts().optional).toEqual(['one', 'two']);
   });
 });
+
+describe('variadic special cases', () => {
+  test('when option flags has word character before dots then is variadic', () => {
+    const program = new commander.Command();
+    program
+      .option('-c,--comma [value...]');
+
+    expect(program.options[0].variadic).toBeTruthy();
+  });
+
+  test('when option flags has special characters before dots then not variadic', () => {
+    // This might be used to describe coercion for comma separated values, and is not variadic.
+    const program = new commander.Command();
+    program
+      .option('-c,--comma [value,...]');
+
+    expect(program.options[0].variadic).toBeFalsy();
+  });
+});


### PR DESCRIPTION
# Pull Request

## Problem

People would like to be able to use variadic options, an option which can take more than one value from the following arguments.

See #571

## Solution

1) Syntax:

```js
program
   .option('-m, --mods <mod...>'),
   .option('-o, --optional [opts...]')
```

Being cautious, this makes the change a breaking change in case people have put dots after a comma separated list for example.

2) If a value or values are specified then the option value is an array.

3) The first option argument is parsed in the same way as if the `...` was not specified.

4) Subsequent option arguments are processed as for optional options (`[value]`), so a leading `-` or `--` indicates an option and not a further argument. A lone `--` stops the option processing as normal.

5) The variadic behaviour triggers for stand-alone options with the first value in the next argument, and not for options where the option value is included in the argument. 

These do not trigger variadic processing:

```js
$ program -mvalue operand
$ program --optional=value operand
```

6) Repeated use of the option will accumulate the values.

These are equivalent:

```js
$ program --mods first second
$ program --mods first --mods second
```

Example:

```
$ transpile --include *.js --exclude *.test.js -- operand
```

## ChangeLog

- add support for variadic options (#1250)