### PR TITLE
Add cjs to list of expected node script extensions

### DIFF
--- a/index.js
+++ b/index.js
@@ -1317,7 +1317,7 @@ class Command extends EventEmitter {
   _executeSubCommand(subcommand, args) {
     args = args.slice();
     let launchWithNode = false; // Use node for source targets so do not need to get permissions correct, and on Windows.
-    const sourceExt = ['.js', '.ts', '.tsx', '.mjs'];
+    const sourceExt = ['.js', '.ts', '.tsx', '.mjs', '.cjs'];
 
     // Not checking for help first. Unlikely to have mandatory and executable, and can't robustly test for help flags in external command.
     this._checkForMissingMandatoryOptions();

--- a/tests/command.executableSubcommand.lookup.test.js
+++ b/tests/command.executableSubcommand.lookup.test.js
@@ -83,11 +83,23 @@ testOrSkipOnWindows('when subcommand file is double symlink then lookup succeeds
 
 test('when subcommand suffix is .ts then lookup succeeds', async() => {
   // We support looking for ts files for ts-node in particular, but don't need to test ts-node itself.
-  // The program and the subcommand `pm-install.ts` are both plain JavaScript code.
-  const binLinkTs = path.join(__dirname, 'fixtures-ts', 'pm.ts');
+  // The subcommand is both plain JavaScript code for this test.
+  const binLinkTs = path.join(__dirname, 'fixtures-extensions', 'pm.js');
   // childProcess.execFile('node', ['-r', 'ts-node/register', binLinkTs, 'install'], function(_error, stdout, stderr) {
-  const { stdout } = await execFileAsync('node', [binLinkTs, 'install']);
-  expect(stdout).toBe('install\n');
+  const { stdout } = await execFileAsync('node', [binLinkTs, 'try-ts']);
+  expect(stdout).toBe('found .ts\n');
+});
+
+test('when subcommand suffix is .cjs then lookup succeeds', async() => {
+  const binLinkTs = path.join(__dirname, 'fixtures-extensions', 'pm.js');
+  const { stdout } = await execFileAsync('node', [binLinkTs, 'try-cjs']);
+  expect(stdout).toBe('found .cjs\n');
+});
+
+test('when subcommand suffix is .mjs then lookup succeeds', async() => {
+  const binLinkTs = path.join(__dirname, 'fixtures-extensions', 'pm.js');
+  const { stdout } = await execFileAsync('node', [binLinkTs, 'try-mjs']);
+  expect(stdout).toBe('found .mjs\n');
 });
 
 test('when subsubcommand then lookup sub-sub-command', async() => {

--- a/tests/fixtures-extensions/pm-try-cjs.cjs
+++ b/tests/fixtures-extensions/pm-try-cjs.cjs
@@ -1,0 +1,1 @@
+console.log('found .cjs');

--- a/tests/fixtures-extensions/pm-try-mjs.mjs
+++ b/tests/fixtures-extensions/pm-try-mjs.mjs
@@ -1,0 +1,1 @@
+console.log('found .mjs');

--- a/tests/fixtures-extensions/pm-try-ts.ts
+++ b/tests/fixtures-extensions/pm-try-ts.ts
@@ -1,0 +1,1 @@
+console.log('found .ts');

--- a/tests/fixtures-extensions/pm.js
+++ b/tests/fixtures-extensions/pm.js
@@ -1,9 +1,8 @@
 #!/usr/bin/env node
 
-var program = require('../../');
+const program = require('../../');
 
 program
-  .version('0.0.1')
   .command('try-ts', 'test file extension lookup')
   .command('try-cjs', 'test file extension lookup')
   .command('try-mjs', 'test file extension lookup')

--- a/tests/fixtures-extensions/pm.js
+++ b/tests/fixtures-extensions/pm.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+var program = require('../../');
+
+program
+  .version('0.0.1')
+  .command('try-ts', 'test file extension lookup')
+  .command('try-cjs', 'test file extension lookup')
+  .command('try-mjs', 'test file extension lookup')
+  .parse(process.argv);

--- a/tests/fixtures-ts/pm-install.ts
+++ b/tests/fixtures-ts/pm-install.ts
@@ -1,3 +1,0 @@
-#!/usr/bin/env node
-
-console.log('install');

--- a/tests/fixtures-ts/pm.ts
+++ b/tests/fixtures-ts/pm.ts
@@ -1,8 +1,0 @@
-#!/usr/bin/env node
-
-var program = require('../../');
-
-program
-  .version('0.0.1')
-  .command('install [name]', 'install one or more packages')
-  .parse(process.argv);


### PR DESCRIPTION
# Pull Request

## Problem

Node uses `.cjs` for specifically CommonJS javascript files, like `.mjs` for esm. Commander does not check for that extension when considering how to launch external stand-alone subcommands.

## Solution

Add `.cjs`.

## ChangeLog

- Add `.cjs` to expected script file extensions.

## To Do

- [x] Add tests for file suffixes. We have a test for `.ts` but not for `.mjs` or `.cjs`.