### PR TITLE
Correctly display default value Infinity in optionHelp instead of null

### DIFF
--- a/index.js
+++ b/index.js
@@ -1509,7 +1509,7 @@ Read more on https://git.io/JJc0W`);
     // Explicit options (including version)
     const help = this.options.map((option) => {
       const fullDesc = option.description +
-        ((!option.negate && option.defaultValue !== undefined) ? ' (default: ' + JSON.stringify(option.defaultValue) + ')' : '');
+        ((!option.negate && option.defaultValue !== undefined) ? ' (default: ' + stringify(option.defaultValue) + ')' : '');
       return padOptionDetails(option.flags, fullDesc);
     });
 
@@ -1776,6 +1776,21 @@ function optionalWrap(str, width, indent) {
   if (width < minWidth) return str;
 
   return wrap(str, width, indent);
+}
+
+/**
+ * Convert JS value to JSON string for output in help.
+ *
+ * @param {any} value
+ * @return {string}
+ * @api private
+ */
+
+function stringify(value) {
+  if (value === Infinity || value === -Infinity) {
+    return value.toString();
+  }
+  return JSON.stringify(value);
 }
 
 /**


### PR DESCRIPTION
# Pull Request

## Problem

If an option has a default value of `Infinity`, it is printed as `null` in the help, because `JSON.stringify(Infinity) === null`.

Test program:

```js
const { program } = require('commander');
program.option('-m, --max <int>', 'max value', parseInt, Infinity);
program.parse(process.argv);
```

Current output:

```sh
> ./test.js --help
Usage: test [options]

Options:
  -m, --max <int>  max value (default: null)
  -h, --help       display help for command
```

## Solution

This PR adds a wrapper function `stringify` for the used `JSON.stringify` which checks for the values `Infinity` and `-Infinity`.

Corrected output:

```sh
> ./test.js --help
Usage: test [options]

Options:
  -m, --max <int>  max value (default: Infinity)
  -h, --help       display help for command
```

## ChangeLog

Fixed: correctly print default value `Infinity` in option help text
