### PR TITLE
Missing subcommand in action for test

### DIFF
--- a/tests/command.unknownOption.test.js
+++ b/tests/command.unknownOption.test.js
@@ -27,7 +27,7 @@ describe('unknownOption', () => {
 
     let caughtErr;
     try {
-      program.parse(['node', 'info', '--NONSENSE']);
+      program.parse(['node', 'test', 'info', '--NONSENSE']);
     } catch (err) {
       caughtErr = err;
     }


### PR DESCRIPTION
# Pull Request

Stumbled across this when it failed unexpectedly while I was experimenting with changes to option handling.

## Problem

`when specify unknown option with subcommand and action handler then error` was not testing subcommand

## Solution

Change call to match test description and intent.