### PR TITLE
Update supported details for 7.x

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -865,8 +865,8 @@ More samples can be found in the [examples](https://github.com/tj/commander.js/t
 
 ## Support
 
-The current version of Commander is fully supported on Long Term Support versions of Node, and is likely to work with Node 6 but not tested.
-(For versions of Node below Node 6, use Commander 3.x or 2.x.)
+The current version of Commander is fully supported on Long Term Support versions of node, and requires node v10.
+(For older versions of node, use an older version of Commander. Commander version 2.x has the widest support.)
 
 The main forum for free and community support is the project [Issues](https://github.com/tj/commander.js/issues) on GitHub.
 

--- a/Readme.md
+++ b/Readme.md
@@ -865,7 +865,7 @@ More samples can be found in the [examples](https://github.com/tj/commander.js/t
 
 ## Support
 
-The current version of Commander is fully supported on Long Term Support versions of node, and requires node v10.
+The current version of Commander is fully supported on Long Term Support versions of node, and requires at least node v10.
 (For older versions of node, use an older version of Commander. Commander version 2.x has the widest support.)
 
 The main forum for free and community support is the project [Issues](https://github.com/tj/commander.js/issues) on GitHub.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,9 +6,12 @@ Old versions receive security updates for six months.
 
 | Version | Supported                                  |
 | ------- | ------------------------------------------ |
+| 7.x     | :white_check_mark: |
 | 6.x     | :white_check_mark: support ends 2021-30-06 |
 | 5.x     | :white_check_mark: support ends 2021-01-20 |
 | < 5     | :x:                                        |
+
+Pull Requests for security issues will be considered for older versions back to 2.x.
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
# Pull Request

Update SUPPORTED and README to node 10 (as already done in `node.engines`!) 

I wondered about node 8, but it is not supported by latest test dependencies.

I added a comment to SUPPORTED saying we will consider merge requests for older versions too, partly because  TideLift analytics show most dependencies are for 2.x.

## ChangeLog

- Commander 7 requires a minimum of node 10.
