### PR TITLE
Test for help for arguments without description

### DIFF
--- a/tests/command.help.test.js
+++ b/tests/command.help.test.js
@@ -251,5 +251,15 @@ test('when arguments described then included in helpInformation', () => {
     .helpOption(false)
     .description('description', { file: 'input source' });
   const helpInformation = program.helpInformation();
-  expect(helpInformation).toMatch(/Arguments:\n +file +input source/); // [sic], extra line
+  expect(helpInformation).toMatch(/Arguments:\n +file +input source/);
+});
+
+test('when arguments described and empty description then arguments included in helpInformation', () => {
+  const program = new commander.Command();
+  program
+    .arguments('<file>')
+    .helpOption(false)
+    .description('', { file: 'input source' });
+  const helpInformation = program.helpInformation();
+  expect(helpInformation).toMatch(/Arguments:\n +file +input source/);
 });


### PR DESCRIPTION
# Pull Request

## Problem

We have added support for describing the command arguments without adding a description, but not a matching test to reduce the chance of a regression.

Related issues: #1192 #1450

## Solution

Added test.