### PR TITLE
Identify breaking features in 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - add support for variadic options ([#1250])
 - allow options to be added with just a short flag ([#1256])
-- throw an error if there might be a clash between option name and a Command property, with advice on how to resolve ([#1275])
+  - *Breaking* the option property has same case as flag. e.g. flag `-n` accessed as `opts().n` (previously uppercase)
+- *Breaking* throw an error if there might be a clash between option name and a Command property, with advice on how to resolve ([#1275])
 
 ### Fixed
 


### PR DESCRIPTION
# Pull Request

I didn't identify which items in v6.0.0 would be breaking for some users.

## Problem

People who managed to use short-only flags despite it not being well supported will be broken by change in behaviour with case of option property. #1318

People who were not aware of option name clash or worked around clash will be broken by new throw. #1308

## Solution

Add *Breaking* and extra detail to CHANGELOG for 6.0.0

We could merge this straight to master so it appears in CHANGELOG, or leave it on develop until we do next code change. I like in theory the master branch having same revision as the npm release, but don't think it makes a practical difference so I am leaning towards merge to master? I'll update the Release Notes when merged either way.