### PR TITLE
WIP: Add globalOpts()

### DIFF
--- a/index.js
+++ b/index.js
@@ -1720,7 +1720,7 @@ class Command extends EventEmitter {
   };
 
   /**
-   * Return an object containing global options as key-value pairs
+   * Return an object containing global options as key-value pairs, from parent command(s).
    *
    * @return {Object}
    */

--- a/index.js
+++ b/index.js
@@ -1720,6 +1720,19 @@ class Command extends EventEmitter {
   };
 
   /**
+   * Return an object containing global options as key-value pairs
+   *
+   * @return {Object}
+   */
+  globalOpts() {
+    const result = {};
+    for (let parentCmd = this.parent; parentCmd; parentCmd = parentCmd.parent) {
+      Object.assign(result, parentCmd.opts());
+    }
+    return result;
+  }
+
+  /**
    * Internal bottleneck for handling of parsing errors.
    *
    * @api private

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -482,6 +482,11 @@ declare namespace commander {
     opts(): OptionValues;
 
     /**
+     * Return an object containing global options as key-value pairs, from parent command(s).
+     */
+    globalOpts(): OptionValues;
+
+    /**
      * Set the description.
      *
      * @returns `this` command for chaining

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -171,6 +171,12 @@ expectType<commander.OptionValues>(opts);
 expectType(opts.foo);
 expectType(opts['bar']);
 
+// globalOpts
+const globalOpts = program.globalOpts();
+expectType<commander.OptionValues>(globalOpts);
+expectType(globalOpts.foo);
+expectType(globalOpts['bar']);
+
 // description
 expectType<commander.Command>(program.description('my description'));
 expectType<string>(program.description());


### PR DESCRIPTION
# Pull Request

## Problem

People wonder how to get the global options from a subcommand. 

The current approaches are calling say `program.opts()` if have a variable available for the program, or calling `cmd.parent.opts()` from in the action handler. And looping if there are multiple levels of subcommands with options.

Related: #243 #476 https://github.com/tj/commander.js/pull/1024#issuecomment-568403615 #1155 #1229

The main expected use of the parent property is to get global options: #1475

## Solution

Add `.globalOpts()` which returns the combined global options from global/parent commands.

I did consider adding a parameter to `.opts()` to return combined local and global options, but I think explicit routine is simpler. Likewise, I wondered adding a configuration option to have the combined options passed into the action handler, but again explicit routine is simpler to understand.

## ChangeLog

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->

## To Do

- [x] typings
- [ ] tests
- [ ] README
- [ ] CHANGELOG
