### PR TITLE
Increase test coverage

### DIFF
--- a/tests/command.allowUnknownOptions.test.js
+++ b/tests/command.allowUnknownOptions.test.js
@@ -29,11 +29,35 @@ describe('allowUnknownOption', () => {
     }).toThrow();
   });
 
-  test('when specify unknown program option and allowUnknownOption then no error', () => {
+  test('when specify unknown program option and allowUnknownOption(false) then error', () => {
+    const program = new commander.Command();
+    program
+      .exitOverride()
+      .allowUnknownOption(false)
+      .option('-p, --pepper', 'add pepper');
+
+    expect(() => {
+      program.parse(['node', 'test', '-m']);
+    }).toThrow();
+  });
+
+  test('when specify unknown program option and allowUnknownOption() then no error', () => {
     const program = new commander.Command();
     program
       .exitOverride()
       .allowUnknownOption()
+      .option('-p, --pepper', 'add pepper');
+
+    expect(() => {
+      program.parse(['node', 'test', '-m']);
+    }).not.toThrow();
+  });
+
+  test('when specify unknown program option and allowUnknownOption(true) then no error', () => {
+    const program = new commander.Command();
+    program
+      .exitOverride()
+      .allowUnknownOption(true)
       .option('-p, --pepper', 'add pepper');
 
     expect(() => {

--- a/tests/command.help.test.js
+++ b/tests/command.help.test.js
@@ -163,6 +163,15 @@ test('when no options then Options not included in helpInformation', () => {
   expect(helpInformation).not.toMatch('Options');
 });
 
+test('when negated option then option included in helpInformation', () => {
+  const program = new commander.Command();
+  program
+    .option('-C, --no-colour', 'colourless');
+  const helpInformation = program.helpInformation();
+  expect(helpInformation).toMatch('--no-colour');
+  expect(helpInformation).toMatch('colourless');
+});
+
 test('when option.hideHelp() then option not included in helpInformation', () => {
   const program = new commander.Command();
   program


### PR DESCRIPTION
# Pull Request

Add tests for a couple of cases:
- passing parameter to `.allowUnknownOption()`
- negated option appearing in help