### PR TITLE
Feature createOption

### DIFF
--- a/index.js
+++ b/index.js
@@ -919,7 +919,7 @@ Read more on https://git.io/JJc0W`);
    * create the option. You can override createOption to return a custom option.
    *
    * @param {string} flags
-   * @param {string} description
+   * @param {string} [description]
    * @return {Option} new option
    */
 
@@ -1070,7 +1070,7 @@ Read more on https://git.io/JJc0W`);
    *     program.option('-c, --cheese [type]', 'add cheese [marble]');
    *
    * @param {string} flags
-   * @param {string} description
+   * @param {string} [description]
    * @param {Function|*} [fn] - custom option processing function or default value
    * @param {*} [defaultValue]
    * @return {Command} `this` command for chaining
@@ -1087,7 +1087,7 @@ Read more on https://git.io/JJc0W`);
   * The `flags` string contains the short and/or long flags, separated by comma, a pipe or space.
   *
   * @param {string} flags
-  * @param {string} description
+  * @param {string} [description]
   * @param {Function|*} [fn] - custom option processing function or default value
   * @param {*} [defaultValue]
   * @return {Command} `this` command for chaining

--- a/index.js
+++ b/index.js
@@ -58,11 +58,11 @@ class Help {
     if (showShortHelpFlag || showLongHelpFlag) {
       let helpOption;
       if (!showShortHelpFlag) {
-        helpOption = new Option(cmd._helpLongFlag, cmd._helpDescription);
+        helpOption = cmd.createOption(cmd._helpLongFlag, cmd._helpDescription);
       } else if (!showLongHelpFlag) {
-        helpOption = new Option(cmd._helpShortFlag, cmd._helpDescription);
+        helpOption = cmd.createOption(cmd._helpShortFlag, cmd._helpDescription);
       } else {
-        helpOption = new Option(cmd._helpFlags, cmd._helpDescription);
+        helpOption = cmd.createOption(cmd._helpFlags, cmd._helpDescription);
       }
       visibleOptions.push(helpOption);
     }
@@ -913,6 +913,21 @@ Read more on https://git.io/JJc0W`);
   };
 
   /**
+   * Factory routine to create a new unattached option.
+   *
+   * See .option() for creating an attached option, which uses this routine to
+   * create the option. You can override createOption to return a custom option.
+   *
+   * @param {string} flags
+   * @param {string} description
+   * @return {Option} new option
+   */
+
+  createOption(flags, description) {
+    return new Option(flags, description);
+  };
+
+  /**
    * Add an option.
    *
    * @param {Option} option
@@ -991,7 +1006,7 @@ Read more on https://git.io/JJc0W`);
    * @api private
    */
   _optionEx(config, flags, description, fn, defaultValue) {
-    const option = new Option(flags, description);
+    const option = this.createOption(flags, description);
     option.makeOptionMandatory(!!config.mandatory);
     if (typeof fn === 'function') {
       option.default(defaultValue).argParser(fn);
@@ -1720,7 +1735,7 @@ Read more on https://git.io/JJc0W`);
     this._version = str;
     flags = flags || '-V, --version';
     description = description || 'output the version number';
-    const versionOption = new Option(flags, description);
+    const versionOption = this.createOption(flags, description);
     this._versionOptionName = versionOption.attributeName();
     this.options.push(versionOption);
     this.on('option:' + versionOption.name(), () => {

--- a/tests/command.createOption.test.js
+++ b/tests/command.createOption.test.js
@@ -1,0 +1,42 @@
+const commander = require('../');
+
+class MyOption extends commander.Option {
+  constructor(flags, description) {
+    super(flags, description);
+    this.myProperty = 'MyOption';
+  };
+}
+
+class MyCommand extends commander.Command {
+  createOption(flags, description) {
+    return new MyOption(flags, description);
+  };
+}
+
+test('when override createOption then used for option()', () => {
+  const program = new MyCommand();
+  program.option('-a, --alpha');
+  expect(program.options.length).toEqual(1);
+  expect(program.options[0].myProperty).toEqual('MyOption');
+});
+
+test('when override createOption then used for requiredOption()', () => {
+  const program = new MyCommand();
+  program.requiredOption('-a, --alpha');
+  expect(program.options.length).toEqual(1);
+  expect(program.options[0].myProperty).toEqual('MyOption');
+});
+
+test('when override createOption then used for version()', () => {
+  const program = new MyCommand();
+  program.version('1.2.3');
+  expect(program.options.length).toEqual(1);
+  expect(program.options[0].myProperty).toEqual('MyOption');
+});
+
+test('when override createOption then used for help option in visibleOptions', () => {
+  const program = new MyCommand();
+  const visibleOptions = program.createHelp().visibleOptions(program);
+  expect(visibleOptions.length).toEqual(1);
+  expect(visibleOptions[0].myProperty).toEqual('MyOption');
+});

--- a/typings/commander-tests.ts
+++ b/typings/commander-tests.ts
@@ -135,6 +135,10 @@ const requiredOptionThis9: commander.Command = program.requiredOption('-v, --ver
 const requiredOptionThis10: commander.Command = program.requiredOption('-c, --collect <value>', 'repeatable value', collect, []);
 const requiredOptionThis11: commander.Command = program.requiredOption('-l, --list <items>', 'comma separated list', commaSeparatedList);
 
+// createOption
+const createOption1: commander.Option = program.createOption('a, --alpha');
+const createOption2: commander.Option = program.createOption('a, --alpha', 'description');
+
 // addOption
 const addOptionThis: commander.Command = program.addOption(new commander.Option('-s,--simple'));
 
@@ -234,7 +238,6 @@ const onThis: commander.Command = program.on('command:foo', () => {
 
 // createCommand
 
-const createInstance1: commander.Command = program.createCommand();
 const createInstance2: commander.Command = program.createCommand('name');
 
 class MyCommand extends commander.Command {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -323,6 +323,15 @@ declare namespace commander {
     requiredOption(flags: string, description: string, regexp: RegExp, defaultValue?: string | boolean): this;
 
     /**
+     * Factory routine to create a new unattached option.
+     *
+     * See .option() for creating an attached option, which uses this routine to
+     * create the option. You can override createOption to return a custom option.
+     */
+
+    createOption(flags: string, description?: string): Option;
+
+    /**
      * Add a prepared Option.
      *
      * See .option() and .requiredOption() for creating and attaching an option in a single call.


### PR DESCRIPTION
# Pull Request

This adds `.createOption()` to support Option subclassing, like `.createCommand()` and `.createHelp()`. Probably less likely to be used than those but follow the same pattern and make it possible!