### PR TITLE
Output stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -693,7 +693,7 @@ Read more on https://git.io/JJc0W`);
    * The Stream to which this command writes
    * normal output (help, usage, etc.).
    *
-   * @param {tty.WriteStream} writeStream
+   * @param {stream.Writeable} writeStream
    * @returns {Command} `this` command for chaining
    * @api public
    */

--- a/tests/command.outputStream.test.js
+++ b/tests/command.outputStream.test.js
@@ -1,0 +1,14 @@
+const commander = require('../');
+const stream = require('stream');
+
+test('when command output stream is not set then default is process.stdout', () => {
+  const program = new commander.Command();
+  expect(program.outputStream()).toBe(process.stdout);
+});
+
+test('when set command output stream then command output stream is set', () => {
+  const program = new commander.Command();
+  const customStream = new stream.Writable();
+  program.outputStream(customStream);
+  expect(program.outputStream()).toBe(customStream);
+});

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,6 +1,8 @@
 // Type definitions for commander
 // Original definitions by: Alan Agius <https://github.com/alan-agius4>, Marcelo Dezem <https://github.com/mdezem>, vvakame <https://github.com/vvakame>, Jules Randolph <https://github.com/sveinburne>
 
+import * as stream from 'stream';
+
 declare namespace commander {
 
   interface CommanderError extends Error {
@@ -220,6 +222,17 @@ declare namespace commander {
      * @returns `this` command for chaining
      */
     allowUnknownOption(arg?: boolean): this;
+
+    /**
+     * Set the Stream to which this command writes normal output (help, usage, etc.).
+     *
+     * @returns `this` command for chaining
+     */
+    outputStream(writeStream: stream.Writable): this;
+    /**
+     * Get the Stream to which this command writes normal output (help, usage, etc.).
+     */
+    outputStream(): stream.Writable;
 
     /**
      * Parse `argv`, setting options and invoking commands when defined.


### PR DESCRIPTION
# Pull Request
Add custom output streams to commands

## Problem
stdout isn't available to my user.  I have a custom method of displaying text output to the user.  I still want to make use of the full Commander help suite.  Disabling the built-in help commands and writing wrappers becomes an increasingly complicated task when you want to make use of the entire help suite.  

## Solution
This PR will solve that problem by removing the assumption that all output is to `process.stdout`.  A user can instead pass a writeable stream that will replace the default stdout stream.  In this way, anyone can output command results in any way that works for their use case by defining their own writeable stream.

This is a more elegant solution to the problem in #1370.  Instead of using `helpOption(false)` and writing my own help option, I can use Commander's help option, and handle the output with my own writeable stream.  This is a less invasive solution than #779, as it leaves the implementation of the writeable stream to the user.

**Things to note:**
* I've intentionally not updated the README or the examples/. This is a WIP PR, and I'd like to know if this idea will be accepted before documenting it further.
* This adds a dependency on `stream.Writeable`, but that's built into Node, so I think that's fine
* `process.stdout` is a `stream.Writeable`, but it's also a `tty.WriteStream`.  Only the latter has the `.columns` field in its API.  Nonetheless, I've chosen to work with `stream.Writeable` for a few reasons.
First, `tty.WriteStream` requires a file descriptor passed to its constructor, which is too literal/constraining of an implementation for this idea; not every Commander output stream should need a file descriptor.  
Second, all of Commander's uses of `.columns` are already protected by a default if the value is Falsey. 
Finally, if someone wants a non-default column width in their custom stream, they can specify a `.columns` field themself.  
* An alternative way to address the above point would be to create a type that's just a `stream.Writeable` + `.columns`.  I think this alternative adds unneeded complexity.  Also, under this alternative, I don't know how the default `process.stdout` would fit in, as it wouldn't be of the custom type, even if it was compatible.  However, this alternative would have the pro of not relying on the existing `.columns || 80` in the code to prevent undefined behavior.
* Error output still prints to `process.stderr` by way of `console.error()`.  For my use case, I have no problem with this, but it would be straightforward to expand with an `errorStream()` method and field if we wanted.  
* Similarly, currently Commander doesn't use `console.log()` for standard output.  From this point forward, that would change from an implementation detail to a requirement.

## ChangeLog
* allow overriding the output from default (`process.stdout`) to any `stream.Writeable`
