### PR TITLE
Rename columns to helpWidth

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -632,7 +632,7 @@ You can configure the Help behaviour by modifying data properties and methods us
 
 The data properties are:
 
-- `columns`: specify the wrap width, useful for unit tests
+- `helpWidth`: specify the wrap width, useful for unit tests
 - `sortSubcommands`: sort the subcommands alphabetically
 - `sortOptions`: sort the options alphabetically
 

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const fs = require('fs');
 // Although this is a class, methods are static in style to allow override using subclass or just functions.
 class Help {
   constructor() {
-    this.columns = undefined;
+    this.helpWidth = undefined;
     this.sortSubcommands = false;
     this.sortOptions = false;
   }
@@ -243,13 +243,13 @@ class Help {
 
   formatHelp(cmd, helper) {
     const termWidth = helper.padWidth(cmd, helper);
-    const columns = helper.columns || 80;
+    const helpWidth = helper.helpWidth || 80;
     const itemIndentWidth = 2;
     const itemSeparatorWidth = 2; // between term and description
     function formatItem(term, description) {
       if (description) {
         const fullText = `${term.padEnd(termWidth + itemSeparatorWidth)}${description}`;
-        return helper.wrap(fullText, columns - itemIndentWidth, termWidth + itemSeparatorWidth);
+        return helper.wrap(fullText, helpWidth - itemIndentWidth, termWidth + itemSeparatorWidth);
       }
       return term;
     };
@@ -550,8 +550,8 @@ class Command extends EventEmitter {
     this._outputConfiguration = {
       writeOut: (str) => process.stdout.write(str),
       writeErr: (str) => process.stderr.write(str),
-      getOutColumns: () => process.stdout.isTTY ? process.stdout.columns : undefined,
-      getErrColumns: () => process.stderr.isTTY ? process.stderr.columns : undefined,
+      getOutHelpWidth: () => process.stdout.isTTY ? process.stdout.columns : undefined,
+      getErrHelpWidth: () => process.stderr.isTTY ? process.stderr.columns : undefined,
       outputError: (str, write) => write(str)
     };
 
@@ -684,9 +684,9 @@ class Command extends EventEmitter {
    *    // functions to change where being written, stdout and stderr
    *    writeOut(str)
    *    writeErr(str)
-   *    // matching functions to specify columns for wrapping help
-   *    getOutColumns()
-   *    getErrColumns()
+   *    // matching functions to specify width for wrapping help
+   *    getOutHelpWidth()
+   *    getErrHelpWidth()
    *    // functions based on what is being written out
    *    outputError(str, write) // used for displaying errors, and not used for displaying help
    *
@@ -1889,8 +1889,8 @@ Read more on https://git.io/JJc0W`);
 
   helpInformation(contextOptions) {
     const helper = this.createHelp();
-    if (helper.columns === undefined) {
-      helper.columns = (contextOptions && contextOptions.error) ? this._outputConfiguration.getErrColumns() : this._outputConfiguration.getOutColumns();
+    if (helper.helpWidth === undefined) {
+      helper.helpWidth = (contextOptions && contextOptions.error) ? this._outputConfiguration.getErrHelpWidth() : this._outputConfiguration.getOutHelpWidth();
     }
     return helper.formatHelp(this, helper);
   };

--- a/tests/command.configureOutput.test.js
+++ b/tests/command.configureOutput.test.js
@@ -107,11 +107,11 @@ test('when custom writeErr then help error on custom output', () => {
   writeSpy.mockRestore();
 });
 
-test('when default getOutColumns then help columns from stdout', () => {
+test('when default getOutHelpWidth then help helpWidth from stdout', () => {
   const expectedColumns = 123;
   const holdIsTTY = process.stdout.isTTY;
   const holdColumns = process.stdout.columns;
-  let helpColumns;
+  let helpWidth;
 
   process.stderr.isTTY = true;
   process.stdout.columns = expectedColumns;
@@ -120,41 +120,41 @@ test('when default getOutColumns then help columns from stdout', () => {
   program
     .configureHelp({
       formatHelp: (cmd, helper) => {
-        helpColumns = helper.columns;
+        helpWidth = helper.helpWidth;
         return '';
       }
     });
   program.outputHelp();
 
-  expect(helpColumns).toBe(expectedColumns);
+  expect(helpWidth).toBe(expectedColumns);
   process.stdout.columns = holdColumns;
   process.stdout.isTTY = holdIsTTY;
 });
 
-test('when custom getOutColumns then help columns custom', () => {
+test('when custom getOutHelpWidth then help helpWidth custom', () => {
   const expectedColumns = 123;
-  let helpColumns;
+  let helpWidth;
 
   const program = new commander.Command();
   program
     .configureHelp({
       formatHelp: (cmd, helper) => {
-        helpColumns = helper.columns;
+        helpWidth = helper.helpWidth;
         return '';
       }
     }).configureOutput({
-      getOutColumns: () => expectedColumns
+      getOutHelpWidth: () => expectedColumns
     });
   program.outputHelp();
 
-  expect(helpColumns).toBe(expectedColumns);
+  expect(helpWidth).toBe(expectedColumns);
 });
 
-test('when default getErrColumns then help error columns from stderr', () => {
+test('when default getErrHelpWidth then help error helpWidth from stderr', () => {
   const expectedColumns = 123;
   const holdIsTTY = process.stderr.isTTY;
   const holdColumns = process.stderr.columns;
-  let helpColumns;
+  let helpWidth;
 
   process.stderr.isTTY = true;
   process.stderr.columns = expectedColumns;
@@ -162,82 +162,82 @@ test('when default getErrColumns then help error columns from stderr', () => {
   program
     .configureHelp({
       formatHelp: (cmd, helper) => {
-        helpColumns = helper.columns;
+        helpWidth = helper.helpWidth;
         return '';
       }
     });
   program.outputHelp({ error: true });
 
-  expect(helpColumns).toBe(expectedColumns);
+  expect(helpWidth).toBe(expectedColumns);
   process.stderr.isTTY = holdIsTTY;
   process.stderr.columns = holdColumns;
 });
 
-test('when custom getErrColumns then help error columns custom', () => {
+test('when custom getErrHelpWidth then help error helpWidth custom', () => {
   const expectedColumns = 123;
-  let helpColumns;
+  let helpWidth;
 
   const program = new commander.Command();
   program
     .configureHelp({
       formatHelp: (cmd, helper) => {
-        helpColumns = helper.columns;
+        helpWidth = helper.helpWidth;
         return '';
       }
     }).configureOutput({
-      getErrColumns: () => expectedColumns
+      getErrHelpWidth: () => expectedColumns
     });
   program.outputHelp({ error: true });
 
-  expect(helpColumns).toBe(expectedColumns);
+  expect(helpWidth).toBe(expectedColumns);
 });
 
-test('when custom getOutColumns and configureHelp:columns then help columns from configureHelp', () => {
+test('when custom getOutHelpWidth and configureHelp:helpWidth then help helpWidth from configureHelp', () => {
   const expectedColumns = 123;
-  let helpColumns;
+  let helpWidth;
 
   const program = new commander.Command();
   program
     .configureHelp({
       formatHelp: (cmd, helper) => {
-        helpColumns = helper.columns;
+        helpWidth = helper.helpWidth;
         return '';
       },
-      columns: expectedColumns
+      helpWidth: expectedColumns
     }).configureOutput({
-      getOutColumns: () => 999
+      getOutHelpWidth: () => 999
     });
   program.outputHelp();
 
-  expect(helpColumns).toBe(expectedColumns);
+  expect(helpWidth).toBe(expectedColumns);
 });
 
-test('when custom getErrColumns and configureHelp:columns then help error columns from configureHelp', () => {
+test('when custom getErrHelpWidth and configureHelp:helpWidth then help error helpWidth from configureHelp', () => {
   const expectedColumns = 123;
-  let helpColumns;
+  let helpWidth;
 
   const program = new commander.Command();
   program
     .configureHelp({
       formatHelp: (cmd, helper) => {
-        helpColumns = helper.columns;
+        helpWidth = helper.helpWidth;
         return '';
       },
-      columns: expectedColumns
+      helpWidth: expectedColumns
     }).configureOutput({
-      getErrColumns: () => 999
+      getErrHelpWidth: () => 999
     });
   program.outputHelp({ error: true });
 
-  expect(helpColumns).toBe(expectedColumns);
+  expect(helpWidth).toBe(expectedColumns);
 });
 
 test('when set configureOutput then get configureOutput', () => {
   const outputOptions = {
     writeOut: jest.fn(),
     writeErr: jest.fn(),
-    getOutColumns: jest.fn(),
-    getErrColumns: jest.fn(),
+    getOutHelpWidth: jest.fn(),
+    getErrHelpWidth: jest.fn(),
     outputError: jest.fn()
   };
   const program = new commander.Command();

--- a/tests/help.wrap.test.js
+++ b/tests/help.wrap.test.js
@@ -56,7 +56,7 @@ describe('wrapping by formatHelp', () => {
   test('when long option description then wrap and indent', () => {
     const program = new commander.Command();
     program
-      .configureHelp({ columns: 80 })
+      .configureHelp({ helpWidth: 80 })
       .option('-x --extra-long-option-switch', 'kjsahdkajshkahd kajhsd akhds kashd kajhs dkha dkh aksd ka dkha kdh kasd ka kahs dkh sdkh askdh aksd kashdk ahsd kahs dkha skdh');
 
     const expectedOutput =
@@ -75,7 +75,7 @@ Options:
   test('when long option description and default then wrap and indent', () => {
     const program = new commander.Command();
     program
-      .configureHelp({ columns: 80 })
+      .configureHelp({ helpWidth: 80 })
       .option('-x --extra-long-option <value>', 'kjsahdkajshkahd kajhsd akhds', 'aaa bbb ccc ddd eee fff ggg');
 
     const expectedOutput =
@@ -93,7 +93,7 @@ Options:
   test('when long command description then wrap and indent', () => {
     const program = new commander.Command();
     program
-      .configureHelp({ columns: 80 })
+      .configureHelp({ helpWidth: 80 })
       .option('-x --extra-long-option-switch', 'x')
       .command('alpha', 'Lorem mollit quis dolor ex do eu quis ad insa a commodo esse.');
 
@@ -118,7 +118,7 @@ Commands:
     const program = new commander.Command();
     const commandDescription = 'description text of very long command which should not be automatically be wrapped. Do fugiat eiusmod ipsum laboris excepteur pariatur sint ullamco tempor labore eu.';
     program
-      .configureHelp({ columns: 60 })
+      .configureHelp({ helpWidth: 60 })
       .command('1234567801234567890x', commandDescription);
 
     const expectedOutput =
@@ -140,7 +140,7 @@ Commands:
     const optionSpec = '-t, --time <HH:MM>';
     const program = new commander.Command();
     program
-      .configureHelp({ columns: 80 })
+      .configureHelp({ helpWidth: 80 })
       .option(optionSpec, `select time
 
 Time can also be specified using special values:

--- a/typings/commander-tests.ts
+++ b/typings/commander-tests.ts
@@ -270,8 +270,8 @@ const configureOutputConfig: commander.OutputConfiguration = program.configureOu
 program.configureOutput({
   writeOut: (str: string) => { },
   writeErr: (str: string) => { },
-  getOutColumns: () => 80,
-  getErrColumns: () => 80,
+  getOutHelpWidth: () => 80,
+  getErrHelpWidth: () => 80,
   outputError: (str: string, write: (str: string) => void) => { }
 });
 
@@ -280,7 +280,7 @@ const helper = new commander.Help();
 const helperCommand = new commander.Command();
 const helperOption = new commander.Option('-a, --all');
 
-helper.columns = 3;
+helper.helpWidth = 3;
 helper.sortSubcommands = true;
 helper.sortOptions = false;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -76,8 +76,8 @@ declare namespace commander {
   type OptionConstructor = new (flags: string, description?: string) => Option;
 
   interface Help {
-    /** output columns, long lines are wrapped to fit */
-    columns?: number;
+    /** output helpWidth, long lines are wrapped to fit */
+    helpWidth?: number;
     sortSubcommands: boolean;
     sortOptions: boolean;
 
@@ -136,8 +136,8 @@ declare namespace commander {
   interface OutputConfiguration {
     writeOut?(str: string): void;
     writeErr?(str: string): void;
-    getOutColumns?(): number;
-    getErrColumns?(): number;
+    getOutHelpWidth?(): number;
+    getErrHelpWidth?(): number;
     outputError?(str: string, write: (str: string) => void): void;
 
   }
@@ -265,9 +265,9 @@ declare namespace commander {
      *    // functions to change where being written, stdout and stderr
      *    writeOut(str)
      *    writeErr(str)
-     *    // matching functions to specify columns for wrapping help
-     *    getOutColumns()
-     *    getErrColumns()
+     *    // matching functions to specify width for wrapping help
+     *    getOutHelpWidth()
+     *    getErrHelpWidth()
      *    // functions based on what is being written out
      *    outputError(str, write) // used for displaying errors, and not used for displaying help
      */


### PR DESCRIPTION
# Pull Request

## Problem

I named the Help property which determines help wrapping `columns`, since the default value is `process.stdout.columns` or `process.stderr.columns`. But this does not describe what it is used for in Help or what custom implementations should be supplying. Naming it based on the purpose could make it clearer for supplying custom values.

## Solution

Rename:
- `columns` -> `helpWidth`
- `getOutColumns()` -> `getOutHelpWidth()`
- `getErrColumns()` -> `getErrHelpWidth()`

## Release Note

This is a breaking change from the first prerelease, but does not need to appear in the final release notes.