### PR TITLE
Rework wrap to have simpler usage pattern

### DIFF
--- a/tests/help.wrap.test.js
+++ b/tests/help.wrap.test.js
@@ -35,16 +35,16 @@ ${' '.repeat(10)}${'a '.repeat(5)}a`);
   });
 
   test('when text has line breaks then respect and indent', () => {
-    const text = 'foo\nbar';
+    const text = 'term description\nanother line';
     const helper = new commander.Help();
-    const wrapped = helper.wrap(text, 50, 3);
-    expect(wrapped).toEqual('foo\n   bar');
+    const wrapped = helper.wrap(text, 78, 5);
+    expect(wrapped).toEqual('term description\n     another line');
   });
 
   test('when text already formatted with line breaks and indent then do not touch', () => {
-    const text = 'a '.repeat(25) + '\n   ' + 'a '.repeat(25) + 'a';
+    const text = 'term a '.repeat(25) + '\n   ' + 'a '.repeat(25) + 'a';
     const helper = new commander.Help();
-    const wrapped = helper.wrap(text, 39, 0);
+    const wrapped = helper.wrap(text, 78, 5);
     expect(wrapped).toEqual(text);
   });
 });

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -112,9 +112,8 @@ declare namespace commander {
     padWidth(cmd: Command, helper: Help): number;
 
     /**
-     * Optionally wrap the given str to a max width of width characters per line
-     * while indenting with indent spaces. Do not wrap if insufficient width or
-     * string is manually formatted.
+     * Wrap the given string to width characters per line, with lines after the first indented.
+     * Do not wrap if insufficient room for wrapping, or string is manually formatted.
      */
     wrap(str: string, width: number, indent: number): string;
 


### PR DESCRIPTION
# Pull Request

The `wrap` routine is now exposed and should make sense alone.

## Problem

The wrap routine was a bit hard to understand in isolation or use for new calls. It does produce
a column of `width` characters excluding the indent, but the column looks misaligned in the result. 

Conceptually:

```
      1234567890
term  d e s c r i p t i o n
123456


wrap('d e s c r i p t i o n', 10, 6):
d e s c r
     i p t i o n

put back together to form

term  d e s c r i
      p t i o n

```

## Solution

Pass in the full text. The width is now the total line length to wrap at, so closely related to the terminal width. The resulting string looks wrapped.

```
12345678901234567890
term  d e s c r i p t i o n

wrap('term  d e s c r i p t i o n', 16, 6):
term  d e s c r
      i p t i o n
```
