### PR TITLE
Update documentation for option event listeners

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -655,7 +655,7 @@ You can execute custom actions by listening to command and option events.
 
 ```js
 program.on('option:verbose', function () {
-  process.env.VERBOSE = this.verbose;
+  process.env.VERBOSE = this.opts().verbose;
 });
 
 program.on('command:*', function (operands) {


### PR DESCRIPTION
# Pull Request

<!--
The text in these markdown comments is instructions that will not appear in the displayed pull request,
and can be deleted.

Please submit pull requests against the develop branch.

Follow the existing code style. Check the tests succeed, including lint.
  npm run test
  npm run lint

Don't update the CHANGELOG or command version number. That gets done by maintainers when preparing the release.

Commander currently has zero production dependencies. That isn't a hard requirement, but is a simple story. Requests which 
add a dependency are much less likely to be accepted, and we are likely to ask if there alternative approaches to avoid the dependency.
-->

## Problem

Documentation for `option:*` event listeners was outdated.

## Solution

Updated the README to reflect the changes made in v7.x. 🚀 

## ChangeLog

> ### Changed
> - Updated documentation for `option:*` event listeners ([#1470])
