### PR TITLE
Allow tsx file extension for sub-commands (#1367)

### DIFF
--- a/index.js
+++ b/index.js
@@ -838,7 +838,7 @@ Read more on https://git.io/JJc0W`);
   _executeSubCommand(subcommand, args) {
     args = args.slice();
     let launchWithNode = false; // Use node for source targets so do not need to get permissions correct, and on Windows.
-    const sourceExt = ['.js', '.ts', '.mjs'];
+    const sourceExt = ['.js', '.ts', '.tsx', '.mjs'];
 
     // Not checking for help first. Unlikely to have mandatory and executable, and can't robustly test for help flags in external command.
     this._checkForMissingMandatoryOptions();


### PR DESCRIPTION
# Pull Request

<!--
The text in these markdown comments is instructions that will not appear in the displayed pull request,
and can be deleted.

Please submit pull requests against the develop branch.

Follow the existing code style. Check the tests succeed, including lint.
  npm run test
  npm run lint

Don't update the CHANGELOG or command version number. That gets done by maintainers when preparing the release.

Commander currently has zero production dependencies. That isn't a hard requirement, but is a simple story. Requests which 
add a dependency are much less likely to be accepted, and we are likely to ask if there alternative approaches to avoid the dependency.
-->

## Problem

I'm using [ink](https://github.com/vadimdemedes/ink) to implement my cli-app which uses React and right now commander does not look for sub-command files in tsx extension. This PR add tsx as a valid file extension when looking for sub-command files.

Related Issue: #1367

<!--
What problem are you solving?
What Issues does this relate to?
Show the broken output if appropriate.
-->

## Solution

It's a very simple PR where i just added tsx as valid file extension in `_executeSubCommand` function.

<!--
How did you solve the problem? 
Show the fixed output if appropriate.

There are a lot of forms of documentation which could need updating for a change in functionality. It
is ok if you want to show us the code to discuss before doing the extra work, and
you should say so in your comments so we focus on the concept first before talking about all the other pieces:

- TypeScript typings
- JSDoc documentation in code
- tests
- README
- examples/
-->

## ChangeLog

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->
