### PR TITLE
Remove line after Arguments title in help

### DIFF
--- a/index.js
+++ b/index.js
@@ -1576,7 +1576,6 @@ Read more on https://git.io/JJc0W`);
         const columns = process.stdout.columns || 80;
         const descriptionWidth = columns - width - 5;
         desc.push('Arguments:');
-        desc.push('');
         this._args.forEach((arg) => {
           desc.push('  ' + pad(arg.name, width) + '  ' + wrap(argsDescription[arg.name] || '', descriptionWidth, width + 4));
         });

--- a/tests/command.help.test.js
+++ b/tests/command.help.test.js
@@ -156,5 +156,5 @@ test('when arguments described then included in helpInformation', () => {
     .helpOption(false)
     .description('description', { file: 'input source' });
   const helpInformation = program.helpInformation();
-  expect(helpInformation).toMatch(/Arguments:\n\n +file +input source/); // [sic], extra line
+  expect(helpInformation).toMatch(/Arguments:\n +file +input source/); // [sic], extra line
 });


### PR DESCRIPTION
# Pull Request

## Problem

The "Arguments:" title in the help has a trailing blank line, unlike the "Options:" and "Commands:".

```js
const { program } = require('commander');

program
  .arguments('<source> <dest>')
  .description('copy elements from source to dest', {
    source: 'source for elements',
    dest: 'dest for elements'
  });

program
  .option('-g, global', 'global option')
  .command('sub', 'demo sub command');

  program.parse();
```

```sh
% node sections.js --help
Usage: sections [options] [command] <source> <dest>

copy elements from source to dest

Arguments:

  source          source for elements
  dest            dest for elements

Options:
  -g, global      global option
  -h, --help      display help for command

Commands:
  sub             demo sub command
  help [command]  display help for command
```

## Solution

Remove the extra blank line.

```sh
% node sections.js --help
Usage: sections [options] [command] <source> <dest>

copy elements from source to dest

Arguments:
  source          source for elements
  dest            dest for elements

Options:
  -g, global      global option
  -h, --help      display help for command

Commands:
  sub             demo sub command
  help [command]  display help for command
```

## ChangeLog

- remove extra blank line after "Arguments:" in help
