### PR TITLE
Add combineFlagAndOptionalValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,9 @@ If you use `program.args` or more complicated tests to detect a missing subcomma
 
 If you use `.command('*')` to add a default command, you may be be able to switch to `isDefault:true` with a named command.
 
+If you want to continue combining short options with optional values as though they were boolean flags, set `combineFlagAndOptionalValue(false)`
+to expand `fb` to `-f -b` rather than `-f b`.
+
 ## [5.0.0-4] (2020-03-03)
 
 (Released in 5.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,7 @@ If you use `program.args` or more complicated tests to detect a missing subcomma
 If you use `.command('*')` to add a default command, you may be be able to switch to `isDefault:true` with a named command.
 
 If you want to continue combining short options with optional values as though they were boolean flags, set `combineFlagAndOptionalValue(false)`
-to expand `fb` to `-f -b` rather than `-f b`.
+to expand `-fb` to `-f -b` rather than `-f b`.
 
 ## [5.0.0-4] (2020-03-03)
 

--- a/index.js
+++ b/index.js
@@ -127,6 +127,7 @@ class Command extends EventEmitter {
     this._defaultCommandName = null;
     this._exitCallback = null;
     this._aliases = [];
+    this._combineFlagAndOptionalValue = true;
 
     this._hidden = false;
     this._helpFlags = '-h, --help';
@@ -194,6 +195,7 @@ class Command extends EventEmitter {
     cmd._exitCallback = this._exitCallback;
     cmd._storeOptionsAsProperties = this._storeOptionsAsProperties;
     cmd._passCommandToAction = this._passCommandToAction;
+    cmd._combineFlagAndOptionalValue = this._combineFlagAndOptionalValue;
 
     cmd._executableFile = opts.executableFile || null; // Custom name for executable file, set missing to null to match constructor
     this.commands.push(cmd);
@@ -634,6 +636,23 @@ Read more on https://git.io/JJc0W`);
 
   requiredOption(flags, description, fn, defaultValue) {
     return this._optionEx({ mandatory: true }, flags, description, fn, defaultValue);
+  };
+
+  /**
+   * Alter parsing of short flags with optional values.
+   *
+   * Examples:
+   *
+   *    // for `.option('-f,--flag [value]'):
+   *    .combineFlagAndOptionalValue(true)  // `-f80` is treated like `--flag=80`, this is the default behaviour
+   *    .combineFlagAndOptionalValue(false) // `-fb` is treated like `-f -b`
+   *
+   * @param {Boolean} [arg] - if `true` or omitted, an optional value can be specified directly after the flag.
+   * @api public
+   */
+  combineFlagAndOptionalValue(arg) {
+    this._combineFlagAndOptionalValue = (arg === undefined) || arg;
+    return this;
   };
 
   /**
@@ -1109,7 +1128,7 @@ Read more on https://git.io/JJc0W`);
       if (arg.length > 2 && arg[0] === '-' && arg[1] !== '-') {
         const option = this._findOption(`-${arg[1]}`);
         if (option) {
-          if (option.required || option.optional) {
+          if (option.required || (option.optional && this._combineFlagAndOptionalValue)) {
             // option with value following in same argument
             this.emit(`option:${option.name()}`, arg.slice(2));
           } else {

--- a/tests/command.parseOptions.test.js
+++ b/tests/command.parseOptions.test.js
@@ -288,4 +288,25 @@ describe('Utility Conventions', () => {
     expect(result).toEqual({ operands: [], unknown: ['--rrr=value'] });
     expect(program.opts()).toEqual({ });
   });
+
+  test('when program has combo optional and combineFlagAndOptionalValue() then treat as value', () => {
+    const program = createProgram();
+    program.combineFlagAndOptionalValue();
+    program.parseOptions(['-db']);
+    expect(program.opts()).toEqual({ ddd: 'b' });
+  });
+
+  test('when program has combo optional and combineFlagAndOptionalValue(true) then treat as value', () => {
+    const program = createProgram();
+    program.combineFlagAndOptionalValue(true);
+    program.parseOptions(['-db']);
+    expect(program.opts()).toEqual({ ddd: 'b' });
+  });
+
+  test('when program has combo optional and combineFlagAndOptionalValue(false) then treat as boolean', () => {
+    const program = createProgram();
+    program.combineFlagAndOptionalValue(false);
+    program.parseOptions(['-db']);
+    expect(program.opts()).toEqual({ ddd: true, bbb: true });
+  });
 });

--- a/typings/commander-tests.ts
+++ b/typings/commander-tests.ts
@@ -134,6 +134,10 @@ const storeOptionsAsPropertiesThis2: commander.Command = program.storeOptionsAsP
 const passCommandToActionThis1: commander.Command = program.passCommandToAction();
 const passCommandToActionThis2: commander.Command = program.passCommandToAction(false);
 
+// combineFlagAndOptionalValue
+const combineFlagAndOptionalValueThis1: commander.Command = program.combineFlagAndOptionalValue();
+const combineFlagAndOptionalValueThis2: commander.Command = program.combineFlagAndOptionalValue(false);
+
 // allowUnknownOption
 const allowUnknownOptionThis1: commander.Command = program.allowUnknownOption();
 const allowUnknownOptionThis2: commander.Command = program.allowUnknownOption(false);

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -206,8 +206,8 @@ declare namespace commander {
      *
      * @example
      *    // for `.option('-f,--flag [value]'):
-     *   .combineFlagAndOptionalValue(false) // `-fb` is treated like `-f -b`
      *   .combineFlagAndOptionalValue(true)  // `-f80` is treated like `--flag=80`, this is the default behaviour
+     *   .combineFlagAndOptionalValue(false) // `-fb` is treated like `-f -b`
      *
      * @returns `this` command for chaining
      */

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -202,6 +202,18 @@ declare namespace commander {
     passCommandToAction(value?: boolean): this;
 
     /**
+     * Alter parsing of short flags with optional values.
+     *
+     * @example
+     *    // for `.option('-f,--flag [value]'):
+     *   .combineFlagAndOptionalValue(false) // `-fb` is treated like `-f -b`
+     *   .combineFlagAndOptionalValue(true)  // `-f80` is treated like `--flag=80`, this is the default behaviour
+     *
+     * @returns `this` command for chaining
+     */
+    combineFlagAndOptionalValue(arg?: boolean): this;
+
+    /**
      * Allow unknown options on the command line.
      *
      * @param [arg] if `true` or omitted, no error will be thrown for unknown options.


### PR DESCRIPTION
# Pull Request

## Problem

Previous versions of Commander always expanded combined short flags, so `-fb` always expanded to `-f -b`.  This allowed combining short flags for options with optional values as though they were boolean flags. 

The new behaviour is that an option with an optional value and the value can be combined, so `-fb` effectively expands to `-f b`.

This is a breaking change for old programs which heavily use optional values without an easy fix.

See: #1203

## Solution

Allow choosing between the two behaviours. Not included in the README. (Thinking might instead include in an future extended discussion of issues with optional values, see #1315.)

## ChangeLog

- add `.combineFlagAndOptionalValue(false)` to ease upgrade path from older versions of Commander (#1326)