### PR TITLE
Add Command parent property to TypeScript

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -156,8 +156,8 @@ declare namespace commander {
 
   interface Command {
     args: string[];
-
     commands: Command[];
+    parent: Command | null;
 
     /**
      * Set the program version to `str`.

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -21,6 +21,7 @@ expectType<commander.Command>(commander.createCommand());
 // Command properties
 expectType<string[]>(program.args);
 expectType<commander.Command[]>(program.commands);
+expectType<commander.Command | null>(program.parent);
 
 // version
 expectType<commander.Command>(program.version('1.2.3'));


### PR DESCRIPTION
# Pull Request

## Problem

The `parent` property is not declared in the TypeScript typings. The common use case for it is accessing the global option values in an action handler, and I have shown this in multiple examples in comments. 

Related: #1184 https://github.com/tj/commander.js/pull/1427#issuecomment-781732703

Previously accessing `cmd.parent` would not have caused a Typescript error, but the typings are stricter in Commander 7 now we no longer store options values as properties by default (hurrah!). This might lead to requests for other properties to be declared too, but planning to only add them on demand rather than declare everything.

Still thinking about providing a higher level way of accessing global options (#1229 #1155) but don't have one yet!

## Solution

Declare `parent` property on `Command` object.

## ChangeLog

- add `parent` property to TypeScript definition for Command