### PR TITLE
Add support for variadic to choices

### DIFF
--- a/tests/options.variadic.test.js
+++ b/tests/options.variadic.test.js
@@ -40,6 +40,24 @@ describe('variadic option with required value', () => {
     expect(program.opts().required).toEqual(['one', 'two']);
   });
 
+  test('when variadic used with choices and one value then set in array', () => {
+    const program = new commander.Command();
+    program
+      .addOption(new commander.Option('-r,--required <value...>').choices(['one', 'two']));
+
+    program.parse(['--required', 'one'], { from: 'user' });
+    expect(program.opts().required).toEqual(['one']);
+  });
+
+  test('when variadic used with choices and two values then set in array', () => {
+    const program = new commander.Command();
+    program
+      .addOption(new commander.Option('-r,--required <value...>').choices(['one', 'two']));
+
+    program.parse(['--required', 'one', 'two'], { from: 'user' });
+    expect(program.opts().required).toEqual(['one', 'two']);
+  });
+
   test('when variadic with short combined argument then not variadic', () => {
     const program = new commander.Command();
     program


### PR DESCRIPTION
# Pull Request

I don't this will be very common, but it is a shortcoming and did get reported!

## Problem

Variadic and choices do not play well together.

Related: #1447

## Solution

Add support for variadic to choices using same code as plain variadic processing.

(This does not add public support for mixing custom option processing with variadic. Keep it private until clearer what people might want to do.)

## ChangeLog

- allow using option choices and variadic together (#1454)
