### PR TITLE
Skip unknown options check if there is a better error to display

### DIFF
--- a/index.js
+++ b/index.js
@@ -1476,6 +1476,7 @@ class Command extends EventEmitter {
       outputHelpIfRequested(this, parsed.unknown);
       this._checkForMissingMandatoryOptions();
 
+      // We do not always call this check to avoid masking a "better" error, like unknown command.
       const checkForUnknownOptions = () => {
         if (parsed.unknown.length > 0) {
           this.unknownOption(parsed.unknown[0]);
@@ -1508,7 +1509,8 @@ class Command extends EventEmitter {
         if (this._findCommand('*')) { // legacy default command
           checkForUnknownOptions();
           this._dispatchSubcommand('*', operands, unknown);
-        } else if (this.listenerCount('command:*')) { // suggestions
+        } else if (this.listenerCount('command:*')) {
+          // skip option check, emit event for possible misspelling suggestion
           this.emit('command:*', operands, unknown);
         } else if (this.commands.length) {
           this.unknownCommand();

--- a/index.js
+++ b/index.js
@@ -1514,7 +1514,6 @@ class Command extends EventEmitter {
           this.unknownCommand();
         }
       } else if (this.commands.length) {
-        checkForUnknownOptions();
         // This command has subcommands and nothing hooked up at this level, so display help.
         this.help({ error: true });
       } else {

--- a/index.js
+++ b/index.js
@@ -1475,12 +1475,16 @@ class Command extends EventEmitter {
 
       outputHelpIfRequested(this, parsed.unknown);
       this._checkForMissingMandatoryOptions();
-      if (parsed.unknown.length > 0) {
-        this.unknownOption(parsed.unknown[0]);
-      }
+
+      const checkForUnknownOptions = () => {
+        if (parsed.unknown.length > 0) {
+          this.unknownOption(parsed.unknown[0]);
+        }
+      };
 
       const commandEvent = `command:${this.name()}`;
       if (this._actionHandler) {
+        checkForUnknownOptions();
         // Check expected arguments and collect variadic together.
         const args = this.args.slice();
         this._args.forEach((arg, i) => {
@@ -1498,8 +1502,10 @@ class Command extends EventEmitter {
         this._actionHandler(args);
         if (this.parent) this.parent.emit(commandEvent, operands, unknown); // legacy
       } else if (this.parent && this.parent.listenerCount(commandEvent)) {
+        checkForUnknownOptions();
         this.parent.emit(commandEvent, operands, unknown); // legacy
       } else if (operands.length) {
+        checkForUnknownOptions();
         if (this._findCommand('*')) { // legacy
           this._dispatchSubcommand('*', operands, unknown);
         } else if (this.listenerCount('command:*')) {
@@ -1508,9 +1514,11 @@ class Command extends EventEmitter {
           this.unknownCommand();
         }
       } else if (this.commands.length) {
+        checkForUnknownOptions();
         // This command has subcommands and nothing hooked up at this level, so display help.
         this.help({ error: true });
       } else {
+        checkForUnknownOptions();
         // fall through for caller to handle after calling .parse()
       }
     }

--- a/index.js
+++ b/index.js
@@ -1505,13 +1505,15 @@ class Command extends EventEmitter {
         checkForUnknownOptions();
         this.parent.emit(commandEvent, operands, unknown); // legacy
       } else if (operands.length) {
-        checkForUnknownOptions();
-        if (this._findCommand('*')) { // legacy
+        if (this._findCommand('*')) { // legacy default command
+          checkForUnknownOptions();
           this._dispatchSubcommand('*', operands, unknown);
-        } else if (this.listenerCount('command:*')) {
+        } else if (this.listenerCount('command:*')) { // suggestions
           this.emit('command:*', operands, unknown);
         } else if (this.commands.length) {
           this.unknownCommand();
+        } else {
+          checkForUnknownOptions();
         }
       } else if (this.commands.length) {
         // This command has subcommands and nothing hooked up at this level, so display help.

--- a/index.js
+++ b/index.js
@@ -1507,7 +1507,6 @@ class Command extends EventEmitter {
         this.parent.emit(commandEvent, operands, unknown); // legacy
       } else if (operands.length) {
         if (this._findCommand('*')) { // legacy default command
-          checkForUnknownOptions();
           this._dispatchSubcommand('*', operands, unknown);
         } else if (this.listenerCount('command:*')) {
           // skip option check, emit event for possible misspelling suggestion

--- a/tests/command.asterisk.test.js
+++ b/tests/command.asterisk.test.js
@@ -66,7 +66,7 @@ describe(".command('*')", () => {
   });
 
   test('when unrecognised argument and known option then asterisk action called', () => {
-    // This tests for a regression between v4 and v5. Unknown option should not be detected by program.
+    // This tests for a regression between v4 and v5. Known default option should not be rejected by program.
     const mockAction = jest.fn();
     const program = new commander.Command();
     program

--- a/tests/command.asterisk.test.js
+++ b/tests/command.asterisk.test.js
@@ -81,20 +81,27 @@ describe(".command('*')", () => {
     expect(star.opts().debug).toEqual(true);
   });
 
-  test('when unrecognised argument and unknown option then error', () => {
-    // This is a change in behaviour from v2, but is consistent with modern better detection of invalid options
+  test('when non-command argument and unknown option then error for unknown option', () => {
+    // This is a change in behaviour from v2 which did not error, but is consistent with modern better detection of invalid options
     const mockAction = jest.fn();
     const program = new commander.Command();
     program
       .exitOverride()
+      .configureOutput({
+        writeErr: () => {}
+      })
       .command('install');
     program
       .command('*')
       .arguments('[args...]')
       .action(mockAction);
-    expect(() => {
-      program.parse(['node', 'test', 'unrecognised-command', '--unknown']);
-    }).toThrow();
+    let caughtErr;
+    try {
+      program.parse(['node', 'test', 'some-argument', '--unknown']);
+    } catch (err) {
+      caughtErr = err;
+    }
+    expect(caughtErr.code).toEqual('commander.unknownOption');
   });
 });
 
@@ -144,7 +151,7 @@ describe(".on('command:*')", () => {
   test('when unrecognised command/argument and unknown option then listener called', () => {
     // Give listener a chance to make a suggestion for misspelled command. The option
     // could only be unknown because the command is not correct.
-    // Regression identified in https://github.com/tj/commander.js/issues/1460#issuecomment-772313494 
+    // Regression identified in https://github.com/tj/commander.js/issues/1460#issuecomment-772313494
     const mockAction = jest.fn();
     const program = new commander.Command();
     program

--- a/tests/command.asterisk.test.js
+++ b/tests/command.asterisk.test.js
@@ -66,6 +66,7 @@ describe(".command('*')", () => {
   });
 
   test('when unrecognised argument and known option then asterisk action called', () => {
+    // This tests for a regression between v4 and v5. Unknown option should not be detected by program.
     const mockAction = jest.fn();
     const program = new commander.Command();
     program

--- a/tests/command.asterisk.test.js
+++ b/tests/command.asterisk.test.js
@@ -64,6 +64,37 @@ describe(".command('*')", () => {
     program.parse(['node', 'test', 'unrecognised-command']);
     expect(mockAction).toHaveBeenCalled();
   });
+
+  test('when unrecognised argument and known option then asterisk action called', () => {
+    const mockAction = jest.fn();
+    const program = new commander.Command();
+    program
+      .command('install');
+    const star = program
+      .command('*')
+      .arguments('[args...]')
+      .option('-d, --debug')
+      .action(mockAction);
+    program.parse(['node', 'test', 'unrecognised-command', '--debug']);
+    expect(mockAction).toHaveBeenCalled();
+    expect(star.opts().debug).toEqual(true);
+  });
+
+  test('when unrecognised argument and unknown option then error', () => {
+    // This is a change in behaviour from v2, but is consistent with modern better detection of invalid options
+    const mockAction = jest.fn();
+    const program = new commander.Command();
+    program
+      .exitOverride()
+      .command('install');
+    program
+      .command('*')
+      .arguments('[args...]')
+      .action(mockAction);
+    expect(() => {
+      program.parse(['node', 'test', 'unrecognised-command', '--unknown']);
+    }).toThrow();
+  });
 });
 
 // Test .on explicitly rather than assuming covered by .command

--- a/tests/command.asterisk.test.js
+++ b/tests/command.asterisk.test.js
@@ -140,4 +140,18 @@ describe(".on('command:*')", () => {
     program.parse(['node', 'test', 'unrecognised-command']);
     expect(mockAction).toHaveBeenCalled();
   });
+
+  test('when unrecognised command/argument and unknown option then listener called', () => {
+    // Give listener a chance to make a suggestion for misspelled command. The option
+    // could only be unknown because the command is not correct.
+    // Regression identified in https://github.com/tj/commander.js/issues/1460#issuecomment-772313494 
+    const mockAction = jest.fn();
+    const program = new commander.Command();
+    program
+      .command('install');
+    program
+      .on('command:*', mockAction);
+    program.parse(['node', 'test', 'intsall', '--unknown']);
+    expect(mockAction).toHaveBeenCalled();
+  });
 });

--- a/tests/command.unknownCommand.test.js
+++ b/tests/command.unknownCommand.test.js
@@ -65,15 +65,14 @@ describe('unknownCommand', () => {
 
   test('when unknown command and unknown option then error is for unknown command', () => {
     //  The unknown command is more useful since the option is for an unknown command (and might be
-    // ok if the commadn had been correctly spelled, say).
+    // ok if the command had been correctly spelled, say).
     const program = new commander.Command();
     program
       .exitOverride()
-      .command('sub')
-      .option('-d, --debug');
+      .command('sub');
     let caughtErr;
     try {
-      program.parse('node test.js sbu --debug'.split(' '));
+      program.parse('node test.js sbu --silly'.split(' '));
     } catch (err) {
       caughtErr = err;
     }

--- a/tests/command.unknownCommand.test.js
+++ b/tests/command.unknownCommand.test.js
@@ -1,6 +1,6 @@
 const commander = require('../');
 
-describe('unknownOption', () => {
+describe('unknownCommand', () => {
   // Optional. Use internal knowledge to suppress output to keep test output clean.
   let writeErrorSpy;
 
@@ -57,6 +57,23 @@ describe('unknownOption', () => {
     let caughtErr;
     try {
       program.parse('node test.js unknown'.split(' '));
+    } catch (err) {
+      caughtErr = err;
+    }
+    expect(caughtErr.code).toBe('commander.unknownCommand');
+  });
+
+  test('when unknown command and unknown option then error is for unknown command', () => {
+    //  The unknown command is more useful since the option is for an unknown command (and might be
+    // ok if the commadn had been correctly spelled, say).
+    const program = new commander.Command();
+    program
+      .exitOverride()
+      .command('sub')
+      .option('-d, --debug');
+    let caughtErr;
+    try {
+      program.parse('node test.js sbu --debug'.split(' '));
     } catch (err) {
       caughtErr = err;
     }

--- a/tests/command.unknownOption.test.js
+++ b/tests/command.unknownOption.test.js
@@ -82,4 +82,17 @@ describe('unknownOption', () => {
     }
     expect(caughtErr.code).toBe('commander.unknownOption');
   });
+
+  test('when specify unknown option with simple program then error', () => {
+    const program = new commander.Command();
+    program
+      .exitOverride();
+    let caughtErr;
+    try {
+      program.parse(['node', 'test', '--NONSENSE']);
+    } catch (err) {
+      caughtErr = err;
+    }
+    expect(caughtErr.code).toBe('commander.unknownOption');
+  });
 });


### PR DESCRIPTION
# Pull Request

I think this is working our sensibly. Making changes in a complicated piece of the code so going slowly.

## Problem

In Commander v5 we started checking for unknown options in more situations, which was an improvement in many cases. However, it unintentional blocked some "better" errors such as an unknown command, and blocked suggestions for the unknown commands (listener for `command:*`).

Related issue: #1460

## Solution

Work through cases and don't block a better error by checking for unknown options. Especially, when the issue is likely to be a misspelled command.

## ChangeLog

- fix regression for legacy `command('*')` and call when command line includes options (#1464)
- fix regression for `on('command:*', ...` and call when command line includes unknown options (#1464)
- fix display best error for combination of unknown command and unknown option (i.e. unknown command) (#1464)
