### PR TITLE
Add package support info

### DIFF
--- a/package-support.json
+++ b/package-support.json
@@ -3,7 +3,7 @@
     {
       "version": "*",
       "target": {
-        "node": "supported"
+        "node": "lts"
       },
       "response": {
         "type": "time-permitting"

--- a/package-support.json
+++ b/package-support.json
@@ -9,11 +9,7 @@
         "type": "time-permitting"
       },
       "backing": {
-        "donations": [
-          "https://github.com/shadowspawn",
-          "https://github.com/abetomo",
-          "https://tidelift.com/funding/github/npm/commander"
-        ]
+        "npm-funding": true
       }
     }
   ]

--- a/package-support.json
+++ b/package-support.json
@@ -10,7 +10,6 @@
       },
       "backing": {
         "donations": [
-          "https://github.com/tj",
           "https://github.com/shadowspawn",
           "https://github.com/abetomo",
           "https://tidelift.com/funding/github/npm/commander"

--- a/package-support.json
+++ b/package-support.json
@@ -1,0 +1,21 @@
+{
+  "versions": [
+    {
+      "version": "*",
+      "target": {
+        "node": "supported"
+      },
+      "response": {
+        "type": "time-permitting"
+      },
+      "backing": {
+        "donations": [
+          "https://github.com/tj",
+          "https://github.com/shadowspawn",
+          "https://github.com/abetomo",
+          "https://tidelift.com/funding/github/npm/commander"
+        ]
+      }
+    }
+  ]
+}

--- a/package-support.json
+++ b/package-support.json
@@ -3,7 +3,7 @@
     {
       "version": "*",
       "target": {
-        "node": "lts"
+        "node": "supported"
       },
       "response": {
         "type": "time-permitting"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   "files": [
     "index.js",
     "esm.mjs",
-    "typings/index.d.ts"
+    "typings/index.d.ts",
+    "package-support.json"
   ],
   "type": "commonjs",
   "dependencies": {},
@@ -62,5 +63,6 @@
   },
   "engines": {
     "node": ">= 10"
-  }
+  },
+  "support": true
 }


### PR DESCRIPTION
# Pull Request

## Problem

The Node.js Package Maintenance group have been working on clarifying how packages are supported. This blog calls for package maintainers to join in by adding support details.

- https://nodejs.medium.com/node-js-package-maintenance-bridging-the-gap-between-maintainers-and-consumers-9b3f154b0847
- https://github.com/nodejs/package-maintenance/blob/main/docs/PACKAGE-SUPPORT.md

We won't see any immediate benefits ourselves by adding this info, but doing our bit to provide the info for future tooling to make use of in the long term.

## Solution

Added support details, using the `support` tool to create initial version and validate.

I kept changing my mind about what target versions to say we support: https://github.com/nodejs/package-maintenance/blob/main/docs/PACKAGE-SUPPORT.md#support-target

I think `supported` best reflects the versions we support, which includes newer versions of node than LTS. We test all these versions in the testing matrix in `tests.yml` and will fix bugs and answer questions about `current` and `active` versions, and not just LTS versions.