### PR TITLE
fix: assignment of negate property

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ class Option {
     this.required = flags.indexOf('<') >= 0; // A value must be supplied when the option is specified.
     this.optional = flags.indexOf('[') >= 0; // A value is optional when the option is specified.
     this.mandatory = false; // The option must have a value after parsing, which usually means it must be specified on command line.
-    this.negate = flags.indexOf('-no-') !== -1;
+    this.negate = flags.indexOf('--no-') !== -1;
     const flagParts = flags.split(/[ ,|]+/);
     if (flagParts.length > 1 && !/^[[<]/.test(flagParts[1])) this.short = flagParts.shift();
     this.long = flagParts.shift();

--- a/tests/options.opts.test.js
+++ b/tests/options.opts.test.js
@@ -70,4 +70,13 @@ describe.each([true, false])('storeOptionsAsProperties is %s', (storeOptionsAsPr
     program.parse(['node', 'test']);
     expect(program.opts()).toEqual({ pepper: pepperDefault });
   });
+
+  test('when option with name including no- is specified then it should not have default value as true', () => {
+    const program = new commander.Command();
+    program.storeOptionsAsProperties(storeOptionsAsProperties);
+    program
+      .option('--module-no-parse <value>', 'test description');
+    program.parse(['node', 'test']);
+    expect(program.opts()).toEqual({});
+  });
 });


### PR DESCRIPTION
# Pull Request
Resolve #1301 
<!--
The text in these markdown comments is instructions that will not appear in the displayed pull request,
and can be deleted.

Please submit pull requests against the develop branch.

Follow the existing code style. Check the tests succeed, including lint.
  npm run test
  npm run lint

Don't update the CHANGELOG or command version number. That gets done by maintainers when preparing the release.

Commander currently has zero production dependencies. That isn't a hard requirement but is a simple story. Requests which 
add a dependency are much less likely to be accepted, and we are likely to ask if their alternative approaches to avoid the dependency.
-->

## Problem
We were checking for indexOf `-no-` for `negate: true` instead of `--no-`
<!--
What problem are you solving?
What Issues does this relate to?
Show the broken output if appropriate.
-->

## Solution
check index of `--no-`
<!--
How did you solve the problem? 
Show the fixed output if appropriate.

There are a lot of forms of documentation which could need updating for a change in functionality. It
is ok if you want to show us the code to discuss before doing the extra work, and
you should say so in your comments so we focus on the concept first before talking about all the other pieces:

- TypeScript typings
- JSDoc documentation in code
- tests
- README
- examples/
-->

## ChangeLog

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->
