### PR TITLE
Document and test description of arguments

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -368,6 +368,7 @@ Configuration options can be passed with the call to `.command()` and `.addComma
 ### Specify the argument syntax
 
 You use `.arguments` to specify the arguments for the top-level command, and for subcommands they are usually included in the `.command` call. Angled brackets (e.g. `<required>`) indicate required input. Square brackets (e.g. `[optional]`) indicate optional input.
+You can optionally describe the arguments in the help by supplying a hash as second parameter to `.description()`.
 
 Example file: [env](./examples/env)
 
@@ -375,6 +376,10 @@ Example file: [env](./examples/env)
 program
   .version('0.1.0')
   .arguments('<cmd> [env]')
+  .description('test command', {
+    cmd: 'command to run',
+    env: 'environment to run test in'
+  })
   .action(function (cmd, env) {
     console.log('command:', cmd);
     console.log('environment:', env || 'no environment given');

--- a/examples/env
+++ b/examples/env
@@ -12,9 +12,18 @@ let envValue;
 program
   .version('0.0.1')
   .arguments('<cmd> [env]')
+  .description('test command', {
+    cmd: 'command to run',
+    env: 'environment to run test in'
+  })
   .action(function(cmdValue, envValue) {
     console.log('command:', cmdValue);
     console.log('environment:', envValue || 'no environment given');
   });
 
 program.parse(process.argv);
+
+// Try the following:
+//    node env --help
+//    node env add
+//    node env add browser

--- a/index.js
+++ b/index.js
@@ -1576,7 +1576,6 @@ Read more on https://git.io/JJc0W`);
         const columns = process.stdout.columns || 80;
         const descriptionWidth = columns - width - 5;
         desc.push('Arguments:');
-        desc.push('');
         this._args.forEach((arg) => {
           desc.push('  ' + pad(arg.name, width) + '  ' + wrap(argsDescription[arg.name] || '', descriptionWidth, width + 4));
         });

--- a/tests/command.help.test.js
+++ b/tests/command.help.test.js
@@ -156,6 +156,5 @@ test('when arguments described then included in helpInformation', () => {
     .helpOption(false)
     .description('description', { file: 'input source' });
   const helpInformation = program.helpInformation();
-  expect(helpInformation).toMatch('Arguments:');
-  expect(helpInformation).toMatch(/file +input source/);
+  expect(helpInformation).toMatch(/Arguments:\n +file +input source/);
 });

--- a/tests/command.help.test.js
+++ b/tests/command.help.test.js
@@ -139,3 +139,23 @@ test('when no options then Options not includes in helpInformation', () => {
   const helpInformation = program.helpInformation();
   expect(helpInformation).not.toMatch('Options');
 });
+
+test('when arguments then included in helpInformation', () => {
+  const program = new commander.Command();
+  program
+    .name('foo')
+    .arguments('<file>');
+  const helpInformation = program.helpInformation();
+  expect(helpInformation).toMatch('Usage: foo [options] <file>');
+});
+
+test('when arguments described then included in helpInformation', () => {
+  const program = new commander.Command();
+  program
+    .arguments('<file>')
+    .helpOption(false)
+    .description('description', { file: 'input source' });
+  const helpInformation = program.helpInformation();
+  expect(helpInformation).toMatch('Arguments:');
+  expect(helpInformation).toMatch(/file +input source/);
+});


### PR DESCRIPTION
# Pull Request

## Problem

The optional way of describing the command-arguments has not been documented or included in tests.

Related: #1333

## Solution

Add simple test, and document in README.

## ChangeLog

- added how to describe command-arguments to README
