### PR TITLE
Test for help for arguments without description

### DIFF
--- a/tests/command.help.test.js
+++ b/tests/command.help.test.js
@@ -251,5 +251,15 @@ test('when arguments described then included in helpInformation', () => {
     .helpOption(false)
     .description('description', { file: 'input source' });
   const helpInformation = program.helpInformation();
-  expect(helpInformation).toMatch(/Arguments:\n +file +input source/); // [sic], extra line
+  expect(helpInformation).toMatch(/Arguments:\n +file +input source/);
+});
+
+test('when arguments described and empty description then arguments included in helpInformation', () => {
+  const program = new commander.Command();
+  program
+    .arguments('<file>')
+    .helpOption(false)
+    .description('', { file: 'input source' });
+  const helpInformation = program.helpInformation();
+  expect(helpInformation).toMatch(/Arguments:\n +file +input source/);
 });


### PR DESCRIPTION
# Pull Request

## Problem

A couple of people have asked about showing help for command-arguments, without a description for the command. We didn't have a test for this now supported case.

Uses: #1450 #1192

## Solution

Add test.