### PR TITLE
Add addHelpCommand to TypeScript

### DIFF
--- a/typings/commander-tests.ts
+++ b/typings/commander-tests.ts
@@ -55,6 +55,13 @@ const addCommandThis: commander.Command = program.addCommand(new commander.Comma
 // arguments
 const argumentsThis: commander.Command = program.arguments('<cmd> [env]');
 
+// addHelpCommand
+const addHelpCommandThis1: commander.Command = program.addHelpCommand();
+const addHelpCommandThis3: commander.Command = program.addHelpCommand(false);
+const addHelpCommandThis2: commander.Command = program.addHelpCommand(true);
+const addHelpCommandThis4: commander.Command = program.addHelpCommand('compress <file>');
+const addHelpCommandThis5: commander.Command = program.addHelpCommand('compress <file>', 'compress target file');
+
 // exitOverride
 const exitThis1: commander.Command = program.exitOverride();
 const exitThis2: commander.Command = program.exitOverride((err): never => {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -110,6 +110,17 @@ declare namespace commander {
     arguments(desc: string): this;
 
     /**
+     * Override default decision whether to add implicit help command.
+     *
+     *    addHelpCommand() // force on
+     *    addHelpCommand(false); // force off
+     *    addHelpCommand('help [cmd]', 'display help for [cmd]'); // force on with custom details
+     *
+     * @returns `this` command for chaining
+     */
+    addHelpCommand(enableOrNameAndArgs?: string | boolean, description?: string): this;
+
+    /**
      * Register callback to use as replacement for calling process.exit.
      */
     exitOverride(callback?: (err: CommanderError) => never|void): this;


### PR DESCRIPTION
# Pull Request

## Problem

`addHelpCommand` missing from TypeScript.

See: #1374

## Solution

Added definition and TypeScript usage tests.
