### PR TITLE
tests: remove eslint-disable jest/no-test-callback

### DIFF
--- a/tests/command.exitOverride.test.js
+++ b/tests/command.exitOverride.test.js
@@ -178,7 +178,7 @@ describe('.exitOverride and error details', () => {
   test('when executableSubcommand succeeds then call exitOverride', async() => {
     const pm = path.join(__dirname, 'fixtures/pm');
     const program = new commander.Command();
-    await new Promise(resolve => {
+    await new Promise((resolve) => {
       program
         .exitOverride((err) => {
           expectCommanderError(err, 0, 'commander.executeSubCommandAsync', '(close)');

--- a/tests/command.exitOverride.test.js
+++ b/tests/command.exitOverride.test.js
@@ -176,6 +176,7 @@ describe('.exitOverride and error details', () => {
   });
 
   test('when executableSubcommand succeeds then call exitOverride', async() => {
+    expect.hasAssertions();
     const pm = path.join(__dirname, 'fixtures/pm');
     const program = new commander.Command();
     await new Promise((resolve) => {

--- a/tests/command.exitOverride.test.js
+++ b/tests/command.exitOverride.test.js
@@ -175,19 +175,18 @@ describe('.exitOverride and error details', () => {
     expectCommanderError(caughtErr, 0, 'commander.version', myVersion);
   });
 
-  // Have not worked out a cleaner way to do this, so suppress warning.
-  // eslint-disable-next-line jest/no-test-callback
-  test('when executableSubcommand succeeds then call exitOverride', (done) => {
+  test('when executableSubcommand succeeds then call exitOverride', async() => {
     const pm = path.join(__dirname, 'fixtures/pm');
     const program = new commander.Command();
-    program
-      .exitOverride((err) => {
-        expectCommanderError(err, 0, 'commander.executeSubCommandAsync', '(close)');
-        done();
-      })
-      .command('silent', 'description');
-
-    program.parse(['node', pm, 'silent']);
+    await new Promise(resolve => {
+      program
+        .exitOverride((err) => {
+          expectCommanderError(err, 0, 'commander.executeSubCommandAsync', '(close)');
+          resolve();
+        })
+        .command('silent', 'description');
+      program.parse(['node', pm, 'silent']);
+    });
   });
 
   test('when mandatory program option missing then throw CommanderError', () => {


### PR DESCRIPTION
# Pull Request

## Problem
I'm proposing a way to remove the use of `// eslint-disable-next-line jest/no-test-callback` in one of the tests.

## Solution

We can use a Promise to remove the use of the callback.
If `resolve` isn't called for some reason, the test will fail after 5 seconds (timeout).

## ChangeLog
