### PR TITLE
Allow partial argument descriptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -1550,7 +1550,7 @@ Read more on https://git.io/JJc0W`);
         desc.push('Arguments:');
         desc.push('');
         this._args.forEach((arg) => {
-          desc.push('  ' + pad(arg.name, width) + '  ' + wrap(argsDescription[arg.name], descriptionWidth, width + 4));
+          desc.push('  ' + pad(arg.name, width) + '  ' + wrap(argsDescription[arg.name] || '', descriptionWidth, width + 4));
         });
         desc.push('');
       }


### PR DESCRIPTION
# Pull Request

## Problem

If any argument descriptions are provided to `.arguments()`, then all the arguments must be described or there is a runtime error.

## Solution

Fallback to empty argument description if missing.

See #1321

## ChangeLog

- allow just some arguments in argumentDescription to `.description()`