### PR TITLE
Include tests for supplying optional  param to .hideHelp

### DIFF
--- a/tests/command.help.test.js
+++ b/tests/command.help.test.js
@@ -163,12 +163,28 @@ test('when no options then Options not included in helpInformation', () => {
   expect(helpInformation).not.toMatch('Options');
 });
 
-test('when option hidden then option not included in helpInformation', () => {
+test('when option.hideHelp() then option not included in helpInformation', () => {
   const program = new commander.Command();
   program
     .addOption(new commander.Option('-s,--secret', 'secret option').hideHelp());
   const helpInformation = program.helpInformation();
   expect(helpInformation).not.toMatch('secret');
+});
+
+test('when option.hideHelp(true) then option not included in helpInformation', () => {
+  const program = new commander.Command();
+  program
+    .addOption(new commander.Option('-s,--secret', 'secret option').hideHelp(true));
+  const helpInformation = program.helpInformation();
+  expect(helpInformation).not.toMatch('secret');
+});
+
+test('when option.hideHelp(false) then option included in helpInformation', () => {
+  const program = new commander.Command();
+  program
+    .addOption(new commander.Option('-s,--secret', 'secret option').hideHelp(false));
+  const helpInformation = program.helpInformation();
+  expect(helpInformation).toMatch('secret');
 });
 
 test('when option has default value then default included in helpInformation', () => {

--- a/typings/commander-tests.ts
+++ b/typings/commander-tests.ts
@@ -264,8 +264,9 @@ const myOptionThis5: commander.Option = baseOption.makeOptionMandatory();
 const myOptionThis6: commander.Option = baseOption.makeOptionMandatory(true);
 
 // hideHelp
-const myOptionThis7: commander.Option = baseOption.hideHelp();
-const myOptionThis8: commander.Option = baseOption.hideHelp(true);
+const hideHelpThis1: commander.Option = baseOption.hideHelp();
+const hideHelpThis2: commander.Option = baseOption.hideHelp(true);
+const hideHelpThis3: commander.Option = baseOption.hideHelp(false);
 
 // argumentRejected
 function goodbye(): never {
@@ -273,7 +274,7 @@ function goodbye(): never {
 };
 
 // choices
-const myOptionThis9: commander.Option = baseOption.choices(['a', 'b']);
+const choicesThis: commander.Option = baseOption.choices(['a', 'b']);
 
 // name
 const optionName: string = baseOption.name();


### PR DESCRIPTION
# Pull Request

## Problem

Was not testing the less common use of `.hideHelp()` with an explicit parameter.

## Solution

Add tests for `.hideHelp(true)` and `.hideHelp(false)`.
