### PR TITLE
Improve basedir calculation to fix #1274

### DIFF
--- a/index.js
+++ b/index.js
@@ -823,7 +823,11 @@ Read more on https://git.io/JJc0W`);
     this._checkForMissingMandatoryOptions();
 
     // Want the entry script as the reference for command name and directory for searching for other files.
-    const scriptPath = this._scriptPath;
+    let scriptPath = this._scriptPath;
+    // Fallback in case not set, due to how subcommand created.
+    if (!scriptPath && process.mainModule) {
+      scriptPath = process.mainModule.filename;
+    }
 
     let baseDir;
     try {

--- a/index.js
+++ b/index.js
@@ -824,7 +824,7 @@ Read more on https://git.io/JJc0W`);
 
     // Want the entry script as the reference for command name and directory for searching for other files.
     let scriptPath = this._scriptPath;
-    // Fallback in case not set, due to how subcommand created.
+    // Fallback in case not set, due to how Command created or called.
     if (!scriptPath && process.mainModule) {
       scriptPath = process.mainModule.filename;
     }


### PR DESCRIPTION
# Pull Request

## Problem

With some of the new ways of creating subcommands, the script path from the command line may not have been set on the Command when calling executable subcommand. Although not a common situation

See #1274

## Solution

Use the same fallback as when script path not know during command creation.

## ChangeLog

- fix executable subcommand launching when script path not known