### PR TITLE
More consistent way of adding command arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 <!-- markdownlint-disable MD024 -->
 <!-- markdownlint-disable MD004 -->
 
-## [7.2.0] (2021-03-26)
+## [7.2.0] (2021-03-22)
 
 ### Added
 

--- a/Readme.md
+++ b/Readme.md
@@ -394,7 +394,7 @@ $ custom --list x,y,z
 
 You can specify (sub)commands using `.command()` or `.addCommand()`. There are two ways these can be implemented: using an action handler attached to the command, or as a stand-alone executable file (described in more detail later). The subcommands may be nested ([example](./examples/nestedCommands.js)).
 
-In the first parameter to `.command()` you specify the command name and any command-arguments. The arguments may be `<required>` or `[optional]`, and the last argument may also be `variadic...`.
+In the first parameter to `.command()` you specify the command name. You may append the command-arguments after the command name, or specify them separately using `.argument()`. The arguments may be `<required>` or `[optional]`, and the last argument may also be `variadic...`.
 
 You can use `.addCommand()` to add an already configured subcommand to the program.
 
@@ -410,7 +410,7 @@ program
     console.log('clone command called');
   });
 
-// Command implemented using stand-alone executable file (description is second parameter to `.command`)
+// Command implemented using stand-alone executable file, indicated by adding description as second parameter to `.command`.
 // Returns `this` for adding more commands.
 program
   .command('start <service>', 'start named service')
@@ -428,9 +428,12 @@ subcommand is specified ([example](./examples/defaultCommand.js)).
 
 ### Specify the argument syntax
 
-You use `.argument` to specify the expected command-arguments.
-Angle brackets around the name indicate a required command-argument (e.g. `<required>`).
-Square brackets indicate an optional command-argument (e.g. `[optional]`). The description parameter is optional.
+For subcommands, you can specify the argument syntax in the call to `.command()` (as shown above). This
+is the only method usable for subcommands implemented using a stand-alone executable, but for other subcommands
+you can instead use the following method.
+
+To configure a command, you can use `.argument()` to specify each expected command-argument. 
+You supply the argument name and an optional description. The argument may be `<required>` or `[optional]`.
 
 Example file: [argument.js](./examples/argument.js)
 
@@ -445,24 +448,14 @@ program
   });
 ```
 
-There are two ways to specify all the arguments at once, but these do not allow argument descriptions.
-
-```js
-program
-  .command('add <number> <number>');
-
-program
-  .command('fraction')
-  .arguments('<numerator> <denominator>');
-```
-
  The last argument of a command can be variadic, and only the last argument.  To make an argument variadic you
- append `...` to the argument name. For example:
+ append `...` to the argument name. A variadic argument is passed to the action handler as an array. For example:
 
 ```js
 program
   .version('0.1.0')
