### PR TITLE
Add test for addTextHelp returning void

### DIFF
--- a/tests/command.addHelp.test.js
+++ b/tests/command.addHelp.test.js
@@ -33,6 +33,13 @@ describe('program calls to addHelpText', () => {
     expect(writeSpy).toHaveBeenNthCalledWith(2, program.helpInformation());
   });
 
+  test('when "before" function returns void then no effect', () => {
+    const program = new commander.Command();
+    program.addHelpText('before', () => { });
+    program.outputHelp();
+    expect(writeSpy).toHaveBeenNthCalledWith(1, program.helpInformation());
+  });
+
   test('when "beforeAll" string then string before built-in help', () => {
     const program = new commander.Command();
     program.addHelpText('beforeAll', 'text');


### PR DESCRIPTION
# Pull Request

## Problem

Function passed to `.addHelpText` may return void, whether because at runtime there was nothing to write, or because handled writing itself (like just converting straight from `.on('--help'`). This was not being tested.

## Solution

Add a test.