### PR TITLE
Add attributeName to Option typings

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -78,6 +78,12 @@ declare namespace commander {
      * Return option name.
      */
     name(): string;
+
+    /**
+     * Return option name, in a camelcase format that can be used
+     * as a object attribute key.
+     */
+    attributeName(): string;
   }
   type OptionConstructor = new (flags: string, description?: string) => Option;
 

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -324,3 +324,6 @@ expectType<commander.Option>(baseOption.choices(['a', 'b']));
 
 // name
 expectType<string>(baseOption.name());
+
+// attributeName
+expectType<string>(baseOption.attributeName());


### PR DESCRIPTION
# Pull Request

## Problem

`.attributeName()` in JavaScript but not TypeScript.

Related: #1480

## Solution

Added to typings.

## ChangeLog

- Added `.attributeName()` to TypeScript typings for Option
