### PR TITLE
Fix syntactically incorrect command name in test

### DIFF
--- a/tests/help.visibleCommands.test.js
+++ b/tests/help.visibleCommands.test.js
@@ -23,9 +23,9 @@ describe('visibleCommands', () => {
     const program = new commander.Command();
     program
       .command('visible', 'desc')
-      .command('invisible executable', 'desc', { hidden: true });
+      .command('invisible-executable', 'desc', { hidden: true });
     program
-      .command('invisible action', { hidden: true });
+      .command('invisible-action', { hidden: true });
     const helper = new commander.Help();
     const visibleCommandNames = helper.visibleCommands(program).map(cmd => cmd.name());
     expect(visibleCommandNames).toEqual(['visible', 'help']);


### PR DESCRIPTION
# Pull Request

## Problem

With more aggressive syntax checking in the arguments PR, found some of the existing tests had invalid syntax when they failed.

## Solution

Give the commands in the test a valid single name.
