### PR TITLE
Fix override for semi after base changed

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,7 @@ const javascriptSettings = {
     'no-var': 'warn',
     'one-var': 'off',
     'space-before-function-paren': ['error', 'never'],
-    semi: ['error', 'always']
+    'semi': ['error', 'always']
   },
 }
 
@@ -24,7 +24,8 @@ const typescriptSettings = {
     'no-var': 'warn',
     'one-var': 'off',
     'space-before-function-paren': ['error', 'never'],
-    semi: ['error', 'always'],
+    'semi': 'off',
+    '@typescript-eslint/semi': ['error', 'always'],
     '@typescript-eslint/member-delimiter-style': [
       'error',
       {


### PR DESCRIPTION
# Pull Request

## Problem

Lots of `@typescript-eslint/semi` errors from `eslint`:
 
```bash
npm run typescript-lint
```

I expect this is because `standard-with-typescript` switched from `semi` to `@typescript-eslint/semi` and I didn't notice the issue when I updated dependencies.

## Solution

Change our custom configuration to override `@typescript-eslint/semi`.

## ChangeLog

- fix linting rules for TypeScript