### PR TITLE
Add document links to errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -468,7 +468,9 @@ class Command extends EventEmitter {
       throw new Error(`option '${option.name()}' clashes with existing property '${option.attributeName()}' on Command
 - call storeOptionsAsProperties(false) to store option values safely,
 - or call storeOptionsAsProperties(true) to suppress this check,
-- or change option name`);
+- or change option name
+
+Read more on https://git.io/JJc0W`);
     }
   };
 


### PR DESCRIPTION

# Pull Request

<!--
The text in these markdown comments is instructions that will not appear in the displayed pull request,
and can be deleted.

Please submit pull requests against the develop branch.

Follow the existing code style. Check the tests succeed, including lint.
  npm run test
  npm run lint

Don't update the CHANGELOG or command version number. That gets done by maintainers when preparing the release.

Commander currently has zero production dependencies. That isn't a hard requirement, but is a simple story. Requests which 
add a dependency are much less likely to be accepted, and we are likely to ask if there alternative approaches to avoid the dependency.
-->

## Problem

Not that there was a problem.

<!--
What problem are you solving?
What Issues does this relate to?
Show the broken output if appropriate.
-->

## Solution

I saw another tool that included the URL of the document in the error message.
That helped to solve the problem.

It's just one idea, so close it if you don't need it.

<!--
How did you solve the problem? 
Show the fixed output if appropriate.

There are a lot of forms of documentation which could need updating for a change in functionality. It
is ok if you want to show us the code to discuss before doing the extra work, and
you should say so in your comments so we focus on the concept first before talking about all the other pieces:

- TypeScript typings
- JSDoc documentation in code
- tests
- README
- examples/
-->

## ChangeLog

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->
