### PR TITLE
Improve backwards compatibility for command events

### DIFF
--- a/index.js
+++ b/index.js
@@ -1490,6 +1490,7 @@ Read more on https://git.io/JJc0W`);
         this.unknownOption(parsed.unknown[0]);
       }
 
+      const commandEvent = `command:${this.name()}`;
       if (this._actionHandler) {
         const args = this.args.slice();
         this._args.forEach((arg, i) => {
@@ -1501,9 +1502,11 @@ Read more on https://git.io/JJc0W`);
         });
 
         this._actionHandler(args);
-        this.emit('command:' + this.name(), operands, unknown);
+        if (this.parent) this.parent.emit(commandEvent, operands, unknown); // legacy
+      } else if (this.parent && this.parent.listenerCount(commandEvent)) {
+        this.parent.emit(commandEvent, operands, unknown); // legacy
       } else if (operands.length) {
-        if (this._findCommand('*')) {
+        if (this._findCommand('*')) { // legacy
           this._dispatchSubcommand('*', operands, unknown);
         } else if (this.listenerCount('command:*')) {
           this.emit('command:*', operands, unknown);

--- a/tests/command.onCommand.test.js
+++ b/tests/command.onCommand.test.js
@@ -1,0 +1,38 @@
+const commander = require('../');
+
+// The action handler used to be implemented using command events and listeners.
+// Now, this is mostly just for backwards compatibility.
+
+describe(".command('*')", () => {
+  test('when action handler for subcommand then emit command:subcommand', () => {
+    const mockListener = jest.fn();
+    const program = new commander.Command();
+    program
+      .command('sub')
+      .action(() => {});
+    program.on('command:sub', mockListener);
+    program.parse(['sub'], { from: 'user' });
+    expect(mockListener).toHaveBeenCalled();
+  });
+
+  test('when no action handler for subcommand then still emit command:subcommand', () => {
+    const mockListener = jest.fn();
+    const program = new commander.Command();
+    program
+      .command('sub');
+    program.on('command:sub', mockListener);
+    program.parse(['sub'], { from: 'user' });
+    expect(mockListener).toHaveBeenCalled();
+  });
+
+  test('when subcommand has argument then emit command:subcommand with argument', () => {
+    const mockListener = jest.fn();
+    const program = new commander.Command();
+    program
+      .command('sub <file>')
+      .action(() => {});
+    program.on('command:sub', mockListener);
+    program.parse(['sub', 'file'], { from: 'user' });
+    expect(mockListener).toHaveBeenCalledWith(['file'], []);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Problem

The custom command event (e.g. `'command:example'`) was being emit-ed from the wrong object to be useful and for backwards compatibility with Commander v4 and earlier.

See: #1402

## Solution

The command events used to be how Commander triggered the action handler, and custom listeners were somewhat of a free bonus. Now the parsing is rather different and it requires extra code to approximate the old behaviour.

There have never been explicit tests for the events. I have added some tests so at least the behaviour is more stable going forward. 

(From code inspection, there may be some minor differences in edge cases from historical behaviour which I won't be attempting to match, like what event name is generated for aliases).

## ChangeLog

- improve backwards compatibility for custom command event listeners (#1403)
