### PR TITLE
Bump required version of node to oldest LTS which is 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
     "collectCoverage": true
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 10"
   }
 }


### PR DESCRIPTION
# Pull Request

For releasing a new version, bump required node to the oldest LTS version to match what we support and test.
