### PR TITLE
Fix help default values display

### DIFF
--- a/index.js
+++ b/index.js
@@ -1462,6 +1462,29 @@ class Command extends EventEmitter {
   };
 
   /**
+   * Convert value to a string for help
+   *
+   * @param {number|object|null} value
+   * @return {string}
+   */
+
+  _stringify(value) {
+    if (typeof value === 'object' && value !== null) {
+      // For arrays, simply execute this same method
+      if (Array.isArray(value)) {
+        return value.map((item) => this._stringify(item)).join(',');
+      }
+
+      // Use the `toString` method for objects that don't use the default
+      if (typeof value.toString === 'function' && Object.getPrototypeOf(value).toString !== Object.prototype.toString) {
+        return value.toString();
+      }
+    }
+
+    return JSON.stringify(value);
+  }
+
+  /**
    * Return help for options.
    *
    * @return {string}
@@ -1479,7 +1502,7 @@ class Command extends EventEmitter {
     // Explicit options (including version)
     const help = this.options.map((option) => {
       const fullDesc = option.description +
-        ((!option.negate && option.defaultValue !== undefined) ? ' (default: ' + JSON.stringify(option.defaultValue) + ')' : '');
+        ((!option.negate && option.defaultValue !== undefined) ? ' (default: ' + this._stringify(option.defaultValue) + ')' : '');
       return padOptionDetails(option.flags, fullDesc);
     });
 

--- a/tests/command.help.test.js
+++ b/tests/command.help.test.js
@@ -130,3 +130,62 @@ test('when both help flags masked then not displayed in helpInformation', () => 
   const helpInformation = program.helpInformation();
   expect(helpInformation).not.toMatch('display help');
 });
+
+test('when default value is object with custom toString then custom string displays in helpInformation', () => {
+  const program = new commander.Command();
+  program
+    .option('--host <host>', 'select host', new URL('http://example.com/'));
+  const helpInformation = program.helpInformation();
+  expect(helpInformation).toContain('default: http://example.com/');
+});
+
+test('when default value is object without custom toString then json displays in helpInformation', () => {
+  const program = new commander.Command();
+  program
+    .option('--host <host>', 'select host', { host: 'example.com' });
+  const helpInformation = program.helpInformation();
+  expect(helpInformation).not.toContain('[object Object]');
+  expect(helpInformation).toContain('default: {"host":"example.com"}');
+});
+
+test('when default value is null then null displays in helpInformation', () => {
+  const program = new commander.Command();
+  program
+    .option('--host <host>', 'select host', null);
+  const helpInformation = program.helpInformation();
+  expect(helpInformation).toContain('default: null');
+});
+
+test('when default value is null prototype then null displays in helpInformation', () => {
+  const program = new commander.Command();
+  program
+    .option('--host <host>', 'select host', Object.create(null));
+  const helpInformation = program.helpInformation();
+  expect(helpInformation).toContain('default: {}');
+});
+
+test('when default value is array of object with custom toString then custom string displays in helpInformation', () => {
+  const program = new commander.Command();
+  program
+    .option('--host <host>', 'select host', [new URL('http://example.com/'), new URL('http://example.org/')]);
+  const helpInformation = program.helpInformation();
+  expect(helpInformation).toContain('default: http://example.com/,http://example.org/');
+});
+
+test('when default value is array of object without custom toString then json displays in helpInformation', () => {
+  const program = new commander.Command();
+  program
+    .option('--host <host>', 'select host', [{ host: 'example.com' }, { host: 'example.org' }]);
+  const helpInformation = program.helpInformation();
+  expect(helpInformation).not.toContain('[object Object]');
+  expect(helpInformation).toContain('{"host":"example.com"},{"host":"example.org"}');
+});
+
+test('when default value is array of object with mix of custom toString then custom string or json displays in helpInformation', () => {
+  const program = new commander.Command();
+  program
+    .option('--host <host>', 'select host', [new URL('http://example.com/'), { host: 'example.com' }]);
+  const helpInformation = program.helpInformation();
+  expect(helpInformation).not.toContain('[object Object]');
+  expect(helpInformation).toContain('http://example.com/,{"host":"example.com"}');
+});

--- a/typings/commander-tests.ts
+++ b/typings/commander-tests.ts
@@ -104,6 +104,10 @@ function commaSeparatedList(value: string, dummyPrevious: string[]): string[] {
   return value.split(',');
 }
 
+function parseObject(value: string): object {
+  return JSON.parse(value);
+}
+
 const optionThis5: commander.Command = program.option('-f, --float <number>', 'float argument', parseFloat);
 const optionThis6: commander.Command = program.option('-f, --float <number>', 'float argument', parseFloat, 3.2);
 const optionThis7: commander.Command = program.option('-i, --integer <number>', 'integer argument', myParseInt);
@@ -111,6 +115,8 @@ const optionThis8: commander.Command = program.option('-i, --integer <number>', 
 const optionThis9: commander.Command = program.option('-v, --verbose', 'verbosity that can be increased', increaseVerbosity, 0);
 const optionThis10: commander.Command = program.option('-c, --collect <value>', 'repeatable value', collect, []);
 const optionThis11: commander.Command = program.option('-l, --list <items>', 'comma separated list', commaSeparatedList);
+const optionThis12: commander.Command = program.option('-o, --object <value>', 'object argument', parseObject, {});
+const optionThis13: commander.Command = program.option('-o, --object <value>', 'object argument', parseObject, null);
 
 // requiredOption, same tests as option
 const requiredOptionThis1: commander.Command = program.requiredOption('-a,--alpha');
@@ -125,6 +131,8 @@ const requiredOptionThis8: commander.Command = program.requiredOption('-i, --int
 const requiredOptionThis9: commander.Command = program.requiredOption('-v, --verbose', 'verbosity that can be increased', increaseVerbosity, 0);
 const requiredOptionThis10: commander.Command = program.requiredOption('-c, --collect <value>', 'repeatable value', collect, []);
 const requiredOptionThis11: commander.Command = program.requiredOption('-l, --list <items>', 'comma separated list', commaSeparatedList);
+const requiredOptionThis12: commander.Command = program.requiredOption('-o, --object <value>', 'object argument', parseObject, {});
+const requiredOptionThis13: commander.Command = program.requiredOption('-o, --object <value>', 'object argument', parseObject, null);
 
 // storeOptionsAsProperties
 const storeOptionsAsPropertiesThis1: commander.Command = program.storeOptionsAsProperties();


### PR DESCRIPTION
# Pull Request


<!--
The text in these markdown comments is instructions that will not appear in the displayed pull request,
and can be deleted.

Please submit pull requests against the develop branch.

Follow the existing code style. Check the tests succeed, including lint.
  npm run test
  npm run lint

Don't update the CHANGELOG or command version number. That gets done by maintainers when preparing the release.

Commander currently has zero production dependencies. That isn't a hard requirement, but is a simple story. Requests which 
add a dependency are much less likely to be accepted, and we are likely to ask if there alternative approaches to avoid the dependency.
-->

## Problem

Fixes #1283.

Default values for options that are not either string or boolean display as JSON encoded string.

An example would be using `IPv4` from `ip-num` package produces the following as the default value:

`(default: {"bitSize":32,"maximumBitSize":"4294967295","type":1,"octets":[{"value":1},{"value":1},{"value":1},{"value":1}],"separator":".","value":"16843009"})`

This value is not helpful or user friendly.

<!--
What problem are you solving?
What Issues does this relate to?
Show the broken output if appropriate.
-->

## Solution

Allow for default values that are objects to utilize a custom `toString` method to display for the help.  The default `Object.toString` method will not be used.  All other types of default values will continue to use `JSON.stringify`.

NOTE: This did require a signature change of TypeScript typings to communicate that allows for `defaultValues` to be `any` instead of just `string | boolean`.

<!--
How did you solve the problem? 
Show the fixed output if appropriate.

There are a lot of forms of documentation which could need updating for a change in functionality. It
is ok if you want to show us the code to discuss before doing the extra work, and
you should say so in your comments so we focus on the concept first before talking about all the other pieces:

- TypeScript typings
- JSDoc documentation in code
- tests
- README
- examples/
-->

## ChangeLog

N/A
<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->
