### PR TITLE
Modify TypeScript return type depending on storeOptionsAsProperties parameter

### DIFF
--- a/typings/commander-tests.ts
+++ b/typings/commander-tests.ts
@@ -132,8 +132,16 @@ const createOption2: commander.Option = program.createOption('a, --alpha', 'desc
 const addOptionThis: commander.Command = program.addOption(new commander.Option('-s,--simple'));
 
 // storeOptionsAsProperties
+// chaining
 const storeOptionsAsPropertiesThis1: commander.Command = program.storeOptionsAsProperties();
 const storeOptionsAsPropertiesThis2: commander.Command = program.storeOptionsAsProperties(false);
+// return type depends on parameter
+const storeOptionsAsPropertiesThis3 = program.storeOptionsAsProperties();
+const storeOptionsAsPropertiesValue3 = storeOptionsAsPropertiesThis3.someOption;
+const storeOptionsAsPropertiesThis4 = program.storeOptionsAsProperties(true);
+const storeOptionsAsPropertiesValue4 = storeOptionsAsPropertiesThis4.someOption;
+const storeOptionsAsPropertiesThis5 = program.storeOptionsAsProperties(false);
+// const storeOptionsAsPropertiesValue5 = storeOptionsAsPropertiesThis5.someOption; // error
 
 // combineFlagAndOptionalValue
 const combineFlagAndOptionalValueThis1: commander.Command = program.combineFlagAndOptionalValue();

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -148,6 +148,10 @@ declare namespace commander {
 
   type AddHelpTextPosition = 'beforeAll' | 'before' | 'after' | 'afterAll';
 
+  interface OptionValues {
+    [key: string]: any;
+  }
+
   interface Command {
     args: string[];
 
@@ -372,6 +376,8 @@ declare namespace commander {
      *
      * @returns `this` command for chaining
      */
+    storeOptionsAsProperties(): this & OptionValues;
+    storeOptionsAsProperties(storeAsProperties: true): this & OptionValues;
     storeOptionsAsProperties(storeAsProperties?: boolean): this;
 
     /**
@@ -450,7 +456,7 @@ declare namespace commander {
     /**
      * Return an object containing options as key-value pairs
      */
-    opts(): { [key: string]: any };
+    opts(): OptionValues;
 
     /**
      * Set the description.


### PR DESCRIPTION
# Pull Request

## Problem

Now that options are stored safely by default and this is reflected in the TypeScript interface for Command, it is an error to access an option using legacy code pattern.

```ts
// Typescript
const program = new Command().storeOptionsAsProperties();
const value = program.myOption; // Error: Property 'myOption' does not exist on type 'Command'.
```

## Solution

Modify the return type when  `.storeOptionsAsProperties()` is called to add arbitrary properties for the options.

```ts
// Typescript
const program = new Command().storeOptionsAsProperties();
const value = program.myOption; // ok
```
