### PR TITLE
Add note to Readme related to name clashes

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -627,6 +627,8 @@ There are two new routines to change the behaviour, and the default behaviour ma
 - `passCommandToAction`: whether to pass command to action handler,
 or just the options (specify false)
 
+> It's important to note that those options must be specified before other options that would be affected by this change in behavior, such as `.version(), .option(), etc`
+
 Example file: [storeOptionsAsProperties-action.js](./examples/storeOptionsAsProperties-action.js)
 
 ```js


### PR DESCRIPTION
Options like storeOptionsAsProperties must be specified before some other types of options. This updates the Readme.md to remind readers to keep this in mind.

# Pull Request

<!--
The text in these markdown comments is instructions that will not appear in the displayed pull request,
and can be deleted.

Please submit pull requests against the develop branch.

Follow the existing code style. Check the tests succeed, including lint.
  npm run test
  npm run lint

Don't update the CHANGELOG or command version number. That gets done by maintainers when preparing the release.

Commander currently has zero production dependencies. That isn't a hard requirement, but is a simple story. Requests which 
add a dependency are much less likely to be accepted, and we are likely to ask if there alternative approaches to avoid the dependency.
-->

## Problem
Hit undocumented bug when specifying `storeOptionsAsProperties(false)` after `version()`. The program would silently crash without telling me that I couldn't call `storeOptionsAsProperties(false)` since I've already called `version()`

<!--
What problem are you solving?
What Issues does this relate to?
Show the broken output if appropriate.
-->

## Solution
Update readme to reflect requirement to be careful with the order of functions called

<!--
How did you solve the problem? 
Show the fixed output if appropriate.

There are a lot of forms of documentation which could need updating for a change in functionality. It
is ok if you want to show us the code to discuss before doing the extra work, and
you should say so in your comments so we focus on the concept first before talking about all the other pieces:

- TypeScript typings
- JSDoc documentation in code
- tests
- README
- examples/
-->

## ChangeLog

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->
