### PR TITLE
Add runtime test that TypeScript imports are working

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1525,6 +1525,15 @@
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
       "dev": true
     },
+    "bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "requires": {
+        "fast-json-stable-stringify": "2.x"
+      }
+    },
     "bser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -4629,6 +4638,12 @@
         }
       }
     },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
     "makeerror": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
@@ -6806,6 +6821,39 @@
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
       "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
       "dev": true
+    },
+    "ts-jest": {
+      "version": "26.5.1",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.5.1.tgz",
+      "integrity": "sha512-G7Rmo3OJMvlqE79amJX8VJKDiRcd7/r61wh9fnvvG8cAjhA9edklGw/dCxRSQmfZ/z8NDums5srSVgwZos1qfg==",
+      "dev": true,
+      "requires": {
+        "@types/jest": "26.x",
+        "bs-logger": "0.x",
+        "buffer-from": "1.x",
+        "fast-json-stable-stringify": "2.x",
+        "jest-util": "^26.1.0",
+        "json5": "2.x",
+        "lodash": "4.x",
+        "make-error": "1.x",
+        "mkdirp": "1.x",
+        "semver": "7.x",
+        "yargs-parser": "20.x"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        },
+        "yargs-parser": {
+          "version": "20.2.5",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.5.tgz",
+          "integrity": "sha512-jYRGS3zWy20NtDtK2kBgo/TlAoy5YUuhD9/LZ7z7W4j1Fdw2cqD0xEEclf8fxc8xjD6X5Qr+qQQwCEsP8iRiYg==",
+          "dev": true
+        }
+      }
     },
     "tsconfig-paths": {
       "version": "3.9.0",

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
   },
   "scripts": {
     "lint": "eslint index.js esm.mjs \"tests/**/*.js\"",
-    "typescript-lint": "eslint typings/*.ts",
+    "typescript-lint": "eslint typings/*.ts tests/*.ts",
     "test": "jest && npm run test-typings",
-    "test-esm": "node --experimental-modules ./tests/esm-test.mjs",
+    "test-esm": "node --experimental-modules ./tests/esm-imports-test.mjs",
     "test-typings": "tsd",
     "typescript-checkJS": "tsc --allowJS --checkJS index.js --noEmit",
     "test-all": "npm run test && npm run lint && npm run typescript-lint && npm run typescript-checkJS && npm run test-esm"
@@ -45,12 +45,20 @@
     "eslint-plugin-jest": "^24.1.3",
     "jest": "^26.6.3",
     "standard": "^16.0.3",
+    "ts-jest": "^26.5.1",
     "tsd": "^0.14.0",
     "typescript": "^4.1.2"
   },
   "types": "typings/index.d.ts",
   "jest": {
-    "collectCoverage": true
+    "testEnvironment": "node",
+    "collectCoverage": true,
+    "transform": {
+      "^.+\\.tsx?$": "ts-jest"
+    },
+    "testPathIgnorePatterns": [
+      "/node_modules/"
+    ]
   },
   "engines": {
     "node": ">= 10"

--- a/tests/esm-imports-test.mjs
+++ b/tests/esm-imports-test.mjs
@@ -1,7 +1,8 @@
 import { program, Command, Option, CommanderError, InvalidOptionArgumentError, Help, createCommand } from '../esm.mjs';
 
-// Do some simple checks that expected imports are available.
+// Do some simple checks that expected imports are available at runtime.
 // Run using `npm run test-esm`.
+// Similar tests to test-imports.test.ts
 
 function check(condition, explanation) {
   if (!condition) {

--- a/tests/ts-imports.test.ts
+++ b/tests/ts-imports.test.ts
@@ -1,5 +1,7 @@
 import { program, Command, Option, CommanderError, InvalidOptionArgumentError, Help, createCommand } from '../';
 
+import * as commander from '../';
+
 // Do some simple checks that expected imports are available at runtime.
 // Similar tests to esm-imports-test.js
 
@@ -8,6 +10,10 @@ function checkClass(obj: object, name: string) {
   expect(typeof obj).toEqual('object');
   expect(obj.constructor.name).toEqual(name);
 }
+
+test('legacy default export of global Command', () => {
+  checkClass(commander, 'Command');
+});
 
 test('program', () => {
   checkClass(program, 'Command');

--- a/tests/ts-imports.test.ts
+++ b/tests/ts-imports.test.ts
@@ -1,0 +1,38 @@
+import { program, Command, Option, CommanderError, InvalidOptionArgumentError, Help, createCommand } from '../';
+
+// Do some simple checks that expected imports are available at runtime.
+// Similar tests to esm-imports-test.js
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+function checkClass(obj: object, name: string) {
+  expect(typeof obj).toEqual('object');
+  expect(obj.constructor.name).toEqual(name);
+}
+
+test('program', () => {
+  checkClass(program, 'Command');
+});
+
+test('createCommand', () => {
+  checkClass(createCommand(), 'Command');
+});
+
+test('Command', () => {
+  checkClass(new Command('name'), 'Command');
+});
+
+test('Option', () => {
+  checkClass(new Option('-e, --example', 'description'), 'Option');
+});
+
+test('CommanderError', () => {
+  checkClass(new CommanderError(1, 'code', 'failed'), 'CommanderError');
+});
+
+test('InvalidOptionArgumentError', () => {
+  checkClass(new InvalidOptionArgumentError('failed'), 'InvalidOptionArgumentError');
+});
+
+test('Help', () => {
+  checkClass(new Help(), 'Help');
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
         "noImplicitThis": true,
         "strictNullChecks": true,
         "types": [
-            "node"
+          "node",
+          "jest"
         ],
         "noEmit": true,
         "forceConsistentCasingInFileNames": true


### PR DESCRIPTION
# Pull Request

## Problem

We have tests that the TypeScript definitions are as intended through static analysis, but not that the expected exports from Commander are available at runtime.

## Solution

Add a TypeScript test to the Jest tests that performs some simple checks that the expected imports are available at runtime. Mirrors tests for esm.
