### PR TITLE
Add missing param in TypeScript for helpInformation

### DIFF
--- a/typings/commander-tests.ts
+++ b/typings/commander-tests.ts
@@ -213,6 +213,7 @@ program.help({ error: true });
 
 // helpInformation
 const helpInformnationValue: string = program.helpInformation();
+const helpInformnationValue2: string = program.helpInformation({ error: true });
 
 // helpOption
 const helpOptionThis1: commander.Command = program.helpOption('-h,--help');

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -523,7 +523,7 @@ declare namespace commander {
     /**
      * Return command help documentation.
      */
-    helpInformation(): string;
+    helpInformation(context?: HelpContext): string;
 
     /**
      * You can pass in flags and a description to override the help


### PR DESCRIPTION
# Pull Request

## Problem

The optional parameter for `.helpInformation()` was not in the TypeScript definition.

## Solution

Add definition.