-  .command('rmdir <dirs...>')
+  .command('rmdir')
+  .argument('<dirs...>')
   .action(function (dirs) {
     dirs.forEach((dir) => {
       console.log('rmdir %s', dir);
@@ -470,7 +463,12 @@ program
   });
 ```
 
-A variadic argument is passed to the action handler as an array.
+There is a convenience method to add multiple arguments at once, but without descriptions:
+
+```js
+program
+  .arguments('<username> <password>');
+```
 
 ### Action handler
 

--- a/Readme.md
+++ b/Readme.md
@@ -428,8 +428,9 @@ subcommand is specified ([example](./examples/defaultCommand.js)).
 
 ### Specify the argument syntax
 
-You use `.argument` to specify the expected command-arguments. Angled brackets (e.g. `<required>`) indicate a required command-argument.
-Square brackets (e.g. `[optional]`) indicate an optional command-argument. The description parameter is optional.
+You use `.argument` to specify the expected command-arguments.
+Angle brackets around the name indicate a required command-argument (e.g. `<required>`).
+Square brackets indicate an optional command-argument (e.g. `[optional]`). The description parameter is optional.
 
 Example file: [argument.js](./examples/argument.js)
 

--- a/Readme.md
+++ b/Readme.md
@@ -428,9 +428,10 @@ subcommand is specified ([example](./examples/defaultCommand.js)).
 
 ### Specify the argument syntax
 
-You use `.argument` to specify the expected command-arguments for the top-level command, and for subcommands they are usually
-included in the `.command` call. Angled brackets (e.g. `<required>`) indicate required command-arguments.
-Square brackets (e.g. `[optional]`) indicate optional command-arguments.
+You use `.argument` to specify the expected command-arguments. Angled brackets (e.g. `<required>`) indicate a required command-argument.
+Square brackets (e.g. `[optional]`) indicate an optional command-argument. The description parameter is optional.
+
+Example file: [argument.js](./examples/argument.js)
 
 ```js
 program
@@ -439,23 +440,20 @@ program
   .argument('[password]', 'password for user, if required')
   .action((username, password) => {
     console.log('username:', username);
-    console.log('environment:', password || 'no password given');
+    console.log('password:', password || 'no password given');
   });
 ```
 
-For more complex cases, use `.addArgument()` and pass `Argument` constructor.
+There are two ways to specify all the arguments at once, but these do not allow argument descriptions.
+
 ```js
 program
-  .version('0.1.0')
-  .addArgument(new Argument('<username>', 'user to login'))
-  .action((username) => {
-    console.log('username:', username);
-  });
+  .command('add <number> <number>');
+
+program
+  .command('fraction')
+  .arguments('<numerator> <denominator>');
 ```
-
-
-Example file: [argument.js](./examples/argument.js)
-
 
  The last argument of a command can be variadic, and only the last argument.  To make an argument variadic you
  append `...` to the argument name. For example:
@@ -471,7 +469,8 @@ program
   });
 ```
 
-The variadic argument is passed to the action handler as an array.
+A variadic argument is passed to the action handler as an array.
+
 ### Action handler
 
 The action handler gets passed a parameter for each command-argument you declared, and two additional parameters

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -86,3 +86,28 @@ Examples:
 ```
 
 Deprecated from Commander v7. 
+
+## cmd.description(cmdDescription, argDescriptions)
+
+This was used to add command argument descriptions for the help.
+
+```js
+program
+  .command('price <book>')
+  .description('show price of book', {
+    book: 'ISBN number for book'
+  });
+```
+
+The new approach is to use the `.argument()` method.
+
+```js
+program
+  .command('price')
+  .description('show price of book')
+  .argument('<book>', 'ISBN number for book');
+```
+
+
+Deprecated from Commander v8.
+

--- a/docs/options-taking-varying-arguments.md
+++ b/docs/options-taking-varying-arguments.md
@@ -5,7 +5,7 @@ and subtle issues in depth.
 
 - [Options taking varying numbers of option-arguments](#options-taking-varying-numbers-of-option-arguments)
   - [Parsing ambiguity](#parsing-ambiguity)
-    - [Alternative: Make  `--` part of your syntax](#alternative-make----part-of-your-syntax)
+    - [Alternative: Make  `--` part of your syntax](#alternative-make-----part-of-your-syntax)
     - [Alternative: Put options last](#alternative-put-options-last)
     - [Alternative: Use options instead of command-arguments](#alternative-use-options-instead-of-command-arguments)
   - [Combining short options, and options taking arguments](#combining-short-options-and-options-taking-arguments)
@@ -34,7 +34,7 @@ intend the argument following the option as a command or command-argument.
 ```js
 program
   .name('cook')
-  .arguments('[technique]')
+  .argument('[technique]')
   .option('-i, --ingredient [ingredient]', 'add cheese or given ingredient')
   .action((technique, options) => {
     console.log(`technique: ${technique}`);

--- a/docs/zh-CN/可变参数的选项.md
+++ b/docs/zh-CN/可变参数的选项.md
@@ -31,7 +31,7 @@ Commander 首先解析选项的参数，而用户有可能想将选项后面跟�
 ```js
 program
   .name('cook')
-  .arguments('[technique]')
+  .argument('[technique]')
   .option('-i, --ingredient [ingredient]', 'add cheese or given ingredient')
   .action((technique, options) => {
     console.log(`technique: ${technique}`);

--- a/esm.mjs
+++ b/esm.mjs
@@ -1,4 +1,4 @@
 import commander from './index.js';
 
 // wrapper to provide named exports for ESM.
-export const { program, Option, Command, CommanderError, InvalidOptionArgumentError, Help, createCommand } = commander;
+export const { program, Option, Command, Argument, CommanderError, InvalidOptionArgumentError, Help, createCommand, createOption } = commander;

--- a/examples/argument.js
+++ b/examples/argument.js
@@ -1,19 +1,19 @@
 #!/usr/bin/env node
 
-// This example shows specifying the arguments using addArgument() and argument() function.
+// This example shows specifying the arguments using argument() function.
 
 // const { Command } = require('commander'); // (normal include)
-const { Command, Argument } = require('../'); // include commander in git clone of commander repo
+const { Command } = require('../'); // include commander in git clone of commander repo
 const program = new Command();
 
 program
   .version('0.1.0')
-  .addArgument(new Argument('<username>', 'user to login'))
-  .argument('[password]', 'password')
-  .description('test command')
+  .argument('<username>', 'user to login')
+  .argument('[password]', 'password for user, if required')
+  .description('example program for argument')
   .action((username, password) => {
     console.log('username:', username);
-    console.log('environment:', password || 'no password given');
+    console.log('password:', password || 'no password given');
   });
 
 program.parse();

--- a/examples/arguments.js
+++ b/examples/arguments.js
@@ -15,7 +15,7 @@ program
   })
   .action((username, password) => {
     console.log('username:', username);
-    console.log('environment:', password || 'no password given');
+    console.log('password:', password || 'no password given');
   });
 
 program.parse();

--- a/examples/pass-through-options.js
+++ b/examples/pass-through-options.js
@@ -5,7 +5,8 @@ const { Command } = require('../'); // include commander in git clone of command
 const program = new Command();
 
 program
-  .arguments('<utility> [args...]')
+  .argument('<utility>')
+  .argument('[args...]')
   .passThroughOptions()
   .option('-d, --dry-run')
   .action((utility, args, options) => {

--- a/examples/thank.js
+++ b/examples/thank.js
@@ -7,7 +7,7 @@ const { Command } = require('../'); // include commander in git clone of command
 const program = new Command();
 
 program
-  .arguments('<name>')
+  .argument('<name>')
   .option('-t, --title <honorific>', 'title to use before name')
   .option('-d, --debug', 'display some debugging')
   .action((name, options, command) => {

--- a/index.js
+++ b/index.js
@@ -817,7 +817,37 @@ class Command extends EventEmitter {
   };
 
   /**
-   * Define argument syntax for the command.
+   * Define argument syntax for command.
+   *
+   * The default is that the argument is required, and you can explicitly
+   * indicate this with <> around the name. Put [] around the name for an optional argument.
+   *
+   * @example
+   *
+   *     program.argument('<input-file>');
+   *     program.argument('[output-file]');
+   *
+   * @param {string} name
+   * @param {string} [description]
+   * @return {Command} `this` command for chaining
+   */
+  argument(name, description) {
+    const argument = new Argument(name, description);
+    this.addArgument(argument);
+    return this;
+  }
+
+  /**
+   * Define argument syntax for command, adding multiple at once (without descriptions).
+   *
+   * See also .argument().
+   *
+   * @example
+   *
+   *     program.arguments('<cmd> [env]');
+   *
+   * @param {string} names
+   * @return {Command} `this` command for chaining
    */
 
   arguments(names) {
@@ -828,9 +858,10 @@ class Command extends EventEmitter {
   };
 
   /**
-   * Define argument syntax for the command.
+   * Define argument syntax for command, adding a prepared argument.
    *
    * @param {Argument} argument
+   * @return {Command} `this` command for chaining
    */
   addArgument(argument) {
     const previousArgument = this._args.slice(-1)[0];
@@ -838,21 +869,6 @@ class Command extends EventEmitter {
       throw new Error(`only the last argument can be variadic '${previousArgument.name()}'`);
     }
     this._args.push(argument);
-    return this;
-  }
-
-  /**
-   * Define argument syntax for the command
-   *
-   * The default is that the argument is required, and you can explicitly
-   * indicate this with <> around the name. Put [] around the name for an optional argument.
-   *
-   * @param {string} name
-   * @param {string} [description]
-   */
-  argument(name, description) {
-    const argument = new Argument(name, description);
-    this.addArgument(argument);
     return this;
   }
 

--- a/index.js
+++ b/index.js
@@ -350,28 +350,30 @@ class Help {
 
 class Argument {
   /**
-   * Initialize a new command argument with the given detail and description.
+   * Initialize a new command argument with the given name and description.
+   * The default is that the argument is required, and you can explicitly
+   * indicate this with <> around the name. Put [] around the name for an optional argument.
    *
-   * @param {string} detail
+   * @param {string} name
    * @param {string} [description]
    */
 
-  constructor(detail, description) {
+  constructor(name, description) {
     this.required = false;
     this.variadic = false;
     this._name = '';
     this.description = description || '';
 
-    switch (detail[0]) {
+    switch (name[0]) {
       case '<': // e.g. <required>
         this.required = true;
-        this._name = detail.slice(1, -1);
+        this._name = name.slice(1, -1);
         break;
       case '[': // e.g. [optional]
-        this._name = detail.slice(1, -1);
+        this._name = name.slice(1, -1);
         break;
       default:
-        this._name = detail;
+        this._name = name;
         this.required = true;
         break;
     }
@@ -818,8 +820,8 @@ class Command extends EventEmitter {
    * Define argument syntax for the command.
    */
 
-  arguments(details) {
-    details.split(/ +/).forEach((detail) => {
+  arguments(names) {
+    names.split(/ +/).forEach((detail) => {
       this.argument(detail);
     });
     return this;
@@ -827,6 +829,7 @@ class Command extends EventEmitter {
 
   /**
    * Define argument syntax for the command.
+   *
    * @param {Argument} argument
    */
   addArgument(argument) {
@@ -839,12 +842,16 @@ class Command extends EventEmitter {
   }
 
   /**
- * Define argument syntax for the command
- * @param {string} detail
- * @param {string} [description]
- */
-  argument(detail, description) {
-    const argument = new Argument(detail, description);
+   * Define argument syntax for the command
+   *
+   * The default is that the argument is required, and you can explicitly
+   * indicate this with <> around the name. Put [] around the name for an optional argument.
+   *
+   * @param {string} name
+   * @param {string} [description]
+   */
+  argument(name, description) {
+    const argument = new Argument(name, description);
     this.addArgument(argument);
     return this;
   }

--- a/index.js
+++ b/index.js
@@ -87,11 +87,11 @@ class Help {
 
   visibleArguments(cmd) {
     // If there are some argument description then return all the arguments.
-    if (cmd._argsDescription || cmd._args.find(argument => argument.description)) {
+    if (cmd._argsDescription || cmd._args.find(argument => argument._description)) {
       const legacyDescriptions = cmd._argsDescription || {};
       return cmd._args.map(argument => {
         const term = argument.name();
-        const description = argument.description || legacyDescriptions[argument.name()] || '';
+        const description = argument._description || legacyDescriptions[argument.name()] || '';
         return { term, description };
       });
     };
@@ -359,14 +359,14 @@ class Argument {
    */
 
   constructor(name, description) {
-    this.required = false;
-    this.variadic = false;
+    this._required = false;
+    this._variadic = false;
     this._name = '';
-    this.description = description || '';
+    this._description = description || '';
 
     switch (name[0]) {
       case '<': // e.g. <required>
-        this.required = true;
+        this._required = true;
         this._name = name.slice(1, -1);
         break;
       case '[': // e.g. [optional]
@@ -374,12 +374,12 @@ class Argument {
         break;
       default:
         this._name = name;
-        this.required = true;
+        this._required = true;
         break;
     }
 
     if (this._name.length > 3 && this._name.slice(-3) === '...') {
-      this.variadic = true;
+      this._variadic = true;
       this._name = this._name.slice(0, -3);
     }
   }
@@ -865,7 +865,7 @@ class Command extends EventEmitter {
    */
   addArgument(argument) {
     const previousArgument = this._args.slice(-1)[0];
-    if (previousArgument && previousArgument.variadic) {
+    if (previousArgument && previousArgument._variadic) {
       throw new Error(`only the last argument can be variadic '${previousArgument.name()}'`);
     }
     this._args.push(argument);
@@ -1546,9 +1546,9 @@ class Command extends EventEmitter {
         // Check expected arguments and collect variadic together.
         const args = this.args.slice();
         this._args.forEach((arg, i) => {
-          if (arg.required && args[i] == null) {
+          if (arg._required && args[i] == null) {
             this.missingArgument(arg.name());
-          } else if (arg.variadic) {
+          } else if (arg._variadic) {
             args[i] = args.splice(i);
             args.length = Math.min(i + 1, args.length);
           }
@@ -2194,15 +2194,15 @@ function outputHelpIfRequested(cmd, args) {
 /**
  * Takes an argument and returns its human readable equivalent for help usage.
  *
- * @param {Object} arg
+ * @param {Argument} arg
  * @return {string}
  * @api private
  */
 
 function humanReadableArgName(arg) {
-  const nameOutput = arg.name() + (arg.variadic === true ? '...' : '');
+  const nameOutput = arg.name() + (arg._variadic === true ? '...' : '');
 
-  return arg.required
+  return arg._required
     ? '<' + nameOutput + '>'
     : '[' + nameOutput + ']';
 }

--- a/index.js
+++ b/index.js
@@ -408,16 +408,13 @@ class Argument {
   }
 
   /**
-   * Get or set the name of the argument.
+   * Return argument name.
    *
-   * @param {string} [str]
-   * @return {string|Argument}
+   * @return {string}
    */
 
-  name(str) {
-    if (str === undefined) return this._name;
-    this._name = str;
-    return this;
+  name() {
+    return this._name;
   };
 }
 

--- a/index.js
+++ b/index.js
@@ -386,7 +386,7 @@ class Argument {
    * Get or set the name of the argument.
    *
    * @param {string} [str]
-   * @return {string|Command}
+   * @return {string|Argument}
    */
 
   name(str) {

--- a/index.js
+++ b/index.js
@@ -350,7 +350,7 @@ class Help {
 
 class Argument {
   /**
-   * Initialize a new argument with the given detail and description.
+   * Initialize a new command argument with the given detail and description.
    *
    * @param {string} detail
    * @param {string} [description]
@@ -370,15 +370,15 @@ class Argument {
       case '[': // e.g. [optional]
         this._name = detail.slice(1, -1);
         break;
+      default:
+        this._name = detail;
+        this.required = true;
+        break;
     }
 
     if (this._name.length > 3 && this._name.slice(-3) === '...') {
       this.variadic = true;
       this._name = this._name.slice(0, -3);
-    }
-
-    if (this._name.length === 0) {
-      throw new Error(`Unrecognised argument format (expecting '<required>' or '[optional]'): ${detail}`);
     }
   }
 

--- a/tests/args.badArg.test.js
+++ b/tests/args.badArg.test.js
@@ -1,7 +1,0 @@
-const commander = require('../');
-
-test('when unexpected argument format then throw', () => {
-  const program = new commander.Command();
-  expect(() => program.addArgument(new commander.Argument('bad-format'))).toThrow();
-  expect(() => program.argument('bad-format')).toThrow();
-});

--- a/tests/args.badArg.test.js
+++ b/tests/args.badArg.test.js
@@ -1,6 +1,6 @@
 const commander = require('../');
 
-test('should throw on bad argument', () => {
+test('when unexpected argument format then throw', () => {
   const program = new commander.Command();
   expect(() => program.addArgument(new commander.Argument('bad-format'))).toThrow();
   expect(() => program.argument('bad-format')).toThrow();

--- a/tests/command.allowExcessArguments.test.js
+++ b/tests/command.allowExcessArguments.test.js
@@ -94,7 +94,7 @@ describe('allowUnknownOption', () => {
   test('when specify expected arg and allowExcessArguments(false) then no error', () => {
     const program = new commander.Command();
     program
-      .arguments('<file>')
+      .argument('<file>')
       .exitOverride()
       .allowExcessArguments(false)
       .action(() => {});
@@ -107,7 +107,7 @@ describe('allowUnknownOption', () => {
   test('when specify excess after <arg> and allowExcessArguments(false) then error', () => {
     const program = new commander.Command();
     program
-      .arguments('<file>')
+      .argument('<file>')
       .exitOverride()
       .allowExcessArguments(false)
       .action(() => {});
@@ -120,7 +120,7 @@ describe('allowUnknownOption', () => {
   test('when specify excess after [arg] and allowExcessArguments(false) then error', () => {
     const program = new commander.Command();
     program
-      .arguments('[file]')
+      .argument('[file]')
       .exitOverride()
       .allowExcessArguments(false)
       .action(() => {});
@@ -133,7 +133,7 @@ describe('allowUnknownOption', () => {
   test('when specify args for [args...] and allowExcessArguments(false) then no error', () => {
     const program = new commander.Command();
     program
-      .arguments('[files...]')
+      .argument('[files...]')
       .exitOverride()
       .allowExcessArguments(false)
       .action(() => {});

--- a/tests/command.allowUnknownOption.test.js
+++ b/tests/command.allowUnknownOption.test.js
@@ -83,7 +83,7 @@ describe('allowUnknownOption', () => {
     program
       .exitOverride()
       .command('sub')
-      .arguments('[args...]') // unknown option will be passed as an argument
+      .argument('[args...]') // unknown option will be passed as an argument
       .allowUnknownOption()
       .option('-p, --pepper', 'add pepper')
       .action(() => { });

--- a/tests/command.argumentVariations.test.js
+++ b/tests/command.argumentVariations.test.js
@@ -7,9 +7,9 @@ test.each(getSingleArgCases('<explicit-required>'))('when add "<arg>" using %s t
   const argument = cmd._args[0];
   const expectedShape = {
     _name: 'explicit-required',
-    required: true,
-    variadic: false,
-    description: ''
+    _required: true,
+    _variadic: false,
+    _description: ''
   };
   expect(argument).toEqual(expectedShape);
 });
@@ -18,9 +18,9 @@ test.each(getSingleArgCases('implicit-required'))('when add "arg" using %s then 
   const argument = cmd._args[0];
   const expectedShape = {
     _name: 'implicit-required',
-    required: true,
-    variadic: false,
-    description: ''
+    _required: true,
+    _variadic: false,
+    _description: ''
   };
   expect(argument).toEqual(expectedShape);
 });
@@ -29,9 +29,9 @@ test.each(getSingleArgCases('[optional]'))('when add "[arg]" using %s then argum
   const argument = cmd._args[0];
   const expectedShape = {
     _name: 'optional',
-    required: false,
-    variadic: false,
-    description: ''
+    _required: false,
+    _variadic: false,
+    _description: ''
   };
   expect(argument).toEqual(expectedShape);
 });
@@ -40,9 +40,9 @@ test.each(getSingleArgCases('<explicit-required...>'))('when add "<arg...>" usin
   const argument = cmd._args[0];
   const expectedShape = {
     _name: 'explicit-required',
-    required: true,
-    variadic: true,
-    description: ''
+    _required: true,
+    _variadic: true,
+    _description: ''
   };
   expect(argument).toEqual(expectedShape);
 });
@@ -51,9 +51,9 @@ test.each(getSingleArgCases('implicit-required...'))('when add "arg..." using %s
   const argument = cmd._args[0];
   const expectedShape = {
     _name: 'implicit-required',
-    required: true,
-    variadic: true,
-    description: ''
+    _required: true,
+    _variadic: true,
+    _description: ''
   };
   expect(argument).toEqual(expectedShape);
 });
@@ -62,9 +62,9 @@ test.each(getSingleArgCases('[optional...]'))('when add "[arg...]" using %s then
   const argument = cmd._args[0];
   const expectedShape = {
     _name: 'optional',
-    required: false,
-    variadic: true,
-    description: ''
+    _required: false,
+    _variadic: true,
+    _description: ''
   };
   expect(argument).toEqual(expectedShape);
 });

--- a/tests/command.argumentVariations.test.js
+++ b/tests/command.argumentVariations.test.js
@@ -7,9 +7,9 @@ test.each(getSingleArgCases('<explicit-required>'))('when add "<arg>" using %s t
   const argument = cmd._args[0];
   const expectedShape = {
     _name: 'explicit-required',
-    _required: true,
-    _variadic: false,
-    _description: ''
+    required: true,
+    variadic: false,
+    description: ''
   };
   expect(argument).toEqual(expectedShape);
 });
@@ -18,9 +18,9 @@ test.each(getSingleArgCases('implicit-required'))('when add "arg" using %s then 
   const argument = cmd._args[0];
   const expectedShape = {
     _name: 'implicit-required',
-    _required: true,
-    _variadic: false,
-    _description: ''
+    required: true,
+    variadic: false,
+    description: ''
   };
   expect(argument).toEqual(expectedShape);
 });
@@ -29,9 +29,9 @@ test.each(getSingleArgCases('[optional]'))('when add "[arg]" using %s then argum
   const argument = cmd._args[0];
   const expectedShape = {
     _name: 'optional',
-    _required: false,
-    _variadic: false,
-    _description: ''
+    required: false,
+    variadic: false,
+    description: ''
   };
   expect(argument).toEqual(expectedShape);
 });
@@ -40,9 +40,9 @@ test.each(getSingleArgCases('<explicit-required...>'))('when add "<arg...>" usin
   const argument = cmd._args[0];
   const expectedShape = {
     _name: 'explicit-required',
-    _required: true,
-    _variadic: true,
-    _description: ''
+    required: true,
+    variadic: true,
+    description: ''
   };
   expect(argument).toEqual(expectedShape);
 });
@@ -51,9 +51,9 @@ test.each(getSingleArgCases('implicit-required...'))('when add "arg..." using %s
   const argument = cmd._args[0];
   const expectedShape = {
     _name: 'implicit-required',
-    _required: true,
-    _variadic: true,
-    _description: ''
+    required: true,
+    variadic: true,
+    description: ''
   };
   expect(argument).toEqual(expectedShape);
 });
@@ -62,9 +62,9 @@ test.each(getSingleArgCases('[optional...]'))('when add "[arg...]" using %s then
   const argument = cmd._args[0];
   const expectedShape = {
     _name: 'optional',
-    _required: false,
-    _variadic: true,
-    _description: ''
+    required: false,
+    variadic: true,
+    description: ''
   };
   expect(argument).toEqual(expectedShape);
 });

--- a/tests/command.argumentVariations.test.js
+++ b/tests/command.argumentVariations.test.js
@@ -1,0 +1,79 @@
+const commander = require('../');
+
+// Do some low-level checks that the multiple ways of specifying command arguments produce same internal result,
+// and not exhaustively testing all methods elsewhere.
+
+test.each(getTestCases('<explicit-required>'))('when add "<arg>" via %s then argument required', (methodName, cmd) => {
+  const argument = cmd._args[0];
+  const expectedShape = {
+    _name: 'explicit-required',
+    required: true,
+    variadic: false,
+    description: ''
+  };
+  expect(argument).toEqual(expectedShape);
+});
+
+test.each(getTestCases('implicit-required'))('when add "arg" via %s then argument required', (methodName, cmd) => {
+  const argument = cmd._args[0];
+  const expectedShape = {
+    _name: 'implicit-required',
+    required: true,
+    variadic: false,
+    description: ''
+  };
+  expect(argument).toEqual(expectedShape);
+});
+
+test.each(getTestCases('[optional]'))('when add "[arg]" via %s then argument optional', (methodName, cmd) => {
+  const argument = cmd._args[0];
+  const expectedShape = {
+    _name: 'optional',
+    required: false,
+    variadic: false,
+    description: ''
+  };
+  expect(argument).toEqual(expectedShape);
+});
+
+test.each(getTestCases('<explicit-required...>'))('when add "<arg...>" via %s then argument required and variadic', (methodName, cmd) => {
+  const argument = cmd._args[0];
+  const expectedShape = {
+    _name: 'explicit-required',
+    required: true,
+    variadic: true,
+    description: ''
+  };
+  expect(argument).toEqual(expectedShape);
+});
+
+test.each(getTestCases('implicit-required...'))('when add "arg..." via %s then argument required and variadic', (methodName, cmd) => {
+  const argument = cmd._args[0];
+  const expectedShape = {
+    _name: 'implicit-required',
+    required: true,
+    variadic: true,
+    description: ''
+  };
+  expect(argument).toEqual(expectedShape);
+});
+
+test.each(getTestCases('[optional...]'))('when add "[arg...]" via %s then argument optional and variadic', (methodName, cmd) => {
+  const argument = cmd._args[0];
+  const expectedShape = {
+    _name: 'optional',
+    required: false,
+    variadic: true,
+    description: ''
+  };
+  expect(argument).toEqual(expectedShape);
+});
+
+function getTestCases(arg) {
+  return [
+    ['.arguments', new commander.Command().arguments(arg)],
+    ['.argument', new commander.Command().argument(arg)],
+    ['.addArgument', new commander.Command('add-argument').addArgument(new commander.Argument(arg))],
+    ['.command', new commander.Command().command(`command ${arg}`)]
+  ];
+}

--- a/tests/command.argumentVariations.test.js
+++ b/tests/command.argumentVariations.test.js
@@ -3,7 +3,7 @@ const commander = require('../');
 // Do some low-level checks that the multiple ways of specifying command arguments produce same internal result,
 // and not exhaustively testing all methods elsewhere.
 
-test.each(getTestCases('<explicit-required>'))('when add "<arg>" via %s then argument required', (methodName, cmd) => {
+test.each(getSingleArgCases('<explicit-required>'))('when add "<arg>" using %s then argument required', (methodName, cmd) => {
   const argument = cmd._args[0];
   const expectedShape = {
     _name: 'explicit-required',
@@ -14,7 +14,7 @@ test.each(getTestCases('<explicit-required>'))('when add "<arg>" via %s then arg
   expect(argument).toEqual(expectedShape);
 });
 
-test.each(getTestCases('implicit-required'))('when add "arg" via %s then argument required', (methodName, cmd) => {
+test.each(getSingleArgCases('implicit-required'))('when add "arg" using %s then argument required', (methodName, cmd) => {
   const argument = cmd._args[0];
   const expectedShape = {
     _name: 'implicit-required',
@@ -25,7 +25,7 @@ test.each(getTestCases('implicit-required'))('when add "arg" via %s then argumen
   expect(argument).toEqual(expectedShape);
 });
 
-test.each(getTestCases('[optional]'))('when add "[arg]" via %s then argument optional', (methodName, cmd) => {
+test.each(getSingleArgCases('[optional]'))('when add "[arg]" using %s then argument optional', (methodName, cmd) => {
   const argument = cmd._args[0];
   const expectedShape = {
     _name: 'optional',
@@ -36,7 +36,7 @@ test.each(getTestCases('[optional]'))('when add "[arg]" via %s then argument opt
   expect(argument).toEqual(expectedShape);
 });
 
-test.each(getTestCases('<explicit-required...>'))('when add "<arg...>" via %s then argument required and variadic', (methodName, cmd) => {
+test.each(getSingleArgCases('<explicit-required...>'))('when add "<arg...>" using %s then argument required and variadic', (methodName, cmd) => {
   const argument = cmd._args[0];
   const expectedShape = {
     _name: 'explicit-required',
@@ -47,7 +47,7 @@ test.each(getTestCases('<explicit-required...>'))('when add "<arg...>" via %s th
   expect(argument).toEqual(expectedShape);
 });
 
-test.each(getTestCases('implicit-required...'))('when add "arg..." via %s then argument required and variadic', (methodName, cmd) => {
+test.each(getSingleArgCases('implicit-required...'))('when add "arg..." using %s then argument required and variadic', (methodName, cmd) => {
   const argument = cmd._args[0];
   const expectedShape = {
     _name: 'implicit-required',
@@ -58,7 +58,7 @@ test.each(getTestCases('implicit-required...'))('when add "arg..." via %s then a
   expect(argument).toEqual(expectedShape);
 });
 
-test.each(getTestCases('[optional...]'))('when add "[arg...]" via %s then argument optional and variadic', (methodName, cmd) => {
+test.each(getSingleArgCases('[optional...]'))('when add "[arg...]" using %s then argument optional and variadic', (methodName, cmd) => {
   const argument = cmd._args[0];
   const expectedShape = {
     _name: 'optional',
@@ -69,7 +69,7 @@ test.each(getTestCases('[optional...]'))('when add "[arg...]" via %s then argume
   expect(argument).toEqual(expectedShape);
 });
 
-function getTestCases(arg) {
+function getSingleArgCases(arg) {
   return [
     ['.arguments', new commander.Command().arguments(arg)],
     ['.argument', new commander.Command().argument(arg)],
@@ -77,3 +77,28 @@ function getTestCases(arg) {
     ['.command', new commander.Command().command(`command ${arg}`)]
   ];
 }
+
+test.each(getMultipleArgCases('<first>', '[second]'))('when add two arguments using %s then two arguments', (methodName, cmd) => {
+  expect(cmd._args[0].name()).toEqual('first');
+  expect(cmd._args[1].name()).toEqual('second');
+});
+
+function getMultipleArgCases(arg1, arg2) {
+  return [
+    ['.arguments', new commander.Command().arguments(`${arg1} ${arg2}`)],
+    ['.argument', new commander.Command().argument(arg1).argument(arg2)],
+    ['.addArgument', new commander.Command('add-argument').addArgument(new commander.Argument(arg1)).addArgument(new commander.Argument(arg2))],
+    ['.command', new commander.Command().command(`command ${arg1} ${arg2}`)]
+  ];
+}
+
+test('when add arguments using multiple methods then all added', () => {
+  // This is not a key use case, but explicitly test that additive behaviour.
+  const program = new commander.Command();
+  const cmd = program.command('sub <arg1> <arg2>');
+  cmd.arguments('<arg3> <arg4>');
+  cmd.argument('<arg5>');
+  cmd.addArgument(new commander.Argument('arg6'));
+  const argNames = cmd._args.map(arg => arg.name());
+  expect(argNames).toEqual(['arg1', 'arg2', 'arg3', 'arg4', 'arg5', 'arg6']);
+});

--- a/tests/command.asterisk.test.js
+++ b/tests/command.asterisk.test.js
@@ -33,7 +33,7 @@ describe(".command('*')", () => {
     const program = new commander.Command();
     program
       .command('*')
-      .arguments('[args...]')
+      .argument('[args...]')
       .action(mockAction);
     program.parse(['node', 'test', 'unrecognised-command']);
     expect(mockAction).toHaveBeenCalled();
@@ -59,7 +59,7 @@ describe(".command('*')", () => {
       .command('install');
     program
       .command('*')
-      .arguments('[args...]')
+      .argument('[args...]')
       .action(mockAction);
     program.parse(['node', 'test', 'unrecognised-command']);
     expect(mockAction).toHaveBeenCalled();
@@ -73,7 +73,7 @@ describe(".command('*')", () => {
       .command('install');
     const star = program
       .command('*')
-      .arguments('[args...]')
+      .argument('[args...]')
       .option('-d, --debug')
       .action(mockAction);
     program.parse(['node', 'test', 'unrecognised-command', '--debug']);
@@ -93,7 +93,7 @@ describe(".command('*')", () => {
       .command('install');
     program
       .command('*')
-      .arguments('[args...]')
+      .argument('[args...]')
       .action(mockAction);
     let caughtErr;
     try {

--- a/tests/command.chain.test.js
+++ b/tests/command.chain.test.js
@@ -1,4 +1,4 @@
-const { Command, Option } = require('../');
+const { Command, Option, Argument } = require('../');
 
 // Testing the functions which should chain.
 // parse and parseAsync are tested in command.parse.test.js
@@ -13,6 +13,18 @@ describe('Command methods that should return this for chaining', () => {
   test('when call .addCommand() then returns this', () => {
     const program = new Command();
     const result = program.addCommand(new Command('name'));
+    expect(result).toBe(program);
+  });
+
+  test('when call .argument() then returns this', () => {
+    const program = new Command();
+    const result = program.argument('<file>');
+    expect(result).toBe(program);
+  });
+
+  test('when call .addArgument() then returns this', () => {
+    const program = new Command();
+    const result = program.addArgument(new Argument('<file>'));
     expect(result).toBe(program);
   });
 

--- a/tests/command.help.test.js
+++ b/tests/command.help.test.js
@@ -235,16 +235,25 @@ test('when option has choices and default then both included in helpInformation'
   expect(helpInformation).toMatch('(choices: "red", "blue", default: "red")');
 });
 
-test('when arguments then included in helpInformation', () => {
+test('when argument then included in helpInformation', () => {
   const program = new commander.Command();
   program
     .name('foo')
-    .arguments('<file>');
+    .argument('<file>');
   const helpInformation = program.helpInformation();
   expect(helpInformation).toMatch('Usage: foo [options] <file>');
 });
 
-test('when arguments described then included in helpInformation', () => {
+test('when argument described then included in helpInformation', () => {
+  const program = new commander.Command();
+  program
+    .argument('<file>', 'input source')
+    .helpOption(false);
+  const helpInformation = program.helpInformation();
+  expect(helpInformation).toMatch(/Arguments:\n +file +input source/);
+});
+
+test('when arguments described in deprecated way then included in helpInformation', () => {
   const program = new commander.Command();
   program
     .arguments('<file>')
@@ -254,7 +263,7 @@ test('when arguments described then included in helpInformation', () => {
   expect(helpInformation).toMatch(/Arguments:\n +file +input source/);
 });
 
-test('when arguments described and empty description then arguments included in helpInformation', () => {
+test('when arguments described in deprecated way and empty description then arguments still included in helpInformation', () => {
   const program = new commander.Command();
   program
     .arguments('<file>')

--- a/tests/command.positionalOptions.test.js
+++ b/tests/command.positionalOptions.test.js
@@ -9,7 +9,7 @@ describe('program with passThrough', () => {
     program.passThroughOptions();
     program
       .option('-d, --debug')
-      .arguments('<args...>');
+      .argument('<args...>');
     return program;
   }
 
@@ -77,10 +77,10 @@ describe('program with positionalOptions and subcommand', () => {
     program
       .enablePositionalOptions()
       .option('-s, --shared <value>')
-      .arguments('<args...>');
+      .argument('<args...>');
     const sub = program
       .command('sub')
-      .arguments('[arg]')
+      .argument('[arg]')
       .option('-s, --shared <value>')
       .action(() => {}); // Not used, but normal to have action handler on subcommand.
     return { program, sub };
@@ -151,10 +151,10 @@ describe('program with positionalOptions and default subcommand (called sub)', (
       .enablePositionalOptions()
       .option('-s, --shared')
       .option('-g, --global')
-      .arguments('<args...>');
+      .argument('<args...>');
     const sub = program
       .command('sub', { isDefault: true })
-      .arguments('[args...]')
+      .argument('[args...]')
       .option('-s, --shared')
       .option('-d, --default')
       .action(() => {}); // Not used, but normal to have action handler on subcommand.
@@ -218,11 +218,11 @@ describe('subcommand with passThrough', () => {
     program
       .enablePositionalOptions()
       .option('-s, --shared <value>')
-      .arguments('<args...>');
+      .argument('<args...>');
     const sub = program
       .command('sub')
       .passThroughOptions()
-      .arguments('[args...]')
+      .argument('[args...]')
       .option('-s, --shared <value>')
       .option('-d, --debug')
       .action(() => {}); // Not used, but normal to have action handler on subcommand.
@@ -289,7 +289,7 @@ describe('default command with passThrough', () => {
     const sub = program
       .command('sub', { isDefault: true })
       .passThroughOptions()
-      .arguments('[args...]')
+      .argument('[args...]')
       .option('-d, --debug')
       .action(() => {}); // Not used, but normal to have action handler on subcommand.
     return { program, sub };
@@ -332,11 +332,11 @@ describe('program with action handler and positionalOptions and subcommand', () 
     program
       .enablePositionalOptions()
       .option('-g, --global')
-      .arguments('<args...>')
+      .argument('<args...>')
       .action(() => {});
     const sub = program
       .command('sub')
-      .arguments('[arg]')
+      .argument('[arg]')
       .action(() => {});
     return { program, sub };
   }
@@ -379,11 +379,11 @@ describe('program with action handler and passThrough and subcommand', () => {
     program
       .passThroughOptions()
       .option('-g, --global')
-      .arguments('<args...>')
+      .argument('<args...>')
       .action(() => {});
     const sub = program
       .command('sub')
-      .arguments('[arg]')
+      .argument('[arg]')
       .option('-g, --group')
       .option('-d, --debug')
       .action(() => {});
@@ -451,7 +451,7 @@ describe('passThroughOptions(xxx) and option after command-argument', () => {
     const program = new commander.Command();
     program
       .option('-d, --debug')
-      .arguments('<args...>');
+      .argument('<args...>');
     return program;
   }
 

--- a/tests/command.unknownCommand.test.js
+++ b/tests/command.unknownCommand.test.js
@@ -30,7 +30,7 @@ describe('unknownCommand', () => {
       .exitOverride()
       .command('sub');
     program
-      .arguments('[args...]')
+      .argument('[args...]')
       .action(() => { });
     expect(() => {
       program.parse('node test.js unknown'.split(' '));

--- a/tests/command.unknownOption.test.js
+++ b/tests/command.unknownOption.test.js
@@ -54,7 +54,7 @@ describe('unknownOption', () => {
     const program = new commander.Command();
     program
       .exitOverride()
-      .arguments('[file]')
+      .argument('[file]')
       .action(() => {});
 
     let caughtErr;
@@ -71,7 +71,7 @@ describe('unknownOption', () => {
     const program = new commander.Command();
     program
       .exitOverride()
-      .arguments('[file]')
+      .argument('[file]')
       .action(() => {});
 
     let caughtErr;

--- a/tests/command.usage.test.js
+++ b/tests/command.usage.test.js
@@ -78,22 +78,20 @@ test('when no commands then [command] not included in usage', () => {
   expect(program.usage()).not.toMatch('[command]');
 });
 
-test('when arguments then arguments included in usage', () => {
+test('when argument then argument included in usage', () => {
   const program = new commander.Command();
 
   program
-    .arguments('<file>')
-    .argument('<secondFile>')
-    .addArgument(new commander.Argument('<lastFile>'));
+    .argument('<file>');
 
-  expect(program.usage()).toMatch('<file> <secondFile> <lastFile>');
+  expect(program.usage()).toMatch('<file>');
 });
 
-test('when options and command and arguments then all three included in usage', () => {
+test('when options and command and argument then all three included in usage', () => {
   const program = new commander.Command();
 
   program
-    .arguments('<file>')
+    .argument('<file>')
     .option('--alpha')
     .command('beta');
 

--- a/tests/commander.configureCommand.test.js
+++ b/tests/commander.configureCommand.test.js
@@ -17,7 +17,7 @@ test('when default then options+command passed to action', () => {
   const program = new commander.Command();
   const callback = jest.fn();
   program
-    .arguments('<value>')
+    .argument('<value>')
     .action(callback);
   program.parse(['node', 'test', 'value']);
   expect(callback).toHaveBeenCalledWith('value', program.opts(), program);
@@ -60,7 +60,7 @@ test('when storeOptionsAsProperties() then command+command passed to action', ()
   const callback = jest.fn();
   program
     .storeOptionsAsProperties()
-    .arguments('<value>')
+    .argument('<value>')
     .action(callback);
   program.parse(['node', 'test', 'value']);
   expect(callback).toHaveBeenCalledWith('value', program, program);
@@ -71,7 +71,7 @@ test('when storeOptionsAsProperties(false) then opts+command passed to action', 
   const callback = jest.fn();
   program
     .storeOptionsAsProperties(false)
-    .arguments('<value>')
+    .argument('<value>')
     .action(callback);
   program.parse(['node', 'test', 'value']);
   expect(callback).toHaveBeenCalledWith('value', program.opts(), program);

--- a/tests/esm-imports-test.mjs
+++ b/tests/esm-imports-test.mjs
@@ -1,4 +1,4 @@
-import { program, Command, Option, CommanderError, InvalidOptionArgumentError, Help, createCommand } from '../esm.mjs';
+import { program, Command, Option, Argument, CommanderError, InvalidOptionArgumentError, Help, createCommand, createOption } from '../esm.mjs';
 
 // Do some simple checks that expected imports are available at runtime.
 // Run using `npm run test-esm`.
@@ -26,8 +26,11 @@ checkClass(new Option('-e, --example'), 'Option');
 checkClass(new CommanderError(1, 'code', 'failed'), 'CommanderError');
 checkClass(new InvalidOptionArgumentError('failed'), 'InvalidOptionArgumentError');
 checkClass(new Help(), 'Help');
+checkClass(new Argument('<file>'), 'Argument');
 
 console.log('Checking createCommand');
 check(typeof createCommand === 'function', 'createCommand is function');
+console.log('Checking createOption');
+check(typeof createOption === 'function', 'createOption is function');
 
 console.log('No problems');

--- a/tests/help.commandTerm.test.js
+++ b/tests/help.commandTerm.test.js
@@ -27,7 +27,7 @@ describe('subcommandTerm', () => {
 
   test('when command has <argument> then returns name <argument>', () => {
     const command = new commander.Command('program')
-      .arguments('<argument>');
+      .argument('<argument>');
     const helper = new commander.Help();
     expect(helper.subcommandTerm(command)).toEqual('program <argument>');
   });
@@ -36,7 +36,7 @@ describe('subcommandTerm', () => {
     const command = new commander.Command('program')
       .alias('alias')
       .option('-a,--all')
-      .arguments('<argument>');
+      .argument('<argument>');
     const helper = new commander.Help();
     expect(helper.subcommandTerm(command)).toEqual('program|alias [options] <argument>');
   });

--- a/tests/help.commandUsage.test.js
+++ b/tests/help.commandUsage.test.js
@@ -42,10 +42,8 @@ describe('commandUsage', () => {
     const program = new commander.Command();
     program
       .name('program')
-      .arguments('<file>')
-      .argument('<desc>', 'description')
-      .addArgument(new commander.Argument('<info>', 'info'));
+      .argument('<file>');
     const helper = new commander.Help();
-    expect(helper.commandUsage(program)).toEqual('program [options] <file> <desc> <info>');
+    expect(helper.commandUsage(program)).toEqual('program [options] <file>');
   });
 });

--- a/tests/help.longestArgumentTermLength.test.js
+++ b/tests/help.longestArgumentTermLength.test.js
@@ -12,20 +12,16 @@ describe('longestArgumentTermLength', () => {
 
   test('when has argument description then returns argument length', () => {
     const program = new commander.Command();
-    program.arguments('<wonder>');
-    program.description('dummy', { wonder: 'wonder description' });
+    program.argument('<wonder>', 'wonder description');
     const helper = new commander.Help();
     expect(helper.longestArgumentTermLength(program, helper)).toEqual('wonder'.length);
   });
 
   test('when has multiple argument descriptions then returns longest', () => {
     const program = new commander.Command();
-    program.arguments('<alpha> <longest> <beta>');
-    program.description('dummy', {
-      alpha: 'x',
-      longest: 'x',
-      beta: 'x'
-    });
+    program.argument('<alpha>', 'x');
+    program.argument('<longest>', 'x');
+    program.argument('<beta>', 'x');
     const helper = new commander.Help();
     expect(helper.longestArgumentTermLength(program, helper)).toEqual('longest'.length);
   });

--- a/tests/help.padWidth.test.js
+++ b/tests/help.padWidth.test.js
@@ -8,8 +8,7 @@ describe('padWidth', () => {
     const longestThing = 'veryLongThingBiggerThanOthers';
     const program = new commander.Command();
     program
-      .arguments(`<${longestThing}>`)
-      .description('description', { veryLongThingBiggerThanOthers: 'desc' })
+      .argument(`<${longestThing}>`, 'description')
       .option('-o');
     program
       .command('sub');
@@ -21,8 +20,7 @@ describe('padWidth', () => {
     const longestThing = '--very-long-thing-bigger-than-others';
     const program = new commander.Command();
     program
-      .arguments('<file}>')
-      .description('description', { file: 'desc' })
+      .argument('<file>', 'desc')
       .option(longestThing);
     program
       .command('sub');
@@ -34,8 +32,7 @@ describe('padWidth', () => {
     const longestThing = 'very-long-thing-bigger-than-others';
     const program = new commander.Command();
     program
-      .arguments('<file}>')
-      .description('description', { file: 'desc' })
+      .argument('<file>', 'desc')
       .option('-o');
     program
       .command(longestThing);

--- a/tests/help.visibleArguments.test.js
+++ b/tests/help.visibleArguments.test.js
@@ -21,6 +21,8 @@ describe('visibleArguments', () => {
     const program = new commander.Command();
     program.argument('<file>', 'file description');
     const helper = new commander.Help();
-    expect(helper.visibleArguments(program)).toEqual([{ term: 'file', description: 'file description' }]);
+    const visibleArguments = helper.visibleArguments(program);
+    expect(visibleArguments.length).toEqual(1);
+    expect(visibleArguments[0]).toEqual(new commander.Argument('<file>', 'file description'));
   });
 });

--- a/tests/help.visibleArguments.test.js
+++ b/tests/help.visibleArguments.test.js
@@ -25,4 +25,41 @@ describe('visibleArguments', () => {
     expect(visibleArguments.length).toEqual(1);
     expect(visibleArguments[0]).toEqual(new commander.Argument('<file>', 'file description'));
   });
+
+  test('when argument and legacy argument description then returned', () => {
+    const program = new commander.Command();
+    program.argument('<file>');
+    program.description('', {
+      file: 'file description'
+    });
+    const helper = new commander.Help();
+    const visibleArguments = helper.visibleArguments(program);
+    expect(visibleArguments.length).toEqual(1);
+    expect(visibleArguments[0]).toEqual(new commander.Argument('<file>', 'file description'));
+  });
+
+  test('when arguments and some described then all returned', () => {
+    const program = new commander.Command();
+    program.argument('<file1>', 'file1 description');
+    program.argument('<file2>');
+    const helper = new commander.Help();
+    const visibleArguments = helper.visibleArguments(program);
+    expect(visibleArguments.length).toEqual(2);
+    expect(visibleArguments[0]).toEqual(new commander.Argument('<file1>', 'file1 description'));
+    expect(visibleArguments[1]).toEqual(new commander.Argument('<file2>'));
+  });
+
+  test('when arguments and some legacy described then all returned', () => {
+    const program = new commander.Command();
+    program.argument('<file1>');
+    program.argument('<file2>');
+    program.description('', {
+      file1: 'file1 description'
+    });
+    const helper = new commander.Help();
+    const visibleArguments = helper.visibleArguments(program);
+    expect(visibleArguments.length).toEqual(2);
+    expect(visibleArguments[0]).toEqual(new commander.Argument('<file1>', 'file1 description'));
+    expect(visibleArguments[1]).toEqual(new commander.Argument('<file2>'));
+  });
 });

--- a/tests/help.visibleArguments.test.js
+++ b/tests/help.visibleArguments.test.js
@@ -12,15 +12,14 @@ describe('visibleArguments', () => {
 
   test('when argument but no argument description then empty array', () => {
     const program = new commander.Command();
-    program.arguments('<file>');
+    program.argument('<file>');
     const helper = new commander.Help();
     expect(helper.visibleArguments(program)).toEqual([]);
   });
 
   test('when argument and argument description then returned', () => {
     const program = new commander.Command();
-    program.arguments('<file>');
-    program.description('dummy', { file: 'file description' });
+    program.argument('<file>', 'file description');
     const helper = new commander.Help();
     expect(helper.visibleArguments(program)).toEqual([{ term: 'file', description: 'file description' }]);
   });

--- a/tests/options.variadic.test.js
+++ b/tests/options.variadic.test.js
@@ -62,7 +62,7 @@ describe('variadic option with required value', () => {
     const program = new commander.Command();
     program
       .option('-r,--required <value...>')
-      .arguments('[arg]');
+      .argument('[arg]');
 
     program.parse(['-rone', 'operand'], { from: 'user' });
     expect(program.opts().required).toEqual(['one']);
@@ -72,7 +72,7 @@ describe('variadic option with required value', () => {
     const program = new commander.Command();
     program
       .option('-r,--required <value...>')
-      .arguments('[arg]');
+      .argument('[arg]');
 
     program.parse(['--required=one', 'operand'], { from: 'user' });
     expect(program.opts().required).toEqual(['one']);
@@ -83,7 +83,7 @@ describe('variadic option with required value', () => {
     program
       .option('-r,--required <value...>')
       .option('-f, --flag')
-      .arguments('[arg]');
+      .argument('[arg]');
 
     program.parse(['-r', 'one', '-f'], { from: 'user' });
     const opts = program.opts();

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -119,6 +119,10 @@ declare namespace commander {
     optionTerm(option: Option): string;
     /** Get the option description to show in the list of options. */
     optionDescription(option: Option): string;
+    /** Get the argument term to show in the list of arguments. */
+    argumentTerm(argument: Argument): string;
+    /** Get the argument description to show in the list of arguments. */
+    argumentDescription(argument: Argument): string;
 
     /** Get the command usage to be displayed at the top of the built-in help. */
     commandUsage(cmd: Command): string;
@@ -130,7 +134,7 @@ declare namespace commander {
     /** Get an array of the visible options. Includes a placeholder for the implicit help option, if there is one. */
     visibleOptions(cmd: Command): Option[];
     /** Get an array of the arguments which have descriptions. */
-    visibleArguments(cmd: Command): Array<{ term: string; description: string}>;
+    visibleArguments(cmd: Command): Argument[];
 
     /** Get the longest command term length. */
     longestSubcommandTermLength(cmd: Command, helper: Help): number;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -21,9 +21,9 @@ declare namespace commander {
   type InvalidOptionArgumentErrorConstructor = new (message: string) => InvalidOptionArgumentError;
 
   interface Argument {
-    // description: string;
-    // required: boolean;
-    // variadic: boolean;
+    description: string;
+    required: boolean;
+    variadic: boolean;
 
     /**
      * Set the name of the argument.

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -25,14 +25,8 @@ declare namespace commander {
     required: boolean;
     variadic: boolean;
 
-    /**
-     * Set the name of the argument.
-     *
-     * @returns `this` command for chaining
-     */
-     name(str: string): this;
      /**
-      * Get the name of the argument.
+      * Return argument name.
       */
      name(): string;
    }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -254,11 +254,14 @@ declare namespace commander {
     /**
      * Define argument syntax for command.
      *
+     * The default is that the argument is required, and you can explicitly
+     * indicate this with <> around the name. Put [] around the name for an optional argument.
+     *
      * @returns `this` command for chaining
      */
-    arguments(desc: string): this;
-    argument(arg: string, description?: string): this;
+    argument(name: string, description?: string): this;
     addArgument(arg: Argument): this;
+    arguments(names: string): this;
 
     /**
      * Override default decision whether to add implicit help command.

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -21,9 +21,9 @@ declare namespace commander {
   type InvalidOptionArgumentErrorConstructor = new (message: string) => InvalidOptionArgumentError;
 
   interface Argument {
-    description: string;
-    required: boolean;
-    variadic: boolean;
+    // description: string;
+    // required: boolean;
+    // variadic: boolean;
 
     /**
      * Set the name of the argument.

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -257,10 +257,33 @@ declare namespace commander {
      * The default is that the argument is required, and you can explicitly
      * indicate this with <> around the name. Put [] around the name for an optional argument.
      *
+     * @example
+     *
+     *     program.argument('<input-file>');
+     *     program.argument('[output-file]');
+     *
      * @returns `this` command for chaining
      */
     argument(name: string, description?: string): this;
+
+    /**
+     * Define argument syntax for command, adding a prepared argument.
+     *
+     * @returns `this` command for chaining
+     */
     addArgument(arg: Argument): this;
+
+    /**
+     * Define argument syntax for command, adding multiple at once (without descriptions).
+     *
+     * See also .argument().
+     *
+     * @example
+     *
+     *     program.arguments('<cmd> [env]');
+     *
+     * @returns `this` command for chaining
+     */
     arguments(names: string): this;
 
     /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -22,12 +22,20 @@ declare namespace commander {
 
   interface Argument {
     description: string;
-    argDetails: {
-      required: boolean;
-      name: string;
-      variadic: boolean;
-    };
-  }
+    required: boolean;
+    variadic: boolean;
+
+    /**
+     * Set the name of the argument.
+     *
+     * @returns `this` command for chaining
+     */
+     name(str: string): this;
+     /**
+      * Get the name of the argument.
+      */
+     name(): string;
+   }
 
   interface Option {
     flags: string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -249,7 +249,7 @@ declare namespace commander {
      * @returns `this` command for chaining
      */
     arguments(desc: string): this;
-    argument(arg: string, description: string): this;
+    argument(arg: string, description?: string): this;
     addArgument(arg: Argument): this;
 
     /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -512,7 +512,10 @@ declare namespace commander {
      *
      * @returns `this` command for chaining
      */
-    description(str: string, argsDescription?: {[argName: string]: string}): this;
+
+    description(str: string): this;
+    /** @deprecated since v8, instead use .argument to add command argument with description */
+    description(str: string, argsDescription: {[argName: string]: string}): this;
     /**
      * Get the description.
      */

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -335,9 +335,9 @@ expectType<string>(baseOption.attributeName());
 
 // Argument properties
 const baseArgument = new commander.Argument('<foo');
-expectType<string>(baseArgument.description);
-expectType<boolean>(baseArgument.required);
-expectType<boolean>(baseArgument.variadic);
+// expectType<string>(baseArgument.description);
+// expectType<boolean>(baseArgument.required);
+// expectType<boolean>(baseArgument.variadic);
 
 // Argument methods
 // name

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -345,4 +345,3 @@ expectType<boolean>(baseArgument.variadic);
 // Argument methods
 // name
 expectType<string>(baseArgument.name());
-expectType<commander.Argument>(baseArgument.name('<foo>'));

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -272,6 +272,7 @@ expectType<commander.Command>(program.configureOutput({
 const helper = new commander.Help();
 const helperCommand = new commander.Command();
 const helperOption = new commander.Option('-a, --all');
+const helperArgument = new commander.Argument('<file>');
 
 expectType<number | undefined>(helper.helpWidth);
 expectType<boolean>(helper.sortSubcommands);
@@ -283,10 +284,12 @@ expectType<string>(helper.commandDescription(helperCommand));
 expectType<string>(helper.subcommandDescription(helperCommand));
 expectType<string>(helper.optionTerm(helperOption));
 expectType<string>(helper.optionDescription(helperOption));
+expectType<string>(helper.argumentTerm(helperArgument));
+expectType<string>(helper.argumentDescription(helperArgument));
 
 expectType<commander.Command[]>(helper.visibleCommands(helperCommand));
 expectType<commander.Option[]>(helper.visibleOptions(helperCommand));
-expectType<Array<{ term: string; description: string}>>(helper.visibleArguments(helperCommand));
+expectType<commander.Argument[]>(helper.visibleArguments(helperCommand));
 
 expectType<number>(helper.longestSubcommandTermLength(helperCommand, helper));
 expectType<number>(helper.longestOptionTermLength(helperCommand, helper));

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -178,6 +178,7 @@ expectType(opts['bar']);
 // description
 expectType<commander.Command>(program.description('my description'));
 expectType<string>(program.description());
+expectType<commander.Command>(program.description('my description of command with arg foo', { foo: 'foo description'})); // deprecated
 
 // alias
 expectType<commander.Command>(program.alias('my alias'));

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -331,3 +331,14 @@ expectType<string>(baseOption.name());
 
 // attributeName
 expectType<string>(baseOption.attributeName());
+
+// Argument properties
+const baseArgument = new commander.Argument('<foo');
+expectType<string>(baseArgument.description);
+expectType<boolean>(baseArgument.required);
+expectType<boolean>(baseArgument.variadic);
+
+// Argument methods
+// name
+expectType<string>(baseArgument.name());
+expectType<commander.Argument>(baseArgument.name('<foo>'));

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -335,9 +335,9 @@ expectType<string>(baseOption.attributeName());
 
 // Argument properties
 const baseArgument = new commander.Argument('<foo');
-// expectType<string>(baseArgument.description);
-// expectType<boolean>(baseArgument.required);
-// expectType<boolean>(baseArgument.variadic);
+expectType<string>(baseArgument.description);
+expectType<boolean>(baseArgument.required);
+expectType<boolean>(baseArgument.variadic);
 
 // Argument methods
 // name

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -37,6 +37,10 @@ expectType<commander.Command>(program.command('exec', 'exec description', { isDe
 // addCommand
 expectType<commander.Command>(program.addCommand(new commander.Command('abc')));
 
+// argument
+expectType<commander.Command>(program.argument('<value>'));
+expectType<commander.Command>(program.argument('<value>', 'description'));
+
 // arguments
 expectType<commander.Command>(program.arguments('<cmd> [env]'));
 


### PR DESCRIPTION
# Pull Request

## Problem

The syntax for adding command arguments which have help descriptions is quite different from the rest of the API, and arguments and options are added quite differently although they could be similar. (Prompted by discussion about offering .choices() for arguments in #1458)

Related: #1458 #1467 #1471

## Solution

This builds on PR #1467. With positive feedback about the new method in  #1471., switching over "normal" way of adding an argument in README and examples and tests from `.arguments()` to `.argument()`.

- `.argument(name, description)` method
    - c.f. `.option(flags, description)`
- `addArgument(arg)` method for future expansion
    - c.f. `.addOption(opt)`
- deprecate `cmd.description(cmdDescription, argsDescription)`

## ChangeLog

- added: `cmd.argument(name, description)` for adding command-arguments
- changed: deprecate second parameter of `cmd.description(desc, argDescriptions)` for adding argument descriptions (removed from README)
- changed: Help `.visibleArguments()` returns array of `Argument`
