### PR TITLE
Allow setting the default command separately from the construction

### DIFF
--- a/index.js
+++ b/index.js
@@ -1681,8 +1681,8 @@ Read more on https://git.io/JJc0W`);
 
   /**
    * Sets the default command for the program.
-   * 
-   * @param {string} command The name of the command 
+   *
+   * @param {string} command The name of the command
    * @api public
    */
   default(name) {

--- a/index.js
+++ b/index.js
@@ -1680,6 +1680,16 @@ Read more on https://git.io/JJc0W`);
   };
 
   /**
+   * Sets the default command for the program.
+   * 
+   * @param {string} command The name of the command 
+   * @api public
+   */
+  default(name) {
+    this._defaultCommandName = name;
+  }
+
+  /**
    * Output help information and exit. Display for error situations.
    *
    * @api private

--- a/index.js
+++ b/index.js
@@ -1687,6 +1687,7 @@ Read more on https://git.io/JJc0W`);
    */
   default(name) {
     this._defaultCommandName = name;
+    return this;
   }
 
   /**

--- a/tests/command.default.test.js
+++ b/tests/command.default.test.js
@@ -1,123 +1,127 @@
-const childProcess = require("child_process");
-const commander = require("../");
-const path = require("path");
-const util = require("util");
+const childProcess = require('child_process');
+const commander = require('../');
+const path = require('path');
+const util = require('util');
 
 const execFileAsync = util.promisify(childProcess.execFile);
 
-describe("default executable command", () => {
+describe('default executable command', () => {
   // Calling node explicitly so pm works without file suffix cross-platform.
-  const pm = path.join(__dirname, "./fixtures/pm");
+  const pm = path.join(__dirname, './fixtures/pm');
 
-  test("when default subcommand and no command then call default", async () => {
-    const { stdout } = await execFileAsync("node", [pm]);
-    expect(stdout).toBe("default\n");
+  test('when default subcommand and no command then call default', async() => {
+    const { stdout } = await execFileAsync('node', [pm]);
+    expect(stdout).toBe('default\n');
   });
 
-  test("when default subcommand and unrecognised argument then call default with argument", async () => {
-    const { stdout } = await execFileAsync("node", [pm, "an-argument"]);
+  test('when default subcommand and unrecognised argument then call default with argument', async() => {
+    const { stdout } = await execFileAsync('node', [pm, 'an-argument']);
     expect(stdout).toBe("default\n[ 'an-argument' ]\n");
   });
 
-  test("when default subcommand and unrecognised option then call default with option", async () => {
-    const { stdout } = await execFileAsync("node", [pm, "--an-option"]);
+  test('when default subcommand and unrecognised option then call default with option', async() => {
+    const { stdout } = await execFileAsync('node', [pm, '--an-option']);
     expect(stdout).toBe("default\n[ '--an-option' ]\n");
   });
 });
 
-describe("default action command", () => {
+describe('default action command', () => {
   function makeProgram() {
     const program = new commander.Command();
     const actionMock = jest.fn();
-    program.command("other");
     program
-      .command("default", { isDefault: true })
+      .command('other');
+    program
+      .command('default', { isDefault: true })
       .allowUnknownOption()
       .action(actionMock);
     return { program, actionMock };
   }
 
-  test("when default subcommand and no command then call default", () => {
+  test('when default subcommand and no command then call default', () => {
     const { program, actionMock } = makeProgram();
-    program.parse("node test.js".split(" "));
+    program.parse('node test.js'.split(' '));
     expect(actionMock).toHaveBeenCalled();
   });
 
-  test("when default subcommand and unrecognised argument then call default", () => {
+  test('when default subcommand and unrecognised argument then call default', () => {
     const { program, actionMock } = makeProgram();
-    program.parse("node test.js an-argument".split(" "));
+    program.parse('node test.js an-argument'.split(' '));
     expect(actionMock).toHaveBeenCalled();
   });
 
-  test("when default subcommand and unrecognised option then call default", () => {
+  test('when default subcommand and unrecognised option then call default', () => {
     const { program, actionMock } = makeProgram();
-    program.parse("node test.js --an-option".split(" "));
+    program.parse('node test.js --an-option'.split(' '));
     expect(actionMock).toHaveBeenCalled();
   });
 });
 
-describe("default added command", () => {
+describe('default added command', () => {
   function makeProgram() {
     const actionMock = jest.fn();
-    const defaultCmd = new commander.Command("default")
+    const defaultCmd = new commander.Command('default')
       .allowUnknownOption()
       .action(actionMock);
 
     const program = new commander.Command();
-    program.command("other");
-    program.addCommand(defaultCmd, { isDefault: true });
+    program
+      .command('other');
+    program
+      .addCommand(defaultCmd, { isDefault: true });
     return { program, actionMock };
   }
 
-  test("when default subcommand and no command then call default", () => {
+  test('when default subcommand and no command then call default', () => {
     const { program, actionMock } = makeProgram();
-    program.parse("node test.js".split(" "));
+    program.parse('node test.js'.split(' '));
     expect(actionMock).toHaveBeenCalled();
   });
 
-  test("when default subcommand and unrecognised argument then call default", () => {
+  test('when default subcommand and unrecognised argument then call default', () => {
     const { program, actionMock } = makeProgram();
-    program.parse("node test.js an-argument".split(" "));
+    program.parse('node test.js an-argument'.split(' '));
     expect(actionMock).toHaveBeenCalled();
   });
 
-  test("when default subcommand and unrecognised option then call default", () => {
+  test('when default subcommand and unrecognised option then call default', () => {
     const { program, actionMock } = makeProgram();
-    program.parse("node test.js --an-option".split(" "));
+    program.parse('node test.js --an-option'.split(' '));
     expect(actionMock).toHaveBeenCalled();
   });
 });
 
-describe("default set command", () => {
+describe('default set command', () => {
   function makeProgram() {
     const actionMock = jest.fn();
-    const defaultCmd = new commander.Command("default")
+    const defaultCmd = new commander.Command('default')
       .allowUnknownOption()
       .action(actionMock);
 
     const program = new commander.Command();
-    program.default("default");
-    program.command("other");
-    program.addCommand(defaultCmd);
-
+    program
+      .command('other');
+    program
+      .addCommand(defaultCmd);
+    program.default('default');
     return { program, actionMock };
   }
 
-  test("when default subcommand and no command then call default", () => {
+  test('when default subcommand and no command then call default', () => {
     const { program, actionMock } = makeProgram();
-    program.parse("node test.js".split(" "));
+    program.parse('node test.js'.split(' '));
     expect(actionMock).toHaveBeenCalled();
   });
 
-  test("when default subcommand and unrecognised argument then call default", () => {
+  test('when default subcommand and unrecognised argument then call default', () => {
     const { program, actionMock } = makeProgram();
-    program.parse("node test.js an-argument".split(" "));
+    program.parse('node test.js an-argument'.split(' '));
     expect(actionMock).toHaveBeenCalled();
   });
 
-  test("when default subcommand and unrecognised option then call default", () => {
+  test('when default subcommand and unrecognised option then call default', () => {
     const { program, actionMock } = makeProgram();
-    program.parse("node test.js --an-option".split(" "));
+    program.parse('node test.js --an-option'.split(' '));
     expect(actionMock).toHaveBeenCalled();
   });
 });

--- a/tests/command.default.test.js
+++ b/tests/command.default.test.js
@@ -1,92 +1,123 @@
-const childProcess = require('child_process');
-const commander = require('../');
-const path = require('path');
-const util = require('util');
+const childProcess = require("child_process");
+const commander = require("../");
+const path = require("path");
+const util = require("util");
 
 const execFileAsync = util.promisify(childProcess.execFile);
 
-describe('default executable command', () => {
+describe("default executable command", () => {
   // Calling node explicitly so pm works without file suffix cross-platform.
-  const pm = path.join(__dirname, './fixtures/pm');
+  const pm = path.join(__dirname, "./fixtures/pm");
 
-  test('when default subcommand and no command then call default', async() => {
-    const { stdout } = await execFileAsync('node', [pm]);
-    expect(stdout).toBe('default\n');
+  test("when default subcommand and no command then call default", async () => {
+    const { stdout } = await execFileAsync("node", [pm]);
+    expect(stdout).toBe("default\n");
   });
 
-  test('when default subcommand and unrecognised argument then call default with argument', async() => {
-    const { stdout } = await execFileAsync('node', [pm, 'an-argument']);
+  test("when default subcommand and unrecognised argument then call default with argument", async () => {
+    const { stdout } = await execFileAsync("node", [pm, "an-argument"]);
     expect(stdout).toBe("default\n[ 'an-argument' ]\n");
   });
 
-  test('when default subcommand and unrecognised option then call default with option', async() => {
-    const { stdout } = await execFileAsync('node', [pm, '--an-option']);
+  test("when default subcommand and unrecognised option then call default with option", async () => {
+    const { stdout } = await execFileAsync("node", [pm, "--an-option"]);
     expect(stdout).toBe("default\n[ '--an-option' ]\n");
   });
 });
 
-describe('default action command', () => {
+describe("default action command", () => {
   function makeProgram() {
     const program = new commander.Command();
     const actionMock = jest.fn();
+    program.command("other");
     program
-      .command('other');
-    program
-      .command('default', { isDefault: true })
+      .command("default", { isDefault: true })
       .allowUnknownOption()
       .action(actionMock);
     return { program, actionMock };
   }
 
-  test('when default subcommand and no command then call default', () => {
+  test("when default subcommand and no command then call default", () => {
     const { program, actionMock } = makeProgram();
-    program.parse('node test.js'.split(' '));
+    program.parse("node test.js".split(" "));
     expect(actionMock).toHaveBeenCalled();
   });
 
-  test('when default subcommand and unrecognised argument then call default', () => {
+  test("when default subcommand and unrecognised argument then call default", () => {
     const { program, actionMock } = makeProgram();
-    program.parse('node test.js an-argument'.split(' '));
+    program.parse("node test.js an-argument".split(" "));
     expect(actionMock).toHaveBeenCalled();
   });
 
-  test('when default subcommand and unrecognised option then call default', () => {
+  test("when default subcommand and unrecognised option then call default", () => {
     const { program, actionMock } = makeProgram();
-    program.parse('node test.js --an-option'.split(' '));
+    program.parse("node test.js --an-option".split(" "));
     expect(actionMock).toHaveBeenCalled();
   });
 });
 
-describe('default added command', () => {
+describe("default added command", () => {
   function makeProgram() {
     const actionMock = jest.fn();
-    const defaultCmd = new commander.Command('default')
+    const defaultCmd = new commander.Command("default")
       .allowUnknownOption()
       .action(actionMock);
 
     const program = new commander.Command();
-    program
-      .command('other');
-    program
-      .addCommand(defaultCmd, { isDefault: true });
+    program.command("other");
+    program.addCommand(defaultCmd, { isDefault: true });
     return { program, actionMock };
   }
 
-  test('when default subcommand and no command then call default', () => {
+  test("when default subcommand and no command then call default", () => {
     const { program, actionMock } = makeProgram();
-    program.parse('node test.js'.split(' '));
+    program.parse("node test.js".split(" "));
     expect(actionMock).toHaveBeenCalled();
   });
 
-  test('when default subcommand and unrecognised argument then call default', () => {
+  test("when default subcommand and unrecognised argument then call default", () => {
     const { program, actionMock } = makeProgram();
-    program.parse('node test.js an-argument'.split(' '));
+    program.parse("node test.js an-argument".split(" "));
     expect(actionMock).toHaveBeenCalled();
   });
 
-  test('when default subcommand and unrecognised option then call default', () => {
+  test("when default subcommand and unrecognised option then call default", () => {
     const { program, actionMock } = makeProgram();
-    program.parse('node test.js --an-option'.split(' '));
+    program.parse("node test.js --an-option".split(" "));
+    expect(actionMock).toHaveBeenCalled();
+  });
+});
+
+describe("default set command", () => {
+  function makeProgram() {
+    const actionMock = jest.fn();
+    const defaultCmd = new commander.Command("default")
+      .allowUnknownOption()
+      .action(actionMock);
+
+    const program = new commander.Command();
+    program.default("default");
+    program.command("other");
+    program.addCommand(defaultCmd);
+
+    return { program, actionMock };
+  }
+
+  test("when default subcommand and no command then call default", () => {
+    const { program, actionMock } = makeProgram();
+    program.parse("node test.js".split(" "));
+    expect(actionMock).toHaveBeenCalled();
+  });
+
+  test("when default subcommand and unrecognised argument then call default", () => {
+    const { program, actionMock } = makeProgram();
+    program.parse("node test.js an-argument".split(" "));
+    expect(actionMock).toHaveBeenCalled();
+  });
+
+  test("when default subcommand and unrecognised option then call default", () => {
+    const { program, actionMock } = makeProgram();
+    program.parse("node test.js --an-option".split(" "));
     expect(actionMock).toHaveBeenCalled();
   });
 });

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -369,6 +369,11 @@ declare namespace commander {
     help(cb?: (str: string) => string): never;
 
     /**
+     * Set the default command for a program.
+     */
+    default(name: string): void;
+
+    /**
      * Add a listener (callback) for when events occur. (Implemented using EventEmitter.)
      *
      * @example


### PR DESCRIPTION
In a project I'm working on, the commands are added dynamically, like so:
```ts
const commandsDir = join(__dirname, "src/commands");
const commandFiles = readdirSync(commandsDir);
await Promise.all(
  commandFiles.map(async (file) => {
    const path = join(commandsDir, file);
    const { default: command } = await import(path);
    program.addCommand(command());
  }),
);
```

This makes pretty hard (or at least harder than it should be) to set the default command, as I would have to mess with the loading, mixing concerns.
```ts
const commandsDir = join(__dirname, "src/commands");
const commandFiles = readdirSync(commandsDir);
await Promise.all(
  commandFiles.map(async (file) => {
    const path = join(commandsDir, file);
    const command = (await import(path)).default();
    program.addCommand(command, {
      isDefault: command.name() === "list",
    });
  }),
);
```

This pull request implements the following interface:
```ts
program
  .description("Help text")
  .default("list");
```

To me, it looks more natural, since I think this configuration belongs on the parent command, not the command itself, as it is even coded like that internally.

