### PR TITLE
Replace indexOf with includes

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,10 +20,10 @@ class Option {
 
   constructor(flags, description) {
     this.flags = flags;
-    this.required = flags.indexOf('<') >= 0; // A value must be supplied when the option is specified.
-    this.optional = flags.indexOf('[') >= 0; // A value is optional when the option is specified.
+    this.required = flags.includes('<'); // A value must be supplied when the option is specified.
+    this.optional = flags.includes('['); // A value is optional when the option is specified.
     this.mandatory = false; // The option must have a value after parsing, which usually means it must be specified on command line.
-    this.negate = flags.indexOf('-no-') !== -1;
+    this.negate = flags.includes('-no-');
     const flagParts = flags.split(/[ ,|]+/);
     if (flagParts.length > 1 && !/^[[<]/.test(flagParts[1])) this.short = flagParts.shift();
     this.long = flagParts.shift();
@@ -1722,35 +1722,35 @@ function incrementNodeInspectorPort(args) {
   //  --inspect-brk[=[host:]port]
   //  --inspect-port=[host:]port
   return args.map((arg) => {
-    let result = arg;
-    if (arg.indexOf('--inspect') === 0) {
-      let debugOption;
-      let debugHost = '127.0.0.1';
-      let debugPort = '9229';
-      let match;
-      if ((match = arg.match(/^(--inspect(-brk)?)$/)) !== null) {
-        // e.g. --inspect
-        debugOption = match[1];
-      } else if ((match = arg.match(/^(--inspect(-brk|-port)?)=([^:]+)$/)) !== null) {
-        debugOption = match[1];
-        if (/^\d+$/.test(match[3])) {
-          // e.g. --inspect=1234
-          debugPort = match[3];
-        } else {
-          // e.g. --inspect=localhost
-          debugHost = match[3];
-        }
-      } else if ((match = arg.match(/^(--inspect(-brk|-port)?)=([^:]+):(\d+)$/)) !== null) {
-        // e.g. --inspect=localhost:1234
-        debugOption = match[1];
-        debugHost = match[3];
-        debugPort = match[4];
-      }
-
-      if (debugOption && debugPort !== '0') {
-        result = `${debugOption}=${debugHost}:${parseInt(debugPort) + 1}`;
-      }
+    if (!arg.includes('--inspect')) {
+      return arg;
     }
-    return result;
+    let debugOption;
+    let debugHost = '127.0.0.1';
+    let debugPort = '9229';
+    let match;
+    if ((match = arg.match(/^(--inspect(-brk)?)$/)) !== null) {
+      // e.g. --inspect
+      debugOption = match[1];
+    } else if ((match = arg.match(/^(--inspect(-brk|-port)?)=([^:]+)$/)) !== null) {
+      debugOption = match[1];
+      if (/^\d+$/.test(match[3])) {
+        // e.g. --inspect=1234
+        debugPort = match[3];
+      } else {
+        // e.g. --inspect=localhost
+        debugHost = match[3];
+      }
+    } else if ((match = arg.match(/^(--inspect(-brk|-port)?)=([^:]+):(\d+)$/)) !== null) {
+      // e.g. --inspect=localhost:1234
+      debugOption = match[1];
+      debugHost = match[3];
+      debugPort = match[4];
+    }
+
+    if (debugOption && debugPort !== '0') {
+      return `${debugOption}=${debugHost}:${parseInt(debugPort) + 1}`;
+    }
+    return arg;
   });
 }

--- a/index.js
+++ b/index.js
@@ -1722,7 +1722,7 @@ function incrementNodeInspectorPort(args) {
   //  --inspect-brk[=[host:]port]
   //  --inspect-port=[host:]port
   return args.map((arg) => {
-    if (!arg.includes('--inspect')) {
+    if (!arg.startsWith('--inspect')) {
       return arg;
     }
     let debugOption;


### PR DESCRIPTION
# Pull Request

<!--
The text in these markdown comments is instructions that will not appear in the displayed pull request,
and can be deleted.

Please submit pull requests against the develop branch.

Follow the existing code style. Check the tests succeed, including lint.
  npm run test
  npm run lint

Don't update the CHANGELOG or command version number. That gets done by maintainers when preparing the release.

Commander currently has zero production dependencies. That isn't a hard requirement, but is a simple story. Requests which 
add a dependency are much less likely to be accepted, and we are likely to ask if there alternative approaches to avoid the dependency.
-->

## Problem

<!--
What problem are you solving?
What Issues does this relate to?
Show the broken output if appropriate.
-->

There was some code that was easier to understand using 'includes' than 'indexOf'.

## Solution

<!--
How did you solve the problem? 
Show the fixed output if appropriate.

There are a lot of forms of documentation which could need updating for a change in functionality. It
is ok if you want to show us the code to discuss before doing the extra work, and
you should say so in your comments so we focus on the concept first before talking about all the other pieces:

- TypeScript typings
- JSDoc documentation in code
- tests
- README
- examples/
-->

* Replace 'indexOf' with 'includes'
    * Changed the relevant if statement to an early return.

## ChangeLog

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->
