### PR TITLE
Give optional boolean parameters appropriate name, and coerce value to boolean

### DIFF
--- a/index.js
+++ b/index.js
@@ -401,24 +401,24 @@ class Option {
   /**
    * Whether the option is mandatory and must have a value after parsing.
    *
-   * @param {boolean} [value]
+   * @param {boolean} [mandatory]
    * @return {Option}
    */
 
-  makeOptionMandatory(value) {
-    this.mandatory = (value === undefined) || value;
+  makeOptionMandatory(mandatory) {
+    this.mandatory = (mandatory === undefined) || !!mandatory;
     return this;
   };
 
   /**
    * Hide option in help.
    *
-   * @param {boolean} [value]
+   * @param {boolean} [hide]
    * @return {Option}
    */
 
-  hideHelp(value) {
-    this.hidden = (value === undefined) || value;
+  hideHelp(hide) {
+    this.hidden = (hide === undefined) || !!hide;
     return this;
   };
 
@@ -1091,21 +1091,21 @@ Read more on https://git.io/JJc0W`);
    *    .combineFlagAndOptionalValue(true)  // `-f80` is treated like `--flag=80`, this is the default behaviour
    *    .combineFlagAndOptionalValue(false) // `-fb` is treated like `-f -b`
    *
-   * @param {Boolean} [arg] - if `true` or omitted, an optional value can be specified directly after the flag.
+   * @param {Boolean} [combine] - if `true` or omitted, an optional value can be specified directly after the flag.
    */
-  combineFlagAndOptionalValue(arg) {
-    this._combineFlagAndOptionalValue = (arg === undefined) || arg;
+  combineFlagAndOptionalValue(combine) {
+    this._combineFlagAndOptionalValue = (combine === undefined) || !!combine;
     return this;
   };
 
   /**
    * Allow unknown options on the command line.
    *
-   * @param {Boolean} [arg] - if `true` or omitted, no error will be thrown
+   * @param {Boolean} [allowUnknown] - if `true` or omitted, no error will be thrown
    * for unknown options.
    */
-  allowUnknownOption(arg) {
-    this._allowUnknownOption = (arg === undefined) || arg;
+  allowUnknownOption(allowUnknown) {
+    this._allowUnknownOption = (allowUnknown === undefined) || !!allowUnknown;
     return this;
   };
 
@@ -1113,13 +1113,13 @@ Read more on https://git.io/JJc0W`);
     * Whether to store option values as properties on command object,
     * or store separately (specify false). In both cases the option values can be accessed using .opts().
     *
-    * @param {boolean} value
+    * @param {boolean} storeAsProperties
     * @return {Command} `this` command for chaining
     */
 
-  storeOptionsAsProperties(value) {
+  storeOptionsAsProperties(storeAsProperties) {
     this._storeOptionsAsPropertiesCalled = true;
-    this._storeOptionsAsProperties = (value === undefined) || value;
+    this._storeOptionsAsProperties = (storeAsProperties === undefined) || !!storeAsProperties;
     if (this.options.length) {
       throw new Error('call .storeOptionsAsProperties() before adding options');
     }
@@ -1130,12 +1130,12 @@ Read more on https://git.io/JJc0W`);
     * Whether to pass command to action handler,
     * or just the options (specify false).
     *
-    * @param {boolean} value
+    * @param {boolean} passCommand
     * @return {Command} `this` command for chaining
     */
 
-  passCommandToAction(value) {
-    this._passCommandToAction = (value === undefined) || value;
+  passCommandToAction(passCommand) {
+    this._passCommandToAction = (passCommand === undefined) || !!passCommand;
     return this;
   };
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -50,12 +50,12 @@ declare namespace commander {
     /**
      * Whether the option is mandatory and must have a value after parsing.
      */
-    makeOptionMandatory(value?: boolean): this;
+    makeOptionMandatory(mandatory?: boolean): this;
 
     /**
      * Hide option in help.
      */
-    hideHelp(value?: boolean): this;
+    hideHelp(hide?: boolean): this;
 
     /**
      * Validation of option argument failed.
@@ -335,7 +335,7 @@ declare namespace commander {
      *
      * @returns `this` command for chaining
      */
-    storeOptionsAsProperties(value?: boolean): this;
+    storeOptionsAsProperties(storeAsProperties?: boolean): this;
 
     /**
      * Whether to pass command to action handler,
@@ -343,7 +343,7 @@ declare namespace commander {
      *
      * @returns `this` command for chaining
      */
-    passCommandToAction(value?: boolean): this;
+    passCommandToAction(passCommand?: boolean): this;
 
     /**
      * Alter parsing of short flags with optional values.
@@ -355,15 +355,14 @@ declare namespace commander {
      *
      * @returns `this` command for chaining
      */
-    combineFlagAndOptionalValue(arg?: boolean): this;
+    combineFlagAndOptionalValue(combine?: boolean): this;
 
     /**
      * Allow unknown options on the command line.
      *
-     * @param [arg] if `true` or omitted, no error will be thrown for unknown options.
      * @returns `this` command for chaining
      */
-    allowUnknownOption(arg?: boolean): this;
+    allowUnknownOption(allowUnknown?: boolean): this;
 
     /**
      * Parse `argv`, setting options and invoking commands when defined.


### PR DESCRIPTION
# Pull Request

One of the patterns we use is `.allowUnknownOption(param)` where param is optional. The parameters just had generic names, either `value` or `arg`.

- give parameters appropriate names
- coerce value to boolean so stored property value is always just a boolean

The coerce matches how I think about what the routine does, but does not make any practical difference in expected use. Happy to drop if you find odd!