### PR TITLE
Add tests for some getters

### DIFF
--- a/tests/command.alias.test.js
+++ b/tests/command.alias.test.js
@@ -73,3 +73,17 @@ test('when use second of aliases then action handler called', () => {
   program.parse(['dir'], { from: 'user' });
   expect(actionMock).toHaveBeenCalled();
 });
+
+test('when set alias then can get alias', () => {
+  const program = new commander.Command();
+  const alias = 'abcde';
+  program.alias(alias);
+  expect(program.alias()).toEqual(alias);
+});
+
+test('when set aliases then can get aliases', () => {
+  const program = new commander.Command();
+  const aliases = ['a', 'b'];
+  program.aliases(aliases);
+  expect(program.aliases()).toEqual(aliases);
+});

--- a/tests/command.description.test.js
+++ b/tests/command.description.test.js
@@ -1,0 +1,8 @@
+const commander = require('../');
+
+test('when set description then get description', () => {
+  const program = new commander.Command();
+  const description = 'abcdef';
+  program.description(description);
+  expect(program.description()).toMatch(description);
+});

--- a/tests/options.version.test.js
+++ b/tests/options.version.test.js
@@ -165,4 +165,11 @@ describe('.version', () => {
       program.parse(['node', 'test', '--version']);
     }).toThrow(myVersion);
   });
+
+  test('when specify version then can get version', () => {
+    const myVersion = '1.2.3';
+    const program = new commander.Command();
+    program.version(myVersion);
+    expect(program.version()).toEqual(myVersion);
+  });
 });


### PR DESCRIPTION
# Pull Request

## Problem

We have a setter `foo(value)` getter `foo()` pattern for some properties, but not appearing in tests.

## Solution

Extend tests.