### PR TITLE
Improve command option types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7320,9 +7320,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "version": "4.1.0-dev.20200915",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.0-dev.20200915.tgz",
+      "integrity": "sha512-zpey0vRjTtubK9FnG9AHAiOeAXrxrYUUuPuUisEegnxM/WwiYKx5P9xaP1lx/sMExfzGlQJd0kKq9go0dNLBGw==",
       "dev": true
     },
     "union-value": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "eslint-plugin-jest": "^23.18.0",
     "jest": "^26.1.0",
     "standard": "^14.3.4",
-    "typescript": "^3.9.7"
+    "typescript": "^4.1.0-dev.20200915"
   },
   "typings": "typings/index.d.ts",
   "jest": {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -32,7 +32,7 @@ declare namespace commander {
   type CommandString<S extends string> = S extends `${infer _}--${infer T}` ? Strip<T> : never;
 
   type CommandType<S extends string, T = string> =
-    S extends `${infer _}[${infer _}]` ? T | undefined :
+    S extends `${infer _}[${infer _}]` ? T | boolean :
     S extends `${infer _}<${infer _}>` ? T :
     boolean;
 
@@ -183,9 +183,9 @@ declare namespace commander {
      *
      * @returns `this` command for chaining
      */
-    option<S extends string, T extends string | boolean>(flags: S, description?: string, defaultValue?: T): this & ParseCommand<S, T>;
-    option<S extends string, T extends string | boolean>(flags: S, description: string, regexp: RegExp, defaultValue?: T): this & ParseCommand<S, T>;
-    option<S extends string, T>(flags: S, description: string, fn: (value: string, previous: T) => T, defaultValue?: T): this & ParseCommand<S, T>;
+    option<S extends string, T = string>(flags: S, description?: string, defaultValue?: T): this & Partial<ParseCommand<S, T | string>>;
+    option<S extends string, T = string>(flags: S, description: string, regexp: RegExp, defaultValue?: T): this & Partial<ParseCommand<S, T | string>>;
+    option<S extends string, T>(flags: S, description: string, fn: (value: string, previous: T) => T, defaultValue?: T): this & Partial<ParseCommand<S, T>>;
 
     /**
      * Define a required option, which must have a value after parsing. This usually means
@@ -193,9 +193,9 @@ declare namespace commander {
      *
      * The `flags` string should contain both the short and long flags, separated by comma, a pipe or space.
      */
-    requiredOption<S extends string, T extends string | boolean>(flags: S, description?: string, defaultValue?: T): this & ParseCommand<S, T>;
-    requiredOption<S extends string, T extends string | boolean>(flags: S, description: string, regexp: RegExp, defaultValue?: T): this & ParseCommand<S, T>;
-    requiredOption<S extends string, T extends string | boolean>(flags: S, description: string, fn: (value: string, previous: T) => T, defaultValue?: T): this & ParseCommand<S, T>;
+    requiredOption<S extends string, T = string>(flags: S, description?: string, defaultValue?: T): this & ParseCommand<S, T | string>;
+    requiredOption<S extends string, T = string>(flags: S, description: string, regexp: RegExp, defaultValue?: T): this & ParseCommand<S, T | string>;
+    requiredOption<S extends string, T>(flags: S, description: string, fn: (value: string, previous: T) => T, defaultValue?: T): this & ParseCommand<S, T>;
 
     /**
      * Whether to store option values as properties on command object,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -27,9 +27,21 @@ declare namespace commander {
     from: 'node' | 'electron' | 'user';
   }
 
-  interface Command {
-    [key: string]: any; // options as properties
+  type Strip<S extends string> = S extends `${infer T} ${infer _}` ? T : S;
 
+  type CommandString<S extends string> = S extends `${infer _}--${infer T}` ? Strip<T> : never;
+
+  type CommandType<S extends string, T = string> =
+    S extends `${infer _}[${infer _}]` ? T | undefined :
+    S extends `${infer _}<${infer _}>` ? T :
+    boolean;
+
+  type ParseCommand<S extends string, T = string> =
+    string extends S ? { [key: string]: any } :
+    CommandString<S> extends never ? never :
+    { [K in CommandString<S>]: CommandType<S, T> };
+
+  interface Command {
     args: string[];
 
     commands: Command[];
@@ -171,9 +183,9 @@ declare namespace commander {
      *
      * @returns `this` command for chaining
      */
-    option(flags: string, description?: string, defaultValue?: string | boolean): this;
-    option(flags: string, description: string, regexp: RegExp, defaultValue?: string | boolean): this;
-    option<T>(flags: string, description: string, fn: (value: string, previous: T) => T, defaultValue?: T): this;
+    option<S extends string, T extends string | boolean>(flags: S, description?: string, defaultValue?: T): this & ParseCommand<S, T>;
+    option<S extends string, T extends string | boolean>(flags: S, description: string, regexp: RegExp, defaultValue?: T): this & ParseCommand<S, T>;
+    option<S extends string, T>(flags: S, description: string, fn: (value: string, previous: T) => T, defaultValue?: T): this & ParseCommand<S, T>;
 
     /**
      * Define a required option, which must have a value after parsing. This usually means
@@ -181,9 +193,9 @@ declare namespace commander {
      *
      * The `flags` string should contain both the short and long flags, separated by comma, a pipe or space.
      */
-    requiredOption(flags: string, description?: string, defaultValue?: string | boolean): this;
-    requiredOption(flags: string, description: string, regexp: RegExp, defaultValue?: string | boolean): this;
-    requiredOption<T>(flags: string, description: string, fn: (value: string, previous: T) => T, defaultValue?: T): this;
+    requiredOption<S extends string, T extends string | boolean>(flags: S, description?: string, defaultValue?: T): this & ParseCommand<S, T>;
+    requiredOption<S extends string, T extends string | boolean>(flags: S, description: string, regexp: RegExp, defaultValue?: T): this & ParseCommand<S, T>;
+    requiredOption<S extends string, T extends string | boolean>(flags: S, description: string, fn: (value: string, previous: T) => T, defaultValue?: T): this & ParseCommand<S, T>;
 
     /**
      * Whether to store option values as properties on command object,


### PR DESCRIPTION
# Pull Request

⚠️ For discussion only ⚠️

Use TypeScript's new [template literal types](https://github.com/microsoft/TypeScript/pull/40336) to improve the command option types. This allows the option flags to be parsed at the type level, giving accurate types to the resulting program object instead of falling back on `{ [key: string]: any }`.

* [ ] camelCase properties
* [ ] distinguish between true / false / undefined values
* [x] handle option and requiredOption differently
* [ ] update [commander-tests.ts](https://github.com/tj/commander.js/blob/master/typings/commander-tests.ts) to pass
* [ ] handle [`--no-` prefixed options](https://github.com/tj/commander.js/#user-content-other-option-types-negatable-boolean-and-flagvalue)
* [ ] handle .storeOptionsAsProperties(false)
* [ ] handle .opts()
* [ ] handle .addOption() #1331

## Problem

Currently there is no real type checking for options, so I might access an option that doesn't exist.

## Solution

TypeScript recently added [template literal types](https://github.com/microsoft/TypeScript/pull/40336), allowing types to match patterns in strings. This allows us to parse the option name, and whether it has a required/optional value. Note that this feature is not released yet, but _could_ be released with TypeScript 4.1.0.

See a working example on the [typescript playground](https://www.typescriptlang.org/play?ts=4.1.0-dev.20200913#code/PTAEBUE8AcFNQCawGYEsB2qAuqD26BnUZXAJ1AGNcBbagQ3SVICgRQB5U1AcwzoBtEKDNjyFQAI0gAuUAEF+DebwCuRADwALLFmgFpIXlk0qJAOirVgAhgFo6qggBYAfABpQAWTqkKsfrigACKwAF6w1KBaOnoGwEYm5pbA1Ejh1O6gAG5ZdADWdNTw0br6htiJFjTAOfmFsJkAUir8sEQASgwIuPzQmlHapXEJplVWBFmwGBIqpOgNzMxIFIqk8Oj1BNB0fpQ09Iyw5ADei6CgGFhHyDvwAML7XUcAoqSkZKCwAB5XjESv7xOzHO5yoSFkBCwXHQ3AA3MCQd9sA9waB0CpqBIjvCQaAigQCA5YBCoRg4QjzvNIbAEACyAB+EnQ8nnAC+CKwMHuj0OpDppAehChKgoWA+AF40bAAO6gAAUSKwKOJaIxWNIHjBKshzI8+MJ3G1pJhAEpQOKXKAHrQnny3mR4QjLtdbhxoDh8KBTrjkIpuPpQDqyTiQWsAI4qVBrBCyCS4HqwBiw0BsOTZAQqeDUNRYSTwAgqaDQfioGmgaWaWDoUDGeC4d1iC5ELawCioNA0swU0D1j0bfix+OtJMpsBp3L8TNNnsN-ACcuV6u1md96cttsdhBd3EHBB0MWkGSSIeJ9DJtjgSsrxvZyGgTR0SagOjpyfwOjIK7kbakAhkjwVqgFD9GoKgCPwkB4qeRDYHiOZ5oGcAbqWCA9tWli7qAJbzNuIJxj0g4Jkm3YEJoZBYIygbGiyIIBDCTLBt2SAEBQXCzugDEwiG7LnJycBun2go6iKB7mlKspyr6DgBkGMIeMxrGoOxlGydwZoWgJYiOuczqkDcuwAAo+AQsDsOxRDeiCyDvNQsgAOToLgSB2aAAA+oB2f4rZQvgLnuXZahHHZ3FnDWXKgAAyqS0DqBFnw-FWCDNtRlqSnF3y-EloAAAYACTHBgyBHBArKgPlhXFQA+qy2WgPSECgLIEXaWF-HWruUXMrF8WZclzKpZFPWJUQeUFegRXkNVti2OV43FeANV1ZF0XqOAlqyPMkykC1fHcjajBQHA3UZcNVG6g1kqqal3bpQlfw5bNE2gNVADaj1VayAC6tX1eAbnHkR1bSDdQ33aNFWTay6jvZDLg-Q1wO4vhw5nqFu2gEZv6wO1XTHXdWWqR4f2XSl5okdRoNZXF9XHKAL15LAR6qZ9sgMJBpWIyCOOMJ1ZKxZaJ33ZtxX1cL5Cc+ctMvQA0hc1bcwgvMwvzLNWjyCCHbAsVE5arItbp+l7ZhlnnD4-qcdwL2fS1oLqwGCtWzbKYAFTO92oDO5FsC5su0DvNwpCFNkRx-p6Yo5Tq2W4SCbu4h7ECaKgRBFMYTnPioYq2GsvDUr+NZXgARLYABqHjTVtofoAXxB+u7nuAcB5aoPwgh+5c+fwBXjbopixUVlWoDbASnZ13XoAAJq4ColBKL2YjgZBBZFhBHfnFJ-rPowQgsWxq7h7gW1cEgq9IDcLRYAQ0fnM7wDdl3+ByjqFseOvBAqdR8ltIpykWyasjGEnJ2wBXZjxCGgeYz49j7QQB4VA1BiwRCrFcVCagySb2fKKRsD5GCtFIFfD2Y8AACax6CkDyAQMel54AYS6Nvb+q4k6BkLMWFCoBUEwhymYBSu8xDZQ8I5XMdAiAvh-PUL8NZAhRxoYwKOo846e0Id8QoCCx7ZTURfMeg9-aB2oJo84YxdxyjsisfAxQCBT18A0OmzEcAbD7J9OyJo9GgC4V-HhD9jF0XfKANY0BcB-gPJBS4gQXzzGlCvViiZkGICjN5MgkBHHOLMDsPscpH4WL8J-SEfA+zqUtCba+cc9iEATGYAI3AjEmIgdI1CFBwI0kcSGGOuJWQmiaYUtR2U5G4gUaIyIGwihyEYHIUgG9bBQMwgM98W8zYYiQQQDwZthFrHONldQ4ZIzRjhj2cg2UXpzznPwb6m9UKKDvPQSCAhzEIWyrkLgdAEBATMM8rp8jQCEL6SuIg4yqDjR4LMfcjYDmECIWsLAsxxBhImV0Out9cQ1LlFMoZCARnmzOv+L5lEFZmT7AQP+oB2jewhZrdQACCAvWMWsfc2N1Z2U+i4dpwDY49OCMICBL4amwPga0Io6BokYEgSZURVx4qtgznQCQrRiDN1gPg5lzTiERB8OQyhV4al0PcdWRhS8WFliEavEyvzUJ9O9sVcOUj1ayPkUQpR3LYCqPURQt5WjcAB0KEkhFdlIQ+FzOoEypAshAQaHZDwXqsA+rRPUVC-rA1+ESc6-RnrIT1jpjGoNDjQ3JugJGoo0ajixtgB4D44ELjIDRIEKZTDl4oUaQ615PSiGfKRcM0Z3zoVb0rbQ2ZvKL6LNbc+FZOV1mwAjLEhA2yPh7OBQIY5tCzm5guc+fg1ysQ5TuagB5TyXmNp8EHbhSlVzjP3exHsZbvhivDZK6h6sd06K+aAH5+A0DcABauYFTqWWKvBXMEaZLarqpIOQYCdARAwlhd2BFzaUWtufhqg9YhYO9jfrIGpRwzDPC+BeiVrRsXmXxWSoBIC3kADEUnxJ8VPWx8Bw6ROpZAqFKg7HhuAmWGpcqx4RVgPAAxXQ5RmkA5QKltjuDoP3Mxys0bTCcoXEBECJkiBkooxnDA1HcBj1oyK5cbGJ5TxntWA+Rwj7UKEzS6BEjKA5hoEnfMUm7ZyrhSCDTpnDFTPfsyfFCtCPysKXIBAqERG+J8GWAsEg2PdOaZx7jCL+MfA02gpQYmdgSaYaF9WMnG4YErFwC+gZvbCaINZGgFwcs-iQext5X6IW-sTgQf9aWBPAdA9wcDuIHkIAVnKCgqRZAKyLe6ZDatoE4rEHi-+NWvOgLZe+UZcy+WBkgHyugXxiCxfVuVz9YKqs5T-e21CDWHxNZayCbt8y5QKV-mNwBoVzhMrHoSnO4i6ktwkDsPI5nArPiIL4xQfge0raA+BNBftcB+AJGYRU9nuyKnYIfVASBOvgRexQPIlEFRvB6+rF49pSB5KlFtVyWRcBw-w+N67LtvPx3u0nR7iPXs5WQOgWqAmtNrfC4UxRXxlGtGcecYHbrdEJrjjxxgRjKy9HjSyopLjj2pLso8rYihIJbTjCZe8-hoAS+aVL5JmCH7IEY7r9AfGvQ86KWwSj0AM5q96GrtYpu2RtLZ-HSrP7ts1bq2Z-bIHMBgfkQ502hvJIcXlM85JMHN6QCtrjwncP-oGRstZ9QMfx0k6u92W7bywEqevJ6aUFR6d+lqx4bKMveEnJz-2dTuAjhtk9NlBnVqG1vKoQX6StVVKBjIi0Wp+Bw0CrjMYA1ZFSCCK3nRETr83BjyFbu6JUhoWLMHkpOs5Ati3DMAneAJAW64DzxwoLS7BATjh2PEteeW49gzpbn2NXyx0Egv3as2Vppi+gLVRhgUtxO89iCIu0Ay62BwBFhHAFzOJ-6uTTRAFwCkCgGC5-4PqAGwDAEwHf7vK2oqKC6jiBhwIIIAwoxCBnz8DCbmY3DLr2qYF846JmDApGKAEAFQFBShptaDxIHQG1rWqYGQGsFHA86UGFBmAMEsCYFsAaQABCJ4DAqBuIbAf4dqeBp4BBdA58aC4cwo5BkuIIfB1A1B7EtBdwABjktgLGbQsAIaHkJCBmlAlYJh7BTeGhvO2i-BxhJkPOIhloahUhII00hhzh6hWumhjh2hvhrhYAGkpBLhHB9hWBGyY6A6L6PavBgROhsutg+hCBwEjy5A6g2wxgLgZhxi2Choq80oZAeQaCmRcSh4thMcPO00GRUYKYWA8CiRrqVB9RQhURbhoABcwATR0AsBdh-hN2YA06ggJ2fKLR-OyRYgtBFAABvhdMu0GaHkzBCxL0pCV6DijukRCqm2ru2UO2AGsWB2PuzWfu3YwKeMvU6KckF0Nx3ALgkkheTUWS9CYgbmGKp8ShRBxcGYsAlE4AqeRAAAZBjD6huvwOoJjCZArNrA1O5FdAyhcexFcadITHcVdE8dJC8XBuxLBtnN8NALIPdhhv-ooefL8W+ACUCaAKCZjDgAIFCcZM5rjBFETP9Iie0pcbdNceiWtFiWimybiX2LBgzrIHKBOJmLBn7LAIGlPAGICeaJaOAJ-IQVgJSZmNSZdiCWCSPhCUyVjLCUKWtEienkRiylnuyj4iOpsmWMCgBInI3LeLmA+E+C+JKe+J+MVD+H+DCBvpeB-gWAvFBAwB+s0suMCnBHeKuuuO2KwmHGqmlthLKvKOwLWKQHnqrsuISEUJ9i4jQSaGYE4jsYUi3vXoXu3hTKRFPPwD3otv3rgIPtmcPqPqcvgBPoXh4DPoHHPpBDQovtAMvjsohOvkducDEdGMNvgKifdHyWJJia-DiaXvgB8bcV8RSX8VqfnIwnScyUaeyQiSlO0hOTSFOegDOQTB-BiSlAKQGEKcucHuiQSV8ESQSrANwKSaqd8eqZubIICdqbSbqTCerHCX9Ief1MeTaWOmeReX1BivyYuZFK8ZqqKcHhKX8dKWsHKWoH+bjiqeST8b+RADSbuYaSBcaaadIeac0gAOqVjpnmbJorKRkenCJEDA7QE4BtBoS7Y9gSAABW3kU+byHwTF+YSBs+-gkEj8SE7YkE4RsAhZoAAAktWAPv0HUvJqvCxX8UQHUmpe+BQKDiZCgr6SJskQQHxutrsUSvsYcfVscd7mSGOVRGQKZOZHIAQPHvWEcFxZZR6ZRMjKeECRNm8nRd7FluZkPHpWluHCklgl0LgsJSyh8PxfBBGeZPKLGcgPJVcopdZeznseIAce7rxV7oducbiNFQrOALgHIIHgFYRCjCFWThniygoOIj6WgrgGWtWSPjXNJE3IPqMa+JmJfKgRzlzn4YUiCGwAJlHDQXZLYMgG4NNOvHTB6VsRLDNS4pYBICpsRn6MimeQIBqbAHKGoWaFgc-sgAABwAAM7+CmJmpyqADMOUa1fo4oD1fC25MECmV465RBeYrpeAsweiYw+18wh1Dgx17Ep1fxkkeVZobAN1EgT1NYL1WEb18AN1D66NE1RV1WScHumE5VpxLle1B1R1jAJ1-AZ1coZsgVEh6ALVZpFOnsCgAQsojGeQjk0o+mmVCZ16ZmyZBVzunyL0Zsn0pa22pAmYtUHwVmOgNI-CgQhmHw5+ggq6xg7wAt-2bC6AfNu+gtuKcq7yRNbuJNZVjlFVPS-uh+u+AAqkbfzegGeYzaMszYDGzVRRzUBbjWbFkL9SZDoN1ZlbQhgITmURwjUkQI-gQSpl-iWfHC3kDbmISd5ICp6IwsYPuKvOMTlgfoVv0k5NMqhK6dRleHQNWnUquPqkHS9PdZ9KflvNmfQnmGgvLVqtWI3QAIyfQAT56BTfi7opwhzPhenkB51YDi2ewYZTX6CeEBGtH8E+nnXA7GVh7cBZDbFREupTHr18bnhgA4ElhthYArwfab1tCXxB3l5KGZxIBXCijlrHxZBEBeSijvDoT4CTB8ojam5aECHMlyjUCQD2CtoeC0wl32Qj0uStIn2gBpV3gj1Vq6r+YzY9oLLloAIcKxnzgSqUZxFZBN0t0p0KKW0lXW1HFAYnHOWVWaGgNB2rmWyD0V4DbQnuW4q+2zXUWFJcM5RB0h15bh24rl5R24Ax0iZx0LgDynxJ1z2gBO2q7r2eULYUByzUgPKnqDzMmy1sy6OQAWIYKrjYIIC4LLLvgEAaMb6ErfriAvjeXUDWZKNp0oDfnxRIThoMIA353LiF1WPEA2Rv3l33iPhV3vi13Z293LI71kOt2oTt27yd0cLd1ywkMvQD1D2D5oMmpfjCJT35z7hKML12pL0UNFLANqM2PoAUByg31g5B171DEOGr3aE1MaPH1YFn1ATYBX2qPvBb331doZy4C2DP3eShPZCf2tDf2ei-L-24pANJGdN1NgMQNLLQPBM0BwP+oINtJYEoO5hoM6olh6pYPzJq14MiYENjFxhW6N3N2E22XiDOPWYuVrP1MsMWxWx9a4qURcNnmjYYwJ4mSko1aUV8P+2CPvo7ORDZTCPWnUAHxoLG363vrJXNK0JFUkOIQli5jBIzhHBdDCJby81u1xGzYXxKOTV2rOL30aQ+WBx-AeAUsm3OLTTovVh5C8szhKl0z1jsNWzOIppcuUu8tvYaT7LQDCvkP2EhYIHsv60qCqv8vSshbCvTTKvViqvTxCvOKKvTRKuu0m1sJqspoaumAmvcvmv6uyseAiuMO87MnAue072-OfT4qoZ4JAvmSEoFhEGhUsr2MQroK4ACVTO-J96nEcN5kMwQMel6NRhhnXwO1IZ8ayBSwJsWyqyGN6ytX8PxycY37wAPm0tUP2We620U3OvCkzFPz3F9r+ghA7zwYrlZtS2jIABy9QubFsrS2pjKRbnsAA4t7CfG4u2+gJDriA+Zm-ccGxFhOwliWPqszomdAko5PNPIuk9oICiysnnfpnU6ps+H5nBEQUpFKgIBuvJhvuwOgCvMuGgL+IImu-9Z3mawKgE2M7YIaPMD2WWK-hW688TbVjbXQ05b7vbd2Le0IozR+xdn9cO-7eO++3ewbSzluy5fB5ZfiqpEu4UiW0une9xRuyLbuEo4+8+1eK+3eHh2uGRPrT+9XX+wByS9EiBy8w4+B6TbQuTQw7B61h+20Ih2RzJNRFHkO+zWPOh6R0IuRx8Nh1R7h6J-h560R8WxOyp7QmoESKB7x1bRB7Q1YdB2ccJyCPp4aI-FCMhwRrJ28vJ7p+SwaLKi5dZ+dQR9RFp57CR8uJWj1avGFpUy7sVVW2TTW0JzHA7VMrZ6QPZ6Tn7XJzp1eIF2Wi58nZZ5SPUAu4R4W-7ewFflbq-nLIBvQKuBu4wiF4MYUuFdWCWNSIB4-GaAfo+CBooFelh1eK-gADLtkw0WfhlkSq77tI7kIDrwCSMMxZcxcXHFdYAAAS6unWEgqOjbqkuOm3sgyevnb5DjvFpX3QFA1LMTs7IIr+ql5XMTeXPnBXY8O7emejBIGTr8D99bYcgQBmbwcOkT1u0AY8b3tCR3U7J6Amxjswu2G+RkL3AqClY84c8u2Gf3MwzcWAtgAqpXwK535wr+Htr8rD-0QVDAyF07rDvDN2I7HAC3-3ZXZAFXjYtCEOLlr+q363dn9xW31E+KYse3vm-m2NTXxUCOz2r2MW5ACdsp8yPYRlswG+coyldqPaZY7CImzwSzzwLjKteCxZtXzu6B3OFBgR9u1BRuS1tgr+Zhxutg+S9utsJSrQZSrqRikW5YsAEg2BIqAmh7U3409PZ31RO1Du7SHs6bRuUvfKFsHJkAmIPQHgjXvwRw4poeSyrM6AkeXrAryeLVbIHI4UCsQkwoooEo4k8ormv8ArnmoUBsrouG4jBSjky3vQ3tKMSDPQqElaAmicfmVY3Y3fSA6ALfp47SScYC35Q-xEufOkfKLouwGGWGV6dfI2lMRAS-+AFkUOmGJ3l6rQxGMqrDIUToM-ekrofruKAb58JuuIzLpLmn3YOrd-ufR-X4hsg2u4RwUUgKmjgsWUCsV-K9-ODHNAnaQKwgBu4QvvLWL7bRuwZ5WQGeQgEiQHQ3YBWFjkBBgDbQ-IBAVAMP7shWAYAEICsB8BoIpka+XYHIG7ZBBQA3AAIC9n4B4DPgBAbCOjyR5XpbA8wH4LYGTLlos4NIVsKsHtTLB+BxSO8D6xQyY48EKA0gJ-xwAUB4QhJciGJB9aOhmArQXMFoUUHiCEQ0xDxBMwAJIAZg3AfIhbitwZRA4QgAwbwBhAS5tBZvWwDg2mgEB6ALcfIo4JLSDlQgoQF8H+HCDWDFqdBBAu4M8G2B0YpKLkHkVDRSRCckPILoELoDWCTyCAD2ktSwAAExQRYMkBoDSGDkYQBAcIR5BoS5ZhUDSDwLmA0iz0Fc2AIxG4EcRtIgAA). Scroll to the bottom and hover the `program` variable.

TypeScript will fail to compile if the option flags are not in the right format.

To get the right behavior, the result of chaining off of `commander` needs to be assigned to a new variable, since the type is built up as a result of the chaining.

## ChangeLog

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->
