### PR TITLE
Implement allowNegateOption.

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,7 +119,6 @@ class Command extends EventEmitter {
     this.options = [];
     this.parent = null;
     this._allowUnknownOption = false;
-    this._implicitNegateOptions = false;
     this._args = [];
     this.rawArgs = null;
     this._scriptPath = null;
@@ -499,7 +498,7 @@ Read more on https://git.io/JJc0W`);
    */
 
   _optionEx(config, flags, description, fn, defaultValue) {
-    const option = new Option(flags, description).allowNegateOption(this._implicitNegateOptions);
+    const option = new Option(flags, description);
     const oname = option.name();
     const name = option.attributeName();
     option.mandatory = !!config.mandatory;
@@ -674,17 +673,6 @@ Read more on https://git.io/JJc0W`);
    */
   allowUnknownOption(arg) {
     this._allowUnknownOption = (arg === undefined) || arg;
-    return this;
-  };
-
-  /**
-   * Allow implicit negate value to options on the command line.
-   *
-   * @param {Boolean} [arg] - if `true` or omitted, a negate option will be accepted for non negative options with no value or non required values.
-   * @api public
-   */
-  implicitNegateOptions(arg) {
-    this._implicitNegateOptions = (arg === undefined) || arg;
     return this;
   };
 

--- a/index.js
+++ b/index.js
@@ -37,6 +37,14 @@ class Option {
     this.negateOption = false;
   }
 
+  /**
+   * Whether the option allows negate value with prefix `--no-`.
+   *
+   * @param {boolean} allowNegateOption
+   * @return {Option}
+   * @api public
+   */
+
   allowNegateOption(allowNegateOption) {
     allowNegateOption = (allowNegateOption === undefined) || allowNegateOption;
     this.negateOption = !this.negate && this.long && allowNegateOption;

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ class Option {
 
   allowNegateOption(allowNegateOption) {
     allowNegateOption = (allowNegateOption === undefined) || allowNegateOption;
-    this.negateOption = !this.negate && this.long && !this.required && allowNegateOption;
+    this.negateOption = !this.negate && this.long && allowNegateOption;
     return this;
   }
 

--- a/tests/options.bool.test.js
+++ b/tests/options.bool.test.js
@@ -92,18 +92,6 @@ describe('boolean flag on command', () => {
     program.parse(['node', 'test', 'sub', '--no-cheese']);
     expect(subCommand.cheese).toBe(false);
   });
-
-  test('when implicit negatable boolean flag specified then value is false', () => {
-    let subCommand;
-    const program = new commander.Command();
-    program
-      .command('sub')
-      .implicitNegateOptions()
-      .option('--cheese', 'add cheese')
-      .action((cmd) => { subCommand = cmd; });
-    program.parse(['node', 'test', 'sub', '--no-cheese']);
-    expect(subCommand.cheese).toBe(false);
-  });
 });
 
 // This is a somewhat undocumented special behaviour which appears in some examples.

--- a/tests/options.bool.test.js
+++ b/tests/options.bool.test.js
@@ -35,6 +35,16 @@ describe('boolean flag on program', () => {
     program.parse(['node', 'test', '--no-cheese']);
     expect(program.cheese).toBe(false);
   });
+
+  test('when implicit negatable boolean flag specified then value is false', () => {
+    const program = new commander.Command();
+    program
+      .option('--cheese', 'add cheese')
+      ._findOption('--cheese')
+      .allowNegateOption(true);
+    program.parse(['node', 'test', '--no-cheese']);
+    expect(program.cheese).toBe(false);
+  });
 });
 
 // boolean flag on command
@@ -78,6 +88,18 @@ describe('boolean flag on command', () => {
     program
       .command('sub')
       .option('--no-cheese', 'remove cheese')
+      .action((cmd) => { subCommand = cmd; });
+    program.parse(['node', 'test', 'sub', '--no-cheese']);
+    expect(subCommand.cheese).toBe(false);
+  });
+
+  test('when implicit negatable boolean flag specified then value is false', () => {
+    let subCommand;
+    const program = new commander.Command();
+    program
+      .command('sub')
+      .implicitNegateOptions()
+      .option('--cheese', 'add cheese')
       .action((cmd) => { subCommand = cmd; });
     program.parse(['node', 'test', 'sub', '--no-cheese']);
     expect(subCommand.cheese).toBe(false);


### PR DESCRIPTION
# Pull Request

Fixes https://github.com/tj/commander.js/issues/1343
<!--
The text in these markdown comments is instructions that will not appear in the displayed pull request,
and can be deleted.

Please submit pull requests against the develop branch.

Follow the existing code style. Check the tests succeed, including lint.
  npm run test
  npm run lint

Don't update the CHANGELOG or command version number. That gets done by maintainers when preparing the release.

Commander currently has zero production dependencies. That isn't a hard requirement, but is a simple story. Requests which 
add a dependency are much less likely to be accepted, and we are likely to ask if there alternative approaches to avoid the dependency.
-->

## Problem

- We are currently using commander with unknown option parsing using [meow](https://github.com/sindresorhus/meow) that allows `--no-` automatically.
- We implement ~25 sub commands each providing their options.
- Almost every option contains 3 states: false, true and default (saved value).
- Adding a negate option to every option is not an option:
  - help will be too big
  - not every option is added the same way, some are generated, some has to be coded.

<!--
What problem are you solving?
What Issues does this relate to?
Show the broken output if appropriate.
-->

## Solution

- Add allowNegateOption() to Options.
- Add implicitNegateOptions() to Command that will set allowNegateOption() at Options.
- Fallback parsing `--no-foo` to `--foo` with false value if no `--no-foo` option was found.

<!--
How did you solve the problem? 
Show the fixed output if appropriate.

There are a lot of forms of documentation which could need updating for a change in functionality. It
is ok if you want to show us the code to discuss before doing the extra work, and
you should say so in your comments so we focus on the concept first before talking about all the other pieces:

- TypeScript typings
- JSDoc documentation in code
- tests
- README
- examples/
-->

## ChangeLog

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->
