### PR TITLE
fix typo: readme example references variables that don't exist

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -376,8 +376,8 @@ program
   .version('0.1.0')
   .arguments('<cmd> [env]')
   .action(function (cmd, env) {
-    console.log('command:', cmdValue);
-    console.log('environment:', envValue || 'no environment given');
+    console.log('command:', cmd);
+    console.log('environment:', env || 'no environment given');
   });
 
 program.parse(process.argv);


### PR DESCRIPTION
# Pull Request

## Problem
Found a type in the readme file while looking for documentation.

## Solution
Simply fixing a typo in the readme file.