### PR TITLE
WYSIWYG sort

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,11 +68,7 @@ class Help {
     }
     if (this.sortOptions) {
       visibleOptions.sort((a, b) => {
-        const compare = a.attributeName().localeCompare(b.attributeName());
-        if (compare === 0) {
-          return (a.negate) ? +1 : -1;
-        }
-        return compare;
+        return a.name().localeCompare(b.name());
       });
     }
     return visibleOptions;

--- a/index.js
+++ b/index.js
@@ -67,8 +67,12 @@ class Help {
       visibleOptions.push(helpOption);
     }
     if (this.sortOptions) {
+      const getSortKey = (option) => {
+        // WYSIWYG for order displayed in help with short before long, no special handling for negated.
+        return option.short ? option.short.replace(/^-/, '') : option.long.replace(/^--/, '');
+      };
       visibleOptions.sort((a, b) => {
-        return a.name().localeCompare(b.name());
+        return getSortKey(a).localeCompare(getSortKey(b));
       });
     }
     return visibleOptions;

--- a/tests/help.sortOptions.test.js
+++ b/tests/help.sortOptions.test.js
@@ -27,7 +27,7 @@ describe('sortOptions', () => {
     expect(visibleOptionNames).toEqual(['aaa', 'bbb', 'help', 'zzz']);
   });
 
-  test('when both short and long flags then sort on long flag (name)', () => {
+  test('when both short and long flags then sort on short flag', () => {
     const program = new commander.Command();
     program
       .configureHelp({ sortOptions: true })
@@ -36,10 +36,10 @@ describe('sortOptions', () => {
       .option('-o,--bbb', 'desc');
     const helper = program.createHelp();
     const visibleOptionNames = helper.visibleOptions(program).map(cmd => cmd.name());
-    expect(visibleOptionNames).toEqual(['aaa', 'bbb', 'help', 'zzz']);
+    expect(visibleOptionNames).toEqual(['help', 'zzz', 'aaa', 'bbb']);
   });
 
-  test('when lone short and long flags then sort on flag (name)', () => {
+  test('when lone short and long flags then sort on lone flag', () => {
     const program = new commander.Command();
     program
       .configureHelp({ sortOptions: true })
@@ -49,6 +49,18 @@ describe('sortOptions', () => {
     const helper = program.createHelp();
     const visibleOptionNames = helper.visibleOptions(program).map(cmd => cmd.name());
     expect(visibleOptionNames).toEqual(['aaa', 'b', 'help', 'zzz']);
+  });
+
+  test('when mixed case flags then sort is case insensitive', () => {
+    const program = new commander.Command();
+    program
+      .configureHelp({ sortOptions: true })
+      .option('-B', 'desc')
+      .option('-a', 'desc')
+      .option('-c', 'desc');
+    const helper = program.createHelp();
+    const visibleOptionNames = helper.visibleOptions(program).map(cmd => cmd.name());
+    expect(visibleOptionNames).toEqual(['a', 'B', 'c', 'help']);
   });
 
   test('when negated option then sort negated option separately', () => {

--- a/tests/help.sortOptions.test.js
+++ b/tests/help.sortOptions.test.js
@@ -27,7 +27,7 @@ describe('sortOptions', () => {
     expect(visibleOptionNames).toEqual(['aaa', 'bbb', 'help', 'zzz']);
   });
 
-  test('when short and long flags then sort on long flag (name)', () => {
+  test('when both short and long flags then sort on long flag (name)', () => {
     const program = new commander.Command();
     program
       .configureHelp({ sortOptions: true })
@@ -39,7 +39,19 @@ describe('sortOptions', () => {
     expect(visibleOptionNames).toEqual(['aaa', 'bbb', 'help', 'zzz']);
   });
 
-  test('when negated option with positive then sort together with negative after positive', () => {
+  test('when lone short and long flags then sort on flag (name)', () => {
+    const program = new commander.Command();
+    program
+      .configureHelp({ sortOptions: true })
+      .option('--zzz', 'desc')
+      .option('--aaa', 'desc')
+      .option('-b', 'desc');
+    const helper = program.createHelp();
+    const visibleOptionNames = helper.visibleOptions(program).map(cmd => cmd.name());
+    expect(visibleOptionNames).toEqual(['aaa', 'b', 'help', 'zzz']);
+  });
+
+  test('when negated option then sort negated option separately', () => {
     const program = new commander.Command();
     program
       .configureHelp({ sortOptions: true })
@@ -49,19 +61,6 @@ describe('sortOptions', () => {
       .option('--aaa', 'desc');
     const helper = program.createHelp();
     const visibleOptionNames = helper.visibleOptions(program).map(cmd => cmd.name());
-    expect(visibleOptionNames).toEqual(['aaa', 'bbb', 'no-bbb', 'ccc', 'help']);
-  });
-
-  test('when negated option without positive then still sorts using attribute name', () => {
-    // Sorting '--no-foo' as 'foo' (mainly for when also 'foo' so sort together)!
-    const program = new commander.Command();
-    program
-      .configureHelp({ sortOptions: true })
-      .option('--ccc', 'desc')
-      .option('--aaa', 'desc')
-      .option('--no-bbb', 'desc');
-    const helper = program.createHelp();
-    const visibleOptionNames = helper.visibleOptions(program).map(cmd => cmd.name());
-    expect(visibleOptionNames).toEqual(['aaa', 'no-bbb', 'ccc', 'help']);
+    expect(visibleOptionNames).toEqual(['aaa', 'bbb', 'ccc', 'help', 'no-bbb']);
   });
 });


### PR DESCRIPTION
# Pull Request

## Problem

There are lots of things we might consider when sorting the options in the help: short flags vs long flags, help flags, and how to sort negated flags. Using the `name` or `attributeName` is tempting but is not what is displayed in the help.

Having an easy to understand method is probably better than having a clever method!

## Solution

I looked at the help for `tar`, which sorts on short flags over long flags, and sorts `--no-foo` as `no-foo` rather than with `foo`.

This is straight forward and matches the way we display the flags in the help, with each line starting with short flags before long flags. Negated options and help options are not treated specially.