### PR TITLE
Implement lazily created sub commands.

### DIFF
--- a/tests/command.subCommandPromise.action.test.js
+++ b/tests/command.subCommandPromise.action.test.js
@@ -1,0 +1,108 @@
+const commander = require('../');
+
+// Test some behaviours of .action not covered in more specific tests.
+
+describe('with action', () => {
+  test('when .action called then builder action is executed', () => {
+    const actionMock = jest.fn();
+    const program = new commander.Command();
+    program.command('run', 'run description', {
+      action: actionOptions => {
+        return actionOptions
+          .command
+          .command('run')
+          .action(actionMock)
+          .parseCommand(actionOptions.operands, actionOptions.unknown);
+      }
+    });
+    program.parse(['node', 'test', 'run']);
+    expect(actionMock).toHaveBeenCalled();
+  });
+
+  test('when .action called action is executed', () => {
+    const actionMock = jest.fn();
+    const program = new commander.Command();
+    program.command('run', 'run description', {
+      action: actionOptions => {
+        return Promise.resolve(actionOptions
+          .command
+          .command('run')
+          .action(actionMock)
+          .parseCommand(actionOptions.operands, actionOptions.unknown));
+      }
+    });
+    return program.parseAsync(['node', 'test', 'run']).then(() => {
+      expect(actionMock).toHaveBeenCalled();
+    });
+  });
+
+  test('arguments is resolved and passed to action', () => {
+    const actionSpy = jest.fn();
+    return new commander.Command()
+      .command('run <action>', 'run description', {
+        action: actionOptions => {
+          return Promise.resolve(actionOptions
+            .command
+            .command('run <arg>')
+            .action((arg) => {
+              expect(arg).toEqual('foo');
+              actionSpy();
+            })
+            .parseCommand(actionOptions.operands, actionOptions.unknown));
+        }
+      })
+      .parseAsync(['node', 'test', 'run', 'foo']).then(() => {
+        expect(actionSpy).toHaveBeenCalled();
+      });
+  });
+
+  test('options is resolved and passed to action', () => {
+    const actionSpy = jest.fn();
+    return new commander.Command()
+      .command('run <action>', 'run description', {
+        action: actionOptions => {
+          return Promise.resolve(actionOptions
+            .command
+            .command('run')
+            .requiredOption('--test-option <val>', 'test value')
+            .action(command => {
+              expect(command.testOption).toEqual('bar');
+              actionSpy();
+            })
+            .parseCommand(actionOptions.operands, actionOptions.unknown)
+          );
+        }
+      })
+      .parseAsync(['node', 'test', 'run', '--test-option', 'bar']).then(() => {
+        expect(actionSpy).toHaveBeenCalled();
+      });
+  });
+
+  test('recursive sub command action', () => {
+    const infoSpy = jest.fn();
+    const runSpy = jest.fn();
+    const runCommandBuilder = actionOptions => {
+      return actionOptions.command.command('run <action>', 'run description', {
+        action: _actionOptions => {
+          if (_actionOptions.operands && _actionOptions.operands[0] === 'run') {
+            runSpy();
+            return runCommandBuilder(_actionOptions)
+              .parseCommand(_actionOptions.operands, _actionOptions.unknown);
+          }
+          return Promise.resolve(actionOptions
+            .command
+            .command('info')
+            .action(infoSpy)
+            .parseCommand(actionOptions.operands, actionOptions.unknown)
+          );
+        }
+      });
+    };
+    return runCommandBuilder({ command: new commander.Command() })
+      .parseAsync(['node', 'test', 'run', 'run', 'run', 'run', 'info']).then(() => {
+        expect(infoSpy).toHaveBeenCalled();
+        expect(runSpy).toHaveBeenCalledTimes(3);
+      })
+    ;
+  });
+});


### PR DESCRIPTION
# Pull Request

<!--
The text in these markdown comments is instructions that will not appear in the displayed pull request,
and can be deleted.

Please submit pull requests against the develop branch.

Follow the existing code style. Check the tests succeed, including lint.
  npm run test
  npm run lint

Don't update the CHANGELOG or command version number. That gets done by maintainers when preparing the release.

Commander currently has zero production dependencies. That isn't a hard requirement, but is a simple story. Requests which 
add a dependency are much less likely to be accepted, and we are likely to ask if there alternative approaches to avoid the dependency.
-->

## Problem

Some programs implements plugin like sub commands.
The plugin options isn't known at the time the root commander is created.

<!--
What problem are you solving?
What Issues does this relate to?
Show the broken output if appropriate.
-->

## Solution

- Implement lazily created sub commands.
- Promisifying some parts of current private api is required.

<!--
How did you solve the problem? 
Show the fixed output if appropriate.

There are a lot of forms of documentation which could need updating for a change in functionality. It
is ok if you want to show us the code to discuss before doing the extra work, and
you should say so in your comments so we focus on the concept first before talking about all the other pieces:

- TypeScript typings
- JSDoc documentation in code
- tests
- README
- examples/
-->

## ChangeLog

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->
