### PR TITLE
Positional options

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -694,7 +694,7 @@ an option for a different purpose in subcommands.
 
 Example file: [positional-options.js](./examples/positional-options.js)
 
-With positional options, these two lines are different:
+With positional options, the `-b` is a program option in the first line and a subcommand option in the second:
 
 ```sh
 program -b subcommand
@@ -704,11 +704,11 @@ program subcommand -b
 By default options are recognised before and after command-arguments. To only process options that come
 before the command-arguments, use `.passThroughOptions()`. This lets you pass the  arguments and following options through to another program
 without needing to use `--` to end the option processing. 
-To use pass through options in a subcommand, the programs need to enable positional options.
+To use pass through options in a subcommand, the program needs to enable positional options.
 
 Example file: [pass-through-options.js](./examples/pass-through-options.js)
 
-With pass through options, these two lines are different:
+With pass through options, the `--port=80` is a program option in the line and passed through as a command-argument in the second:
 
 ```sh
 program --port=80 arg

--- a/Readme.md
+++ b/Readme.md
@@ -35,6 +35,7 @@ Read this in other languages: English | [简体中文](./Readme_zh-CN.md)
   - [Custom event listeners](#custom-event-listeners)
   - [Bits and pieces](#bits-and-pieces)
     - [.parse() and .parseAsync()](#parse-and-parseasync)
+    - [Parsing Configuration](#parsing-configuration)
     - [Legacy options as properties](#legacy-options-as-properties)
     - [TypeScript](#typescript)
     - [createCommand()](#createcommand)
@@ -84,7 +85,7 @@ For example `-a -b -p 80` may be written as `-ab -p80` or even `-abp80`.
 
 You can use `--` to indicate the end of the options, and any remaining arguments will be used without being interpreted.
 
-Options on the command line are not positional, and can be specified before or after other arguments.
+By default options on the command line are not positional, and can be specified before or after other arguments.
 
 ### Common option types, boolean and value
 
@@ -683,6 +684,39 @@ program.parse(process.argv); // Explicit, node conventions
 program.parse(); // Implicit, and auto-detect electron
 program.parse(['-f', 'filename'], { from: 'user' });
 ```
+
+### Parsing Configuration
+
+If the default parsing does not suit your needs, there are some behaviours to support other usage patterns.
+
+By default program options are recognised before and after subcommands. To only look for program options before subcommands, use `.enablePositionalOptions()`. This lets you use
+an option for a different purpose in subcommands.
+
+Example file: [positional-options.js](./examples/positional-options.js)
+
+With positional options, these two lines are different:
+
+```sh
+program -b subcommand
+program subcommand -b
+```
+
+By default options are recognised before and after command-arguments. To only process options that come
+before the command-arguments, use `.passThroughOptions()`. This lets you pass the  arguments and following options through to another program
+without needing to use `--` to end the option processing. 
+To use pass through options in a subcommand, the programs need to enable positional options.
+
+Example file: [pass-through-options.js](./examples/pass-through-options.js)
+
+With pass through options, these two lines are different:
+
+```sh
+program --port=80 arg
+program arg --port=80
+```
+
+
+By default the option processing shows an error for an unknown option. To have an unknown option treated as an ordinary command-argument and continue looking for options, use `.allowUnknownOption()`. This lets you mix known and unknown options.
 
 ### Legacy options as properties 
 

--- a/examples/pass-through-options.js
+++ b/examples/pass-through-options.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+// const { Command } = require('commander'); // (normal include)
+const { Command } = require('../'); // include commander in git clone of commander repo
+const program = new Command();
+
+program
+  .arguments('<utility> [args...]')
+  .passThroughOptions()
+  .option('-d, --dry-run')
+  .action((utility, args, options) => {
+    const action = options.dryRun ? 'Would run' : 'Running';
+    console.log(`${action}: ${utility} ${args.join(' ')}`);
+  });
+
+program.parse();
+
+// Try the following:
+//
+//    node pass-through-options.js git status
+//    node pass-through-options.js git --version
+//    node pass-through-options.js --dry-run git checkout -b new-branch
+//    node pass-through-options.js git push --dry-run

--- a/examples/positional-options.js
+++ b/examples/positional-options.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+
+// const { Command } = require('commander'); // (normal include)
+const { Command } = require('../'); // include commander in git clone of commander repo
+const program = new Command();
+
+program
+  .enablePositionalOptions()
+  .option('-p, --progress');
+
+program
+  .command('upload <file>')
+  .option('-p, --port <number>', 'port number', 80)
+  .action((file, options) => {
+    if (program.opts().progress) console.log('Starting upload...');
+    console.log(`Uploading ${file} to port ${options.port}`);
+    if (program.opts().progress) console.log('Finished upload');
+  });
+
+program.parse();
+
+// Try the following:
+//
+//    node positional-options.js upload test.js
+//    node positional-options.js -p upload test.js
+//    node positional-options.js upload -p 8080 test.js
+//    node positional-options.js -p upload -p 8080 test.js

--- a/index.js
+++ b/index.js
@@ -1136,6 +1136,35 @@ class Command extends EventEmitter {
   };
 
   /**
+   * Enable positional options. Positional means global options are specified before subcommands which lets
+   * subcommands reuse the same option names, and also enables subcommands to turn on passThroughOptions.
+   * The default behaviour is non-positional and global options may appear anywhere on the command line.
+   *
+   * @param {Boolean} [positional=true]
+   */
+  enablePositionalOptions(positional = true) {
+    this._enablePositionalOptions = !!positional;
+    return this;
+  };
+
+  /**
+   * Pass through options that come after command-arguments rather than treat them as command-options,
+   * so actual command-options come before command-arguments. Turning this on for a subcommand requires
+   * positional options to have been enabled on the program (parent commands).
+   * The default behaviour is non-positional and options may appear before or after command-arguments.
+   *
+   * @param {Boolean} [passThrough=true]
+   * for unknown options.
+   */
+  passThroughOptions(passThrough = true) {
+    this._passThroughOptions = !!passThrough;
+    if (!!this.parent && !this.parent._enablePositionalOptions) {
+      throw new Error('passThroughOptions() can not be used because enablePositionOptions() has been called on program (parent commands)');
+    }
+    return this;
+  };
+
+  /**
     * Whether to store option values as properties on command object,
     * or store separately (specify false). In both cases the option values can be accessed using .opts().
     *

--- a/index.js
+++ b/index.js
@@ -552,8 +552,8 @@ class Command extends EventEmitter {
     this._combineFlagAndOptionalValue = true;
     this._description = '';
     this._argsDescription = undefined;
-    this._parseGlobalOptionsAnywhere = true; // before and after subcommands
-    this._parseOptionsFollowingArguments = true;
+    this._allowGlobalOptionsAnywhere = true; // before and after subcommands
+    this._allowOptionsFollowingArguments = true;
 
     // see .configureOutput() for docs
     this._outputConfiguration = {
@@ -1614,13 +1614,13 @@ class Command extends EventEmitter {
       // found first non-option
       if (operands.length === 0 && unknown.length === 0) {
         // check whether to stop parsing global options because hit subcommand
-        if (!this._parseGlobalOptionsAnywhere && this._findCommand(arg)) {
+        if (!this._allowGlobalOptionsAnywhere && this._findCommand(arg)) {
           operands.push(arg);
           unknown.push(...args);
           break;
         }
         // check whether to stop parsing options because hit argument
-        if (!this._parseOptionsFollowingArguments && !this._findCommand(arg)) {
+        if (!this._allowOptionsFollowingArguments && !this._findCommand(arg)) {
           operands.push(arg, ...args);
           break;
         }

--- a/index.js
+++ b/index.js
@@ -552,8 +552,8 @@ class Command extends EventEmitter {
     this._combineFlagAndOptionalValue = true;
     this._description = '';
     this._argsDescription = undefined;
-    this._allowGlobalOptionsAnywhere = true; // before and after subcommands
-    this._allowOptionsFollowingArguments = true;
+    this._allowGlobalOptionsAnywhere = true; // in particular, including after subcommands
+    this._passThroughOptions = false;
 
     // see .configureOutput() for docs
     this._outputConfiguration = {
@@ -1619,8 +1619,8 @@ class Command extends EventEmitter {
           unknown.push(...args);
           break;
         }
-        // check whether to stop parsing options because hit argument
-        if (!this._allowOptionsFollowingArguments && !this._findCommand(arg)) {
+        // check whether to stop parsing options because hit command-argument
+        if (this._passThroughOptions && !this._findCommand(arg)) {
           operands.push(arg, ...args);
           break;
         }

--- a/index.js
+++ b/index.js
@@ -635,6 +635,7 @@ class Command extends EventEmitter {
     cmd._exitCallback = this._exitCallback;
     cmd._storeOptionsAsProperties = this._storeOptionsAsProperties;
     cmd._combineFlagAndOptionalValue = this._combineFlagAndOptionalValue;
+    cmd._enablePositionalOptions = this._enablePositionalOptions;
 
     cmd._executableFile = opts.executableFile || null; // Custom name for executable file, set missing to null to match constructor
     this.commands.push(cmd);

--- a/index.js
+++ b/index.js
@@ -552,7 +552,7 @@ class Command extends EventEmitter {
     this._combineFlagAndOptionalValue = true;
     this._description = '';
     this._argsDescription = undefined;
-    this._allowGlobalOptionsAnywhere = true; // in particular, including after subcommands
+    this._enablePositionalOptions = false;
     this._passThroughOptions = false;
 
     // see .configureOutput() for docs
@@ -1614,7 +1614,7 @@ class Command extends EventEmitter {
       // found first non-option
       if (operands.length === 0 && unknown.length === 0 && !maybeOption(arg)) {
         // check whether to stop parsing global options because hit subcommand
-        if (!this._allowGlobalOptionsAnywhere && this._findCommand(arg)) {
+        if (this._enablePositionalOptions && this._findCommand(arg)) {
           operands.push(arg);
           unknown.push(...args);
           break;

--- a/index.js
+++ b/index.js
@@ -552,7 +552,7 @@ class Command extends EventEmitter {
     this._combineFlagAndOptionalValue = true;
     this._description = '';
     this._argsDescription = undefined;
-    this._optionsBeforeArguments = false;
+    this._parseGlobalOptionsAnywhere = true;
 
     // see .configureOutput() for docs
     this._outputConfiguration = {
@@ -1615,18 +1615,16 @@ class Command extends EventEmitter {
         dest = unknown;
       }
 
-      if (!maybeOption(arg) && this._optionsBeforeArguments) {
-        dest.push(arg);
-        if (this._findCommand(arg)) {
-          // sub --debug
+      // found first non-option
+      if (operands.length === 0 && unknown.length === 0) {
+        // check whether to stop parsing global options because hit subcommand
+        if (!this._parseGlobalOptionsAnywhere && this._findCommand(arg)) {
+          dest.push(arg);
           unknown.push(...args);
-        } else {
-          // help foo
-          // arg --help
-          // arg --debug
-          dest.push(...args);
+          break;
         }
-        break;
+        // check whether to stop parsing options because hit argument
+        // ...
       }
 
       // add arg

--- a/index.js
+++ b/index.js
@@ -1650,13 +1650,13 @@ class Command extends EventEmitter {
 
       // If using positionalOptions, stop processing our options at subcommand.
       if ((this._enablePositionalOptions || this._passThroughOptions) && operands.length === 0 && unknown.length === 0) {
-        if (this._hasImplicitHelpCommand() && arg === this._helpCommandName) {
-          operands.push(arg);
-          if (args.length > 0) operands.push(...args);
-          break;
-        } if (this._findCommand(arg)) {
+        if (this._findCommand(arg)) {
           operands.push(arg);
           if (args.length > 0) unknown.push(...args);
+          break;
+        } else if (arg === this._helpCommandName && this._hasImplicitHelpCommand()) {
+          operands.push(arg);
+          if (args.length > 0) operands.push(...args);
           break;
         } else if (this._defaultCommandName) {
           unknown.push(arg);

--- a/index.js
+++ b/index.js
@@ -1612,7 +1612,7 @@ class Command extends EventEmitter {
       }
 
       // found first non-option
-      if (operands.length === 0 && unknown.length === 0) {
+      if (operands.length === 0 && unknown.length === 0 && !maybeOption(arg)) {
         // check whether to stop parsing global options because hit subcommand
         if (!this._allowGlobalOptionsAnywhere && this._findCommand(arg)) {
           operands.push(arg);

--- a/index.js
+++ b/index.js
@@ -552,6 +552,7 @@ class Command extends EventEmitter {
     this._combineFlagAndOptionalValue = true;
     this._description = '';
     this._argsDescription = undefined;
+    this._optionsBeforeArguments = false;
 
     // see .configureOutput() for docs
     this._outputConfiguration = {
@@ -1612,6 +1613,20 @@ class Command extends EventEmitter {
       // looks like an option but unknown, unknowns from here
       if (arg.length > 1 && arg[0] === '-') {
         dest = unknown;
+      }
+
+      if (!maybeOption(arg) && this._optionsBeforeArguments) {
+        dest.push(arg);
+        if (this._findCommand(arg)) {
+          // sub --debug
+          unknown.push(...args);
+        } else {
+          // help foo
+          // arg --help
+          // arg --debug
+          dest.push(...args);
+        }
+        break;
       }
 
       // add arg

--- a/index.js
+++ b/index.js
@@ -552,7 +552,8 @@ class Command extends EventEmitter {
     this._combineFlagAndOptionalValue = true;
     this._description = '';
     this._argsDescription = undefined;
-    this._parseGlobalOptionsAnywhere = true;
+    this._parseGlobalOptionsAnywhere = true; // before and after subcommands
+    this._parseOptionsFollowingArguments = true;
 
     // see .configureOutput() for docs
     this._outputConfiguration = {
@@ -1610,21 +1611,24 @@ class Command extends EventEmitter {
         }
       }
 
-      // looks like an option but unknown, unknowns from here
-      if (arg.length > 1 && arg[0] === '-') {
-        dest = unknown;
-      }
-
       // found first non-option
       if (operands.length === 0 && unknown.length === 0) {
         // check whether to stop parsing global options because hit subcommand
         if (!this._parseGlobalOptionsAnywhere && this._findCommand(arg)) {
-          dest.push(arg);
+          operands.push(arg);
           unknown.push(...args);
           break;
         }
         // check whether to stop parsing options because hit argument
-        // ...
+        if (!this._parseOptionsFollowingArguments && !this._findCommand(arg)) {
+          operands.push(arg, ...args);
+          break;
+        }
+      }
+
+      // looks like an option but unknown, unknowns from here
+      if (arg.length > 1 && arg[0] === '-') {
+        dest = unknown;
       }
 
       // add arg

--- a/index.js
+++ b/index.js
@@ -1158,8 +1158,8 @@ class Command extends EventEmitter {
    */
   passThroughOptions(passThrough = true) {
     this._passThroughOptions = !!passThrough;
-    if (!!this.parent && !this.parent._enablePositionalOptions) {
-      throw new Error('passThroughOptions() can not be used because enablePositionOptions() has been called on program (parent commands)');
+    if (!!this.parent && passThrough && !this.parent._enablePositionalOptions) {
+      throw new Error('passThroughOptions can not be used without turning on enablePositionOptions for parent command(s)');
     }
     return this;
   };
@@ -1650,19 +1650,25 @@ class Command extends EventEmitter {
 
       // If using positionalOptions, stop processing our options at subcommand.
       if ((this._enablePositionalOptions || this._passThroughOptions) && operands.length === 0 && unknown.length === 0) {
-        if (this._findCommand(arg)) {
-          dest.push(arg);
-          unknown.push(...args);
+        if (this._hasImplicitHelpCommand() && arg === this._helpCommandName) {
+          operands.push(arg);
+          if (args.length > 0) operands.push(...args);
+          break;
+        } if (this._findCommand(arg)) {
+          operands.push(arg);
+          if (args.length > 0) unknown.push(...args);
           break;
         } else if (this._defaultCommandName) {
-          dest.push(arg);
-          unknown.push(...args);
+          unknown.push(arg);
+          if (args.length > 0) unknown.push(...args);
+          break;
         }
       }
 
       // If using passThroughOptions, stop processing options at first command-argument.
       if (this._passThroughOptions) {
-        dest.push(arg, ...args);
+        dest.push(arg);
+        if (args.length > 0) dest.push(...args);
         break;
       }
 

--- a/tests/command.chain.test.js
+++ b/tests/command.chain.test.js
@@ -141,4 +141,16 @@ describe('Command methods that should return this for chaining', () => {
     const result = program.configureOutput({ });
     expect(result).toBe(program);
   });
+
+  test('when call .passThroughOptions() then returns this', () => {
+    const program = new Command();
+    const result = program.passThroughOptions();
+    expect(result).toBe(program);
+  });
+
+  test('when call .enablePositionOptions() then returns this', () => {
+    const program = new Command();
+    const result = program.enablePositionalOptions();
+    expect(result).toBe(program);
+  });
 });

--- a/tests/command.chain.test.js
+++ b/tests/command.chain.test.js
@@ -148,7 +148,7 @@ describe('Command methods that should return this for chaining', () => {
     expect(result).toBe(program);
   });
 
-  test('when call .enablePositionOptions() then returns this', () => {
+  test('when call .enablePositionalOptions() then returns this', () => {
     const program = new Command();
     const result = program.enablePositionalOptions();
     expect(result).toBe(program);

--- a/tests/command.optionsBeforeArguments.test.js
+++ b/tests/command.optionsBeforeArguments.test.js
@@ -1,6 +1,6 @@
 const commander = require('../');
 
-test('when default then option parsed after command-argument', () => {
+test('when option after argument then option parsed', () => {
   const program = new commander.Command();
   program
     .option('-d, --debug')
@@ -10,18 +10,18 @@ test('when default then option parsed after command-argument', () => {
   expect(program.args).toEqual(['arg']);
 });
 
-// test('when optionsBeforeArguments then global option not parsed after command-argument', () => {
-//   const program = new commander.Command();
-//   program._optionsBeforeArguments = true;
-//   program
-//     .option('-d, --debug')
-//     .arguments('[arg]');
-//   program.parse(['arg', '--debug'], { from: 'user' });
-//   expect(program.opts().debug).toBeUndefined();
-//   expect(program.args).toEqual(['arg', '--debug']);
-// });
+test('when option after argument and _parseOptionsFollowingArguments(false) then option not parsed', () => {
+  const program = new commander.Command();
+  program._parseOptionsFollowingArguments = false;
+  program
+    .option('-d, --debug')
+    .arguments('[arg]');
+  program.parse(['arg', '--debug'], { from: 'user' });
+  expect(program.opts().debug).toBeUndefined();
+  expect(program.args).toEqual(['arg', '--debug']);
+});
 
-test('when global option after subcommand and default then global option parsed', () => {
+test('when global option after subcommand then global option parsed', () => {
   const mockAction = jest.fn();
   const program = new commander.Command();
   program

--- a/tests/command.optionsBeforeArguments.test.js
+++ b/tests/command.optionsBeforeArguments.test.js
@@ -63,7 +63,32 @@ test('when option after subcommand is global and local and allowGlobalOptionsAny
   expect(sub.opts().debug).toBe(true);
 });
 
-// arg --help
-// sub --help
-// help sub
-// default command, arg
+describe('program with _allowGlobalOptionsAnywhere=false and subcommand with _passThroughOptions=true', () => {
+  test.each([
+    [[], true],
+    [['help'], true],
+    [['--help'], true],
+    [['sub'], false],
+    [['sub', '--help'], true],
+    [['sub', 'foo', '--help'], false]
+  ])('when user args %p then help called is %p', (userArgs, expectHelpCalled) => {
+    const program = new commander.Command();
+    program._allowGlobalOptionsAnywhere = false;
+    program
+      .exitOverride()
+      .configureHelp({ formatHelp: () => '' });
+    const sub = program.command('sub')
+      .exitOverride()
+      .configureHelp({ formatHelp: () => '' })
+      .action(() => { });
+    sub._passThroughOptions = true;
+
+    let helpCalled = false;
+    try {
+      program.parse(userArgs, { from: 'user' });
+    } catch (err) {
+      helpCalled = err.code === 'commander.helpDisplayed' || err.code === 'commander.help';
+    }
+    expect(helpCalled).toEqual(expectHelpCalled);
+  });
+});

--- a/tests/command.optionsBeforeArguments.test.js
+++ b/tests/command.optionsBeforeArguments.test.js
@@ -10,9 +10,9 @@ test('when option after argument then option parsed', () => {
   expect(program.args).toEqual(['arg']);
 });
 
-test('when option after argument and _parseOptionsFollowingArguments(false) then option not parsed', () => {
+test('when option after argument and passThroughOptions=true then option not parsed', () => {
   const program = new commander.Command();
-  program._allowOptionsFollowingArguments = false;
+  program._passThroughOptions = true;
   program
     .option('-d, --debug')
     .arguments('[arg]');
@@ -34,7 +34,7 @@ test('when global option after subcommand then global option parsed', () => {
   expect(mockAction).toBeCalledWith('arg', sub.opts(), sub);
 });
 
-test('when global option after subcommand and parseGlobalOptionsAnywhere(false) then global option not parsed', () => {
+test('when global option after subcommand and allowGlobalOptionsAnywhere=false then global option not parsed', () => {
   const mockAction = jest.fn();
   const program = new commander.Command();
   program._allowGlobalOptionsAnywhere = false;
@@ -49,7 +49,7 @@ test('when global option after subcommand and parseGlobalOptionsAnywhere(false) 
   expect(mockAction).toBeCalledWith('--debug', sub.opts(), sub);
 });
 
-test('when option after subcommand is global and local and parseGlobalOptionsAnywhere(false) then option parsed as local', () => {
+test('when option after subcommand is global and local and allowGlobalOptionsAnywhere=false then option parsed as local', () => {
   const mockAction = jest.fn();
   const program = new commander.Command();
   program._allowGlobalOptionsAnywhere = false;

--- a/tests/command.optionsBeforeArguments.test.js
+++ b/tests/command.optionsBeforeArguments.test.js
@@ -21,6 +21,19 @@ test('when option after argument and passThroughOptions=true then option not par
   expect(program.args).toEqual(['arg', '--debug']);
 });
 
+// This shows bug, parsing of the "known" at the top level ate the argument before parsing by the subcommand.
+// Could require that global parsing is off, to get pass-through?
+// test('BUG: when option after subcommand argument and passThroughOptions=true then option not parsed', () => {
+//   const program = new commander.Command();
+//   const sub = program.command('sub')
+//     .option('-d, --debug')
+//     .arguments('<arg>');
+//   sub._passThroughOptions = true;
+//   program.parse(['sub', 'arg', '--debug'], { from: 'user' });
+//   expect(sub.opts().debug).toBeUndefined();
+//   expect(sub.args).toEqual(['arg', '--debug']);
+// });
+
 test('when global option after subcommand then global option parsed', () => {
   const mockAction = jest.fn();
   const program = new commander.Command();
@@ -34,10 +47,10 @@ test('when global option after subcommand then global option parsed', () => {
   expect(mockAction).toBeCalledWith('arg', sub.opts(), sub);
 });
 
-test('when global option after subcommand and allowGlobalOptionsAnywhere=false then global option not parsed', () => {
+test('when global option after subcommand and _enablePositionalOptions=true then global option not parsed', () => {
   const mockAction = jest.fn();
   const program = new commander.Command();
-  program._allowGlobalOptionsAnywhere = false;
+  program._enablePositionalOptions = true;
   program
     .option('-d, --debug');
   const sub = program.command('sub')
@@ -49,10 +62,10 @@ test('when global option after subcommand and allowGlobalOptionsAnywhere=false t
   expect(mockAction).toBeCalledWith('--debug', sub.opts(), sub);
 });
 
-test('when option after subcommand is global and local and allowGlobalOptionsAnywhere=false then option parsed as local', () => {
+test('when option after subcommand is global and local and _enablePositionalOptions=true then option parsed as local', () => {
   const mockAction = jest.fn();
   const program = new commander.Command();
-  program._allowGlobalOptionsAnywhere = false;
+  program._enablePositionalOptions = true;
   program
     .option('-d, --debug');
   const sub = program.command('sub')
@@ -63,7 +76,7 @@ test('when option after subcommand is global and local and allowGlobalOptionsAny
   expect(sub.opts().debug).toBe(true);
 });
 
-describe('program with _allowGlobalOptionsAnywhere=false and subcommand with _passThroughOptions=true', () => {
+describe('program with _enablePositionalOptions=true and subcommand with _passThroughOptions=true', () => {
   test.each([
     [[], true],
     [['help'], true],
@@ -73,7 +86,7 @@ describe('program with _allowGlobalOptionsAnywhere=false and subcommand with _pa
     [['sub', 'foo', '--help'], false]
   ])('when user args %p then help called is %p', (userArgs, expectHelpCalled) => {
     const program = new commander.Command();
-    program._allowGlobalOptionsAnywhere = false;
+    program._enablePositionalOptions = true;
     program
       .exitOverride()
       .configureHelp({ formatHelp: () => '' });

--- a/tests/command.optionsBeforeArguments.test.js
+++ b/tests/command.optionsBeforeArguments.test.js
@@ -12,7 +12,7 @@ test('when option after argument then option parsed', () => {
 
 test('when option after argument and _parseOptionsFollowingArguments(false) then option not parsed', () => {
   const program = new commander.Command();
-  program._parseOptionsFollowingArguments = false;
+  program._allowOptionsFollowingArguments = false;
   program
     .option('-d, --debug')
     .arguments('[arg]');
@@ -37,7 +37,7 @@ test('when global option after subcommand then global option parsed', () => {
 test('when global option after subcommand and parseGlobalOptionsAnywhere(false) then global option not parsed', () => {
   const mockAction = jest.fn();
   const program = new commander.Command();
-  program._parseGlobalOptionsAnywhere = false;
+  program._allowGlobalOptionsAnywhere = false;
   program
     .option('-d, --debug');
   const sub = program.command('sub')
@@ -52,7 +52,7 @@ test('when global option after subcommand and parseGlobalOptionsAnywhere(false) 
 test('when option after subcommand is global and local and parseGlobalOptionsAnywhere(false) then option parsed as local', () => {
   const mockAction = jest.fn();
   const program = new commander.Command();
-  program._parseGlobalOptionsAnywhere = false;
+  program._allowGlobalOptionsAnywhere = false;
   program
     .option('-d, --debug');
   const sub = program.command('sub')

--- a/tests/command.optionsBeforeArguments.test.js
+++ b/tests/command.optionsBeforeArguments.test.js
@@ -1,38 +1,70 @@
 const commander = require('../');
 
-test('when option after argument then option parsed', () => {
-  const program = new commander.Command();
-  program
-    .option('-d, --debug')
-    .arguments('[arg]');
-  program.parse(['arg', '--debug'], { from: 'user' });
-  expect(program.opts().debug).toBe(true);
-  expect(program.args).toEqual(['arg']);
-});
+describe('program with _passThroughOptions=true', () => {
+  function makeProgram() {
+    const program = new commander.Command();
+    program._passThroughOptions = true;
+    program
+      .option('-d, --debug')
+      .arguments('<args...>');
+    return program;
+  }
 
-test('when option after argument and passThroughOptions=true then option not parsed', () => {
-  const program = new commander.Command();
-  program._passThroughOptions = true;
-  program
-    .option('-d, --debug')
-    .arguments('[arg]');
-  program.parse(['arg', '--debug'], { from: 'user' });
-  expect(program.opts().debug).toBeUndefined();
-  expect(program.args).toEqual(['arg', '--debug']);
-});
+  test('when option before command-argument then option parsed', () => {
+    const program = makeProgram();
+    program.parse(['--debug', 'arg'], { from: 'user' });
+    expect(program.args).toEqual(['arg']);
+    expect(program.opts().debug).toBe(true);
+  });
 
-// This shows bug, parsing of the "known" at the top level ate the argument before parsing by the subcommand.
-// Could require that global parsing is off, to get pass-through?
-// test('BUG: when option after subcommand argument and passThroughOptions=true then option not parsed', () => {
-//   const program = new commander.Command();
-//   const sub = program.command('sub')
-//     .option('-d, --debug')
-//     .arguments('<arg>');
-//   sub._passThroughOptions = true;
-//   program.parse(['sub', 'arg', '--debug'], { from: 'user' });
-//   expect(sub.opts().debug).toBeUndefined();
-//   expect(sub.args).toEqual(['arg', '--debug']);
-// });
+  test('when known option after command-argument then option passed through', () => {
+    const program = makeProgram();
+    program.parse(['arg', '--debug'], { from: 'user' });
+    expect(program.args).toEqual(['arg', '--debug']);
+    expect(program.opts().debug).toBeUndefined();
+  });
+
+  test('when unknown option after command-argument then option passed through', () => {
+    const program = makeProgram();
+    program.parse(['arg', '--pass'], { from: 'user' });
+    expect(program.args).toEqual(['arg', '--pass']);
+  });
+
+  test('when action handler and unknown option after command-argument then option passed through', () => {
+    const program = makeProgram();
+    const mockAction = jest.fn();
+    program.action(mockAction);
+    program.parse(['arg', '--pass'], { from: 'user' });
+    expect(mockAction).toHaveBeenCalledWith(['arg', '--pass'], program.opts(), program);
+  });
+
+  test('when help option (without command-argument) then help called', () => {
+    const program = makeProgram();
+    const mockHelp = jest.fn(() => '');
+
+    program
+      .exitOverride()
+      .configureHelp({ formatHelp: mockHelp });
+    try {
+      program.parse(['--help'], { from: 'user' });
+    } catch (err) {
+    }
+    expect(mockHelp).toHaveBeenCalled();
+  });
+
+  test('when help option after command-argument then option passed through', () => {
+    const program = makeProgram();
+    program.parse(['arg', '--help'], { from: 'user' });
+    expect(program.args).toEqual(['arg', '--help']);
+  });
+
+  test('when version option after command-argument then option passed through', () => {
+    const program = makeProgram();
+    program.version('1.2.3');
+    program.parse(['arg', '--version'], { from: 'user' });
+    expect(program.args).toEqual(['arg', '--version']);
+  });
+});
 
 test('when global option after subcommand then global option parsed', () => {
   const mockAction = jest.fn();
@@ -85,6 +117,7 @@ describe('program with _enablePositionalOptions=true and subcommand with _passTh
     [['sub', '--help'], true],
     [['sub', 'foo', '--help'], false]
   ])('when user args %p then help called is %p', (userArgs, expectHelpCalled) => {
+    // also check which command calls help ????
     const program = new commander.Command();
     program._enablePositionalOptions = true;
     program
@@ -105,3 +138,9 @@ describe('program with _enablePositionalOptions=true and subcommand with _passTh
     expect(helpCalled).toEqual(expectHelpCalled);
   });
 });
+
+// test for "foo sub" where sub is a parameter and not a command ????
+
+// default command tests, including help
+
+// Interaction of unknowns with passThrough.

--- a/tests/command.optionsBeforeArguments.test.js
+++ b/tests/command.optionsBeforeArguments.test.js
@@ -6,7 +6,7 @@ const commander = require('../');
 describe('program with passThrough', () => {
   function makeProgram() {
     const program = new commander.Command();
-    program._passThroughOptions = true;
+    program.passThroughOptions();
     program
       .option('-p, --debug')
       .arguments('<args...>');
@@ -74,7 +74,7 @@ describe('program with passThrough', () => {
 describe('program with positionalOptions and subcommand', () => {
   function makeProgram() {
     const program = new commander.Command();
-    program._enablePositionalOptions = true;
+    program.enablePositionalOptions();
     program
       .option('-s, --shared')
       .arguments('<args...>');
@@ -146,7 +146,7 @@ describe('program with positionalOptions and subcommand', () => {
 describe('program with positionalOptions and default subcommand (called sub)', () => {
   function makeProgram() {
     const program = new commander.Command();
-    program._enablePositionalOptions = true;
+    program.enablePositionalOptions();
     program
       .option('-s, --shared')
       .option('-g, --global')
@@ -213,7 +213,7 @@ describe('program with positionalOptions and default subcommand (called sub)', (
 describe('subcommand with passThrough', () => {
   function makeProgram() {
     const program = new commander.Command();
-    program._enablePositionalOptions = true;
+    program.enablePositionalOptions();
     program
       .option('-s, --shared')
       .arguments('<args...>');
@@ -222,7 +222,7 @@ describe('subcommand with passThrough', () => {
       .option('-s, --shared')
       .option('-d, --debug')
       .action(() => {}); // Not used, but normal to have action handler on subcommand.
-    sub._passThroughOptions = true;
+    sub.passThroughOptions();
     return { program, sub };
   }
 
@@ -282,7 +282,7 @@ describe('subcommand with passThrough', () => {
 describe('program with action handler and positionalOptions and subcommand', () => {
   function makeProgram() {
     const program = new commander.Command();
-    program._enablePositionalOptions = true;
+    program.enablePositionalOptions();
     program
       .option('-g, --global')
       .arguments('<args...>')

--- a/tests/command.optionsBeforeArguments.test.js
+++ b/tests/command.optionsBeforeArguments.test.js
@@ -1,0 +1,55 @@
+const commander = require('../');
+
+test('when default then global option parsed after command-argument', () => {
+  const program = new commander.Command();
+  program
+    .option('-d, --debug')
+    .arguments('[arg]');
+  program.parse(['arg', '--debug'], { from: 'user' });
+  expect(program.opts().debug).toBe(true);
+  expect(program.args).toEqual(['arg']);
+});
+
+test('when optionsBeforeArguments then global option not parsed after command-argument', () => {
+  const program = new commander.Command();
+  program._optionsBeforeArguments = true;
+  program
+    .option('-d, --debug')
+    .arguments('[arg]');
+  program.parse(['arg', '--debug'], { from: 'user' });
+  expect(program.opts().debug).toBeUndefined();
+  expect(program.args).toEqual(['arg', '--debug']);
+});
+
+test('when default then global option parsed after command', () => {
+  const mockAction = jest.fn();
+  const program = new commander.Command();
+  program
+    .option('-d, --debug');
+  const sub = program.command('sub')
+    .arguments('[arg]')
+    .action(mockAction);
+  program.parse(['sub', '--debug', 'arg'], { from: 'user' });
+  expect(program.opts().debug).toBe(true);
+  expect(mockAction).toBeCalledWith('arg', sub.opts(), sub);
+});
+
+test('when optionsBeforeArguments then global option after command belongs to command', () => {
+  const mockAction = jest.fn();
+  const program = new commander.Command();
+  program._optionsBeforeArguments = true;
+  program
+    .option('-d, --debug');
+  const sub = program.command('sub')
+    .arguments('[arg]')
+    .option('-d, --debug')
+    .action(mockAction);
+  program.parse(['sub', '--debug', 'arg'], { from: 'user' });
+  expect(program.opts().debug).toBeUndefined();
+  expect(mockAction).toBeCalledWith('arg', sub.opts(), sub);
+});
+
+// arg --help
+// sub --help
+// help sub
+// default command, arg --debug

--- a/tests/command.positionalOptions.test.js
+++ b/tests/command.positionalOptions.test.js
@@ -78,7 +78,8 @@ describe('program with positionalOptions and subcommand', () => {
       .enablePositionalOptions()
       .option('-s, --shared <value>')
       .arguments('<args...>');
-    const sub = program.command('sub')
+    const sub = program
+      .command('sub')
       .arguments('[arg]')
       .option('-s, --shared <value>')
       .action(() => {}); // Not used, but normal to have action handler on subcommand.
@@ -151,7 +152,8 @@ describe('program with positionalOptions and default subcommand (called sub)', (
       .option('-s, --shared')
       .option('-g, --global')
       .arguments('<args...>');
-    const sub = program.command('sub', { isDefault: true })
+    const sub = program
+      .command('sub', { isDefault: true })
       .arguments('[args...]')
       .option('-s, --shared')
       .option('-d, --default')
@@ -217,7 +219,8 @@ describe('subcommand with passThrough', () => {
       .enablePositionalOptions()
       .option('-s, --shared <value>')
       .arguments('<args...>');
-    const sub = program.command('sub')
+    const sub = program
+      .command('sub')
       .passThroughOptions()
       .arguments('[args...]')
       .option('-s, --shared <value>')
@@ -283,7 +286,8 @@ describe('default command with passThrough', () => {
     const program = new commander.Command();
     program
       .enablePositionalOptions();
-    const sub = program.command('sub', { isDefault: true })
+    const sub = program
+      .command('sub', { isDefault: true })
       .passThroughOptions()
       .arguments('[args...]')
       .option('-d, --debug')
@@ -330,7 +334,8 @@ describe('program with action handler and positionalOptions and subcommand', () 
       .option('-g, --global')
       .arguments('<args...>')
       .action(() => {});
-    const sub = program.command('sub')
+    const sub = program
+      .command('sub')
       .arguments('[arg]')
       .action(() => {});
     return { program, sub };

--- a/tests/command.positionalOptions.test.js
+++ b/tests/command.positionalOptions.test.js
@@ -443,3 +443,73 @@ describe('program with allowUnknownOption', () => {
     expect(program.args).toEqual(['--unknown']);
   });
 });
+
+// ------------------------------------------------------------------------------
+
+describe('passThroughOptions(xxx) and option after command-argument', () => {
+  function makeProgram() {
+    const program = new commander.Command();
+    program
+      .option('-d, --debug')
+      .arguments('<args...>');
+    return program;
+  }
+
+  test('when passThroughOptions() then option passed through', () => {
+    const program = makeProgram();
+    program.passThroughOptions();
+    program.parse(['foo', '--debug'], { from: 'user' });
+    expect(program.args).toEqual(['foo', '--debug']);
+  });
+
+  test('when passThroughOptions(true) then option passed through', () => {
+    const program = makeProgram();
+    program.passThroughOptions(true);
+    program.parse(['foo', '--debug'], { from: 'user' });
+    expect(program.args).toEqual(['foo', '--debug']);
+  });
+
+  test('when passThroughOptions(false) then option parsed', () => {
+    const program = makeProgram();
+    program.passThroughOptions(false);
+    program.parse(['foo', '--debug'], { from: 'user' });
+    expect(program.args).toEqual(['foo']);
+    expect(program.opts().debug).toEqual(true);
+  });
+});
+
+// ------------------------------------------------------------------------------
+
+describe('enablePositionalOptions(xxx) and shared option after subcommand', () => {
+  function makeProgram() {
+    const program = new commander.Command();
+    program
+      .option('-d, --debug');
+    const sub = program
+      .command('sub')
+      .option('-d, --debug');
+    return { program, sub };
+  }
+
+  test('when enablePositionalOptions() then option parsed by subcommand', () => {
+    const { program, sub } = makeProgram();
+    program.enablePositionalOptions();
+    program.parse(['sub', '--debug'], { from: 'user' });
+    expect(sub.opts().debug).toEqual(true);
+  });
+
+  test('when enablePositionalOptions(true) then option parsed by subcommand', () => {
+    const { program, sub } = makeProgram();
+    program.enablePositionalOptions(true);
+    program.parse(['sub', '--debug'], { from: 'user' });
+    expect(sub.opts().debug).toEqual(true);
+  });
+
+  test('when enablePositionalOptions(false) then option parsed by program', () => {
+    const { program, sub } = makeProgram();
+    program.enablePositionalOptions(false);
+    program.parse(['sub', '--debug'], { from: 'user' });
+    expect(sub.opts().debug).toBeUndefined();
+    expect(program.opts().debug).toEqual(true);
+  });
+});

--- a/tests/command.positionalOptions.test.js
+++ b/tests/command.positionalOptions.test.js
@@ -322,4 +322,4 @@ describe('program with action handler and positionalOptions and subcommand', () 
 
 // Test action handler at least once in each block ????
 
-// Test default command support does not break any other cases ????
+// Test error when passThrough in subcommand without positionalOptions in parent

--- a/typings/commander-tests.ts
+++ b/typings/commander-tests.ts
@@ -147,6 +147,14 @@ const allowUnknownOptionThis2: commander.Command = program.allowUnknownOption(fa
 const allowExcessArgumentsThis1: commander.Command = program.allowExcessArguments();
 const allowExcessArgumentsThis2: commander.Command = program.allowExcessArguments(false);
 
+// enablePositionalOptions
+const enablePositionalOptionsThis1: commander.Command = program.enablePositionalOptions();
+const enablePositionalOptionsThis2: commander.Command = program.enablePositionalOptions(false);
+
+// passThroughOptions
+const passThroughOptionsThis1: commander.Command = program.passThroughOptions();
+const passThroughOptionsThis2: commander.Command = program.passThroughOptions(false);
+
 // parse
 const parseThis1: commander.Command = program.parse();
 const parseThis2: commander.Command = program.parse(process.argv);

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -401,6 +401,27 @@ declare namespace commander {
     allowExcessArguments(allowExcess?: boolean): this;
 
     /**
+     * Enable positional options. Positional means global options are specified before subcommands which lets
+     * subcommands reuse the same option names, and also enables subcommands to turn on passThroughOptions.
+     *
+     * The default behaviour is non-positional and global options may appear anywhere on the command line.
+     *
+     * @returns `this` command for chaining
+     */
+    enablePositionalOptions(positional?: boolean): this;
+
+    /**
+     * Pass through options that come after command-arguments rather than treat them as command-options,
+     * so actual command-options come before command-arguments. Turning this on for a subcommand requires
+     * positional options to have been enabled on the program (parent commands).
+     *
+     * The default behaviour is non-positional and options may appear before or after command-arguments.
+     *
+     * @returns `this` command for chaining
+     */
+    passThroughOptions(passThrough?: boolean): this;
+
+    /**
      * Parse `argv`, setting options and invoking commands when defined.
      *
      * The default expectation is that the arguments are from node and have the application as argv[0]


### PR DESCRIPTION
# Pull Request

Collected issues and background research in #1229

## Problem

Two quite similar problems in how they look on command line, but different use cases.

1) A program option can not be reused in a subcommand, as the program options are recognised anywhere on the command line.

Related: #598 #797 #1033 #1307 #1426

2) It is not easy to pass through options which are intended for another program. The options are recognised before or after command-arguments.

Related: #1127 #1293 

## Solution

Add two new routines to alter the parsing of options to be positional. The default behaviour is unchanged.

`.enablePositionalOptions()`

Enable positional options. Positional means global options are specified before subcommands which lets subcommands reuse the same option names, and also enables subcommands to turn on passThroughOptions.

The default behaviour is non-positional (as before) and global options may appear anywhere on the command line.

Positional options makes it different whether an option comes before or after a subcommand. e.g.

```js
program -p subcommand
program subcommand -p
program -p subcommand -p
```

`.passThroughOptions()`

Pass through options that come after command-arguments rather than treat them as command-options, so actual command-options come before command-arguments. Turning this on for a subcommand requires positional options to have been enabled on the program (parent commands).

The default behaviour is non-positional (as before) and options may appear before or after command-arguments.

Pass through options makes it different whether an option comes before or after a command-argument. e.g.

```js
program --verbose arg
program arg --verbose
program --verbose arg --verbose
```

## ChangeLog

- `.enablePositionalOptions()` to let program and subcommand reuse same option
- `.passThroughOptions()` to pass options through to other programs without needing `--`

## To Do:

- [x] TypeScript typings
- [x] tests
- [x] README
- [x] examples
