### PR TITLE
Throw for likely option name problems

### DIFF
--- a/index.js
+++ b/index.js
@@ -441,8 +441,8 @@ class Command extends EventEmitter {
     const name = option.attributeName();
     option.mandatory = !!config.mandatory;
 
-    if (!this._storeOptionsAsPropertiesCalled && this[oname] !== undefined && !option.negate) {
-      throw new Error(`option name '${oname}' clashes with existing property on Command
+    if (!this._storeOptionsAsPropertiesCalled && this[name] !== undefined && !option.negate) {
+      throw new Error(`option name '${name}' clashes with existing property on Command
   - either call storeOptionsAsProperties(false) and use .opts() for option values,
   - or call storeOptionsAsProperties(true) to suppress this error and continue storing option values as properties on Command`);
     }

--- a/index.js
+++ b/index.js
@@ -110,6 +110,7 @@ class Command extends EventEmitter {
     this._name = name || '';
     this._optionValues = {};
     this._storeOptionsAsProperties = true; // backwards compatible by default
+    this._storeOptionsAsPropertiesCalled = false;
     this._passCommandToAction = true; // backwards compatible by default
     this._actionResults = [];
     this._actionHandler = null;
@@ -440,6 +441,12 @@ class Command extends EventEmitter {
     const name = option.attributeName();
     option.mandatory = !!config.mandatory;
 
+    if (!this._storeOptionsAsPropertiesCalled && this[oname] !== undefined && !option.negate) {
+      throw new Error(`option name '${oname}' clashes with existing property on Command
+  - either call storeOptionsAsProperties(false) and use .opts() for option values,
+  - or call storeOptionsAsProperties(true) to suppress this error and continue storing option values as properties on Command`);
+    }
+
     // default as 3rd arg
     if (typeof fn !== 'function') {
       if (fn instanceof RegExp) {
@@ -596,6 +603,7 @@ class Command extends EventEmitter {
     */
 
   storeOptionsAsProperties(value) {
+    this._storeOptionsAsPropertiesCalled = true;
     this._storeOptionsAsProperties = (value === undefined) || value;
     if (this.options.length) {
       throw new Error('call .storeOptionsAsProperties() before adding options');

--- a/index.js
+++ b/index.js
@@ -450,16 +450,25 @@ class Command extends EventEmitter {
 
     const commandProperty = this._getOptionValue(option.attributeName());
     if (commandProperty === undefined) {
+      // no clash
       return;
     }
 
-    let foundClash = false;
-    foundClash = true;
+    let foundClash = true;
+    if (option.negate) {
+      // It is ok if define foo before --no-foo.
+      const positiveLongFlag = option.long.replace(/^--no-/, '--');
+      foundClash = !this._findOption(positiveLongFlag);
+    } else if (option.long) {
+      const negativeLongFlag = option.long.replace(/^--/, '--no-');
+      foundClash = !this._findOption(negativeLongFlag);
+    }
 
     if (foundClash) {
-      throw new Error(`option '${option.name()}' clashes with existing property on Command
-- either call storeOptionsAsProperties(false) and use .opts() for option values,
-- or call storeOptionsAsProperties(true) to suppress this error and continue storing option values as properties on Command`);
+      throw new Error(`option '${option.name()}' clashes with existing property '${option.attributeName()}' on Command
+- either call storeOptionsAsProperties(false) and use .opts() to access option values,
+- or call storeOptionsAsProperties(true) to suppress this check,
+- or change option name`);
     }
   };
 

--- a/index.js
+++ b/index.js
@@ -466,7 +466,7 @@ class Command extends EventEmitter {
 
     if (foundClash) {
       throw new Error(`option '${option.name()}' clashes with existing property '${option.attributeName()}' on Command
-- either call storeOptionsAsProperties(false) and use .opts() to access option values,
+- call storeOptionsAsProperties(false) to store option values safely,
 - or call storeOptionsAsProperties(true) to suppress this check,
 - or change option name`);
     }

--- a/tests/options.detectClash.test.js
+++ b/tests/options.detectClash.test.js
@@ -1,0 +1,52 @@
+const commander = require('../');
+
+// Check detection of likely name clashes
+
+test('when option clashes with property then throw', () => {
+  const program = new commander.Command();
+  expect(() => {
+    program.option('-n, --name <name>');
+  }).toThrow();
+});
+
+test('when option clashes with property and storeOptionsAsProperties(true) then ok', () => {
+  const program = new commander.Command();
+  program.storeOptionsAsProperties(true);
+  expect(() => {
+    program.option('-n, --name <name>');
+  }).not.toThrow();
+});
+
+test('when option would clash with property but storeOptionsAsProperties(false) then ok', () => {
+  const program = new commander.Command();
+  program.storeOptionsAsProperties(false);
+  expect(() => {
+    program.option('-n, --name <name>');
+  }).not.toThrow();
+});
+
+test('when negated option clashes with property then throw', () => {
+  const program = new commander.Command();
+  expect(() => {
+    program.option('-E, --no-emit');
+  }).toThrow();
+});
+
+test('when positive and negative option then ok', () => {
+  const program = new commander.Command();
+  expect(() => {
+    program
+      .option('-c, --colour', 'red')
+      .option('-C, --no-colour');
+  }).not.toThrow();
+});
+
+test('when negative and positive option then ok', () => {
+  // Not a likely pattern, but possible and not an error.
+  const program = new commander.Command();
+  expect(() => {
+    program
+      .option('-C, --no-colour')
+      .option('-c, --colour');
+  }).not.toThrow();
+});


### PR DESCRIPTION
# Pull Request

One day we might change the default behaviour to make options safer! In the meantime, we can try harder to warn about possible problems.

## Problem

While the default behaviour is to store options values as properties, people may hit issues with clashes with existing properties:

Collected issues: #933
Recent `--name`: #1226
Recent `--no-emit`: #1237

## Solution

Throw an error if the user has not called `storeOptionsAsProperties` and the property matching the option is already defined. 

Takes a reasonable amount of code to avoid incorrect warnings, but hopefully helps programmer resolve the problem.

## ChangeLog

- throw an error with advice on how to resolve if there might be a clash between option name and a Command property

## Example

```js
program
  .option('-E,--no-emit')
```

```shell
...
      throw new Error(`option '${option.flags}' clashes with existing property '${option.attributeName()}' on Command
      ^

Error: option '--no-emit' clashes with existing property 'emit' on Command
- call storeOptionsAsProperties(false) to store option values safely,
- or call storeOptionsAsProperties(true) to suppress this check,
- or change option name
...
```