### PR TITLE
Update testing node versions, supported node versions, and archive 4.x CHANGELOG entries

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [10.x, 12.x, 14.x, 15.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - "10"
+  - "12"
   - "lts/*"
 - "node"
 cache:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,90 +201,9 @@ to expand `-fb` to `-f -b` rather than `-f b`.
 
 (Released in 5.0.0)
 
-## [4.1.1] (2020-02-02)
-
-### Fixed
-
-* TypeScript definition for `.action()` should include Promise for async ([#1157])
-
-## [4.1.0] (2020-01-06)
-
-### Added
-
-* two routines to change how option values are handled, and eliminate name clashes with command properties ([#933] [#1102])
-  * see storeOptionsAsProperties and passCommandToAction in README
-* `.parseAsync` to use instead of `.parse` if supply async action handlers ([#806] [#1118])
-
-### Fixed
-
-* Remove trailing blanks from wrapped help text ([#1096])
-
-### Changed
-
-* update dependencies
-* extend security coverage for Commander 2.x to 2020-02-03
-* improvements to README
-* improvements to TypeScript definition documentation
-* move old versions out of main CHANGELOG
-* removed explicit use of `ts-node` in tests
-
-## [4.0.1] (2019-11-12)
-
-### Fixed
-
-* display help when requested, even if there are missing required options ([#1091])
-
-## [4.0.0] (2019-11-02)
-
-### Added
-
-* automatically wrap and indent help descriptions for options and commands ([#1051])
-* `.exitOverride()` allows override of calls to `process.exit` for additional error handling and to keep program running ([#1040])
-* support for declaring required options with `.requiredOptions()` ([#1071])
-* GitHub Actions support ([#1027])
-* translation links in README
-
-### Changed
-
-* dev: switch tests from Sinon+Should to Jest with major rewrite of tests ([#1035])
-* call default subcommand even when there are unknown options ([#1047])
-* *Breaking* Commander is only officially supported on Node 8 and above, and requires Node 6 ([#1053])
-
-### Fixed
-
-* *Breaking* keep command object out of program.args when action handler called ([#1048])
-  * also, action handler now passed array of unknown arguments
-* complain about unknown options when program argument supplied and action handler ([#1049])
-  * this changes parameters to `command:*` event to include unknown arguments
-* removed deprecated `customFds` option from call to `child_process.spawn` ([#1052])
-* rework TypeScript declarations to bring all types into imported namespace ([#1081])
-
-### Migration Tips
-
-#### Testing for no arguments
-
-If you were previously using code like:
-
-```js
-if (!program.args.length) ...
-```
-
-a partial replacement is:
-
-```js
-if (program.rawArgs.length < 3) ...
-```
-
-## [4.0.0-1] Prerelease (2019-10-08)
-
-(Released in 4.0.0)
-
-## [4.0.0-0] Prerelease (2019-10-01)
-
-(Released in 4.0.0)
-
 ## Older versions
 
+* [4.x](./changelogs/CHANGELOG-4.md)
 * [3.x](./changelogs/CHANGELOG-3.md)
 * [2.x](./changelogs/CHANGELOG-2.md)
 * [1.x](./changelogs/CHANGELOG-1.md)
@@ -299,29 +218,13 @@ if (program.rawArgs.length < 3) ...
 [#742]: https://github.com/tj/commander.js/issues/742
 [#764]: https://github.com/tj/commander.js/issues/764
 [#802]: https://github.com/tj/commander.js/issues/802
-[#806]: https://github.com/tj/commander.js/issues/806
 [#809]: https://github.com/tj/commander.js/issues/809
 [#948]: https://github.com/tj/commander.js/issues/948
 [#962]: https://github.com/tj/commander.js/issues/962
 [#995]: https://github.com/tj/commander.js/issues/995
-[#1027]: https://github.com/tj/commander.js/pull/1027
 [#1032]: https://github.com/tj/commander.js/issues/1032
-[#1035]: https://github.com/tj/commander.js/pull/1035
-[#1040]: https://github.com/tj/commander.js/pull/1040
-[#1047]: https://github.com/tj/commander.js/pull/1047
-[#1048]: https://github.com/tj/commander.js/pull/1048
-[#1049]: https://github.com/tj/commander.js/pull/1049
-[#1051]: https://github.com/tj/commander.js/pull/1051
-[#1052]: https://github.com/tj/commander.js/pull/1052
-[#1053]: https://github.com/tj/commander.js/pull/1053
 [#1062]: https://github.com/tj/commander.js/pull/1062
-[#1071]: https://github.com/tj/commander.js/pull/1071
-[#1081]: https://github.com/tj/commander.js/pull/1081
 [#1088]: https://github.com/tj/commander.js/issues/1088
-[#1091]: https://github.com/tj/commander.js/pull/1091
-[#1096]: https://github.com/tj/commander.js/pull/1096
-[#1102]: https://github.com/tj/commander.js/pull/1102
-[#1118]: https://github.com/tj/commander.js/pull/1118
 [#1119]: https://github.com/tj/commander.js/pull/1119
 [#1133]: https://github.com/tj/commander.js/pull/1133
 [#1138]: https://github.com/tj/commander.js/pull/1138
@@ -329,7 +232,6 @@ if (program.rawArgs.length < 3) ...
 [#1146]: https://github.com/tj/commander.js/pull/1146
 [#1149]: https://github.com/tj/commander.js/pull/1149
 [#1153]: https://github.com/tj/commander.js/issues/1153
-[#1157]: https://github.com/tj/commander.js/pull/1157
 [#1159]: https://github.com/tj/commander.js/pull/1159
 [#1165]: https://github.com/tj/commander.js/pull/1165
 [#1169]: https://github.com/tj/commander.js/pull/1169
@@ -379,9 +281,3 @@ if (program.rawArgs.length < 3) ...
 [5.0.0-2]: https://github.com/tj/commander.js/compare/v5.0.0-1..v5.0.0-2
 [5.0.0-1]: https://github.com/tj/commander.js/compare/v5.0.0-0..v5.0.0-1
 [5.0.0-0]: https://github.com/tj/commander.js/compare/v4.1.1..v5.0.0-0
-[4.1.1]: https://github.com/tj/commander.js/compare/v4.1.0..v4.1.1
-[4.1.0]: https://github.com/tj/commander.js/compare/v4.0.1..v4.1.0
-[4.0.1]: https://github.com/tj/commander.js/compare/v4.0.0..v4.0.1
-[4.0.0]: https://github.com/tj/commander.js/compare/v3.0.2..v4.0.0
-[4.0.0-1]: https://github.com/tj/commander.js/compare/v4.0.0-0..v4.0.0-1
-[4.0.0-0]: https://github.com/tj/commander.js/compare/v3.0.2...v4.0.0-0

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,9 +6,9 @@ Old versions receive security updates for six months.
 
 | Version | Supported                                  |
 | ------- | ------------------------------------------ |
-| 5.x     | :white_check_mark:                         |
-| 4.x     | :white_check_mark: support ends 2020-09-14 |
-| < 4     | :x:                                        |
+| 6.x     | :white_check_mark: support ends 2021-30-06 |
+| 5.x     | :white_check_mark: support ends 2021-01-20 |
+| < 5     | :x:                                        |
 
 ## Reporting a Vulnerability
 

--- a/changelogs/CHANGELOG-4.md
+++ b/changelogs/CHANGELOG-4.md
@@ -1,0 +1,108 @@
+# Changelog for 4.x
+
+## [4.1.1] (2020-02-02)
+
+### Fixed
+
+* TypeScript definition for `.action()` should include Promise for async ([#1157])
+
+## [4.1.0] (2020-01-06)
+
+### Added
+
+* two routines to change how option values are handled, and eliminate name clashes with command properties ([#933] [#1102])
+  * see storeOptionsAsProperties and passCommandToAction in README
+* `.parseAsync` to use instead of `.parse` if supply async action handlers ([#806] [#1118])
+
+### Fixed
+
+* Remove trailing blanks from wrapped help text ([#1096])
+
+### Changed
+
+* update dependencies
+* extend security coverage for Commander 2.x to 2020-02-03
+* improvements to README
+* improvements to TypeScript definition documentation
+* move old versions out of main CHANGELOG
+* removed explicit use of `ts-node` in tests
+
+## [4.0.1] (2019-11-12)
+
+### Fixed
+
+* display help when requested, even if there are missing required options ([#1091])
+
+## [4.0.0] (2019-11-02)
+
+### Added
+
+* automatically wrap and indent help descriptions for options and commands ([#1051])
+* `.exitOverride()` allows override of calls to `process.exit` for additional error handling and to keep program running ([#1040])
+* support for declaring required options with `.requiredOptions()` ([#1071])
+* GitHub Actions support ([#1027])
+* translation links in README
+
+### Changed
+
+* dev: switch tests from Sinon+Should to Jest with major rewrite of tests ([#1035])
+* call default subcommand even when there are unknown options ([#1047])
+* *Breaking* Commander is only officially supported on Node 8 and above, and requires Node 6 ([#1053])
+
+### Fixed
+
+* *Breaking* keep command object out of program.args when action handler called ([#1048])
+  * also, action handler now passed array of unknown arguments
+* complain about unknown options when program argument supplied and action handler ([#1049])
+  * this changes parameters to `command:*` event to include unknown arguments
+* removed deprecated `customFds` option from call to `child_process.spawn` ([#1052])
+* rework TypeScript declarations to bring all types into imported namespace ([#1081])
+
+### Migration Tips
+
+#### Testing for no arguments
+
+If you were previously using code like:
+
+```js
+if (!program.args.length) ...
+```
+
+a partial replacement is:
+
+```js
+if (program.rawArgs.length < 3) ...
+```
+
+## [4.0.0-1] Prerelease (2019-10-08)
+
+(Released in 4.0.0)
+
+## [4.0.0-0] Prerelease (2019-10-01)
+
+(Released in 4.0.0)
+
+[#1027]: https://github.com/tj/commander.js/pull/1027
+[#1035]: https://github.com/tj/commander.js/pull/1035
+[#1040]: https://github.com/tj/commander.js/pull/1040
+[#1047]: https://github.com/tj/commander.js/pull/1047
+[#1048]: https://github.com/tj/commander.js/pull/1048
+[#1049]: https://github.com/tj/commander.js/pull/1049
+[#1051]: https://github.com/tj/commander.js/pull/1051
+[#1052]: https://github.com/tj/commander.js/pull/1052
+[#1053]: https://github.com/tj/commander.js/pull/1053
+[#1071]: https://github.com/tj/commander.js/pull/1071
+[#1081]: https://github.com/tj/commander.js/pull/1081
+[#1091]: https://github.com/tj/commander.js/pull/1091
+[#1096]: https://github.com/tj/commander.js/pull/1096
+[#1102]: https://github.com/tj/commander.js/pull/1102
+[#1118]: https://github.com/tj/commander.js/pull/1118
+[#1157]: https://github.com/tj/commander.js/pull/1157
+[#806]: https://github.com/tj/commander.js/issues/806
+
+[4.1.1]: https://github.com/tj/commander.js/compare/v4.1.0..v4.1.1
+[4.1.0]: https://github.com/tj/commander.js/compare/v4.0.1..v4.1.0
+[4.0.1]: https://github.com/tj/commander.js/compare/v4.0.0..v4.0.1
+[4.0.0]: https://github.com/tj/commander.js/compare/v3.0.2..v4.0.0
+[4.0.0-1]: https://github.com/tj/commander.js/compare/v4.0.0-0..v4.0.0-1
+[4.0.0-0]: https://github.com/tj/commander.js/compare/v3.0.2...v4.0.0-0


### PR DESCRIPTION
# Pull Request

- move 4.x CHANGELOG entries to separate file
- update supported versions and dates in SECURITY
- update target versions for testing