### PR TITLE
Extend .argument() to add default value and custom parse for command-argument

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -485,6 +485,7 @@ Example file: [arguments-custom-processing.js](./examples/arguments-custom-proce
 
 ```js
 program
+  .command('add')
   .argument('<first>', 'integer argument', myParseInt)
   .argument('[second]', 'integer argument', myParseInt, 1000)
   .action((first, second) => {

--- a/Readme.md
+++ b/Readme.md
@@ -343,7 +343,7 @@ function myParseInt(value, dummyPrevious) {
   // parseInt takes a string and a radix
   const parsedValue = parseInt(value, 10);
   if (isNaN(parsedValue)) {
-    throw new commander.InvalidOptionArgumentError('Not a number.');
+    throw new commander.InvalidArgumentError('Not a number.');
   }
   return parsedValue;
 }

--- a/Readme.md
+++ b/Readme.md
@@ -23,6 +23,7 @@ Read this in other languages: English | [简体中文](./Readme_zh-CN.md)
     - [Custom option processing](#custom-option-processing)
   - [Commands](#commands)
     - [Specify the argument syntax](#specify-the-argument-syntax)
+    - [Custom argument processing](#custom-argument-processing)
     - [Action handler](#action-handler)
     - [Stand-alone executable (sub)commands](#stand-alone-executable-subcommands)
   - [Automated help](#automated-help)
@@ -434,6 +435,8 @@ you can instead use the following method.
 
 To configure a command, you can use `.argument()` to specify each expected command-argument. 
 You supply the argument name and an optional description. The argument may be `<required>` or `[optional]`.
+You can specify a default value for an optional command-argument.
+
 
 Example file: [argument.js](./examples/argument.js)
 
@@ -441,10 +444,10 @@ Example file: [argument.js](./examples/argument.js)
 program
   .version('0.1.0')
   .argument('<username>', 'user to login')
-  .argument('[password]', 'password for user, if required')
+  .argument('[password]', 'password for user, if required', 'no password given')
   .action((username, password) => {
     console.log('username:', username);
-    console.log('password:', password || 'no password given');
+    console.log('password:', password);
   });
 ```
 
@@ -468,6 +471,26 @@ There is a convenience method to add multiple arguments at once, but without des
 ```js
 program
   .arguments('<username> <password>');
+```
+
+### Custom argument processing
+
+You may specify a function to do custom processing of command-arguments before they are passed to the action handler.
+The callback function receives two parameters, the user specified command-argument and the previous value for the argument.
+It returns the new value for the argument.
+
+You can optionally specify the default/starting value for the argument after the function parameter.
+
+Example file: [arguments-custom-processing.js](./examples/arguments-custom-processing.js)
+
+```js
+program
+  .argument('<first>', 'integer argument', myParseInt)
+  .argument('[second]', 'integer argument', myParseInt, 1000)
+  .action((first, second) => {
+    console.log(`${first} + ${second} = ${first + second}`);
+  })
+;
 ```
 
 ### Action handler

--- a/Readme_zh-CN.md
+++ b/Readme_zh-CN.md
@@ -314,7 +314,7 @@ function myParseInt(value, dummyPrevious) {
   // parseInt takes a string and a radix
   const parsedValue = parseInt(value, 10);
   if (isNaN(parsedValue)) {
-    throw new commander.InvalidOptionArgumentError('Not a number.');
+    throw new commander.InvalidArgumentError('Not a number.');
   }
   return parsedValue;
 }

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -111,3 +111,32 @@ program
 
 Deprecated from Commander v8.
 
+## InvalidOptionArgumentError
+
+This was used for throwing an error from custom option processing, for a nice error message.
+
+```js
+function myParseInt(value, dummyPrevious) {
+  // parseInt takes a string and a radix
+  const parsedValue = parseInt(value, 10);
+  if (isNaN(parsedValue)) {
+    throw new commander.InvalidOptionArgumentError('Not a number.');
+  }
+  return parsedValue;
+}
+```
+
+The replacement is `InvalidArgumentError` since can be used now for custom command-argument processing too.
+
+```js
+function myParseInt(value, dummyPrevious) {
+  // parseInt takes a string and a radix
+  const parsedValue = parseInt(value, 10);
+  if (isNaN(parsedValue)) {
+    throw new commander.InvalidArgumentError('Not a number.');
+  }
+  return parsedValue;
+}
+```
+
+Deprecated from Commander v8.

--- a/esm.mjs
+++ b/esm.mjs
@@ -7,7 +7,7 @@ export const {
   createArgument,
   createOption,
   CommanderError,
-  InvalidOptionArgumentError,
+  InvalidArgumentError,
   Command,
   Argument,
   Option,

--- a/examples/argument.js
+++ b/examples/argument.js
@@ -9,11 +9,11 @@ const program = new Command();
 program
   .version('0.1.0')
   .argument('<username>', 'user to login')
-  .argument('[password]', 'password for user, if required')
+  .argument('[password]', 'password for user, if required', 'no password given')
   .description('example program for argument')
   .action((username, password) => {
     console.log('username:', username);
-    console.log('password:', password || 'no password given');
+    console.log('password:', password);
   });
 
 program.parse();

--- a/examples/arguments-custom-processing.js
+++ b/examples/arguments-custom-processing.js
@@ -17,17 +17,31 @@ function myParseInt(value, dummyPrevious) {
   return parsedValue;
 }
 
+// The previous value passed to the custom processing is used when processing variadic values.
+function mySum(value, total) {
+  return total + myParseInt(value);
+}
+
 program
+  .command('add')
   .argument('<first>', 'integer argument', myParseInt)
   .argument('[second]', 'integer argument', myParseInt, 1000)
   .action((first, second) => {
     console.log(`${first} + ${second} = ${first + second}`);
-  })
-;
+  });
+
+program
+  .command('sum')
+  .argument('<value...>', 'values to be summed', mySum, 0)
+  .action((total) => {
+    console.log(`sum is ${total}`);
+  });
 
 program.parse();
 
 // Try the following:
-//    node arguments-custom-processing --help
-//    node arguments-custom-processing 2
-//    node arguments-custom-processing 12 56
+//    node arguments-custom-processing add --help
+//    node arguments-custom-processing add 2
+//    node arguments-custom-processing add 12 56
+//    node arguments-custom-processing sum 1 2 3
+//    node arguments-custom-processing sum silly

--- a/examples/arguments-custom-processing.js
+++ b/examples/arguments-custom-processing.js
@@ -11,9 +11,9 @@ const program = new commander.Command();
 function myParseInt(value, dummyPrevious) {
   // parseInt takes a string and a radix
   const parsedValue = parseInt(value, 10);
-  // if (isNaN(parsedValue)) {
-  //   throw new commander.InvalidOptionArgumentError('Not a number.');
-  // }
+  if (isNaN(parsedValue)) {
+    throw new commander.InvalidArgumentError('Not a number.');
+  }
   return parsedValue;
 }
 

--- a/examples/arguments-custom-processing.js
+++ b/examples/arguments-custom-processing.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+
+// This is used as an example in the README for:
+//    Custom argument processing
+//    You may specify a function to do custom processing of argument values.
+
+// const commander = require('commander'); // (normal include)
+const commander = require('../'); // include commander in git clone of commander repo
+const program = new commander.Command();
+
+function myParseInt(value, dummyPrevious) {
+  // parseInt takes a string and a radix
+  const parsedValue = parseInt(value, 10);
+  // if (isNaN(parsedValue)) {
+  //   throw new commander.InvalidOptionArgumentError('Not a number.');
+  // }
+  return parsedValue;
+}
+
+program
+  .argument('<first>', 'integer argument', myParseInt)
+  .argument('[second]', 'integer argument', myParseInt, 1000)
+  .action((first, second) => {
+    console.log(`${first} + ${second} = ${first + second}`);
+  })
+;
+
+program.parse();
+
+// Try the following:
+//    node arguments-custom-processing --help
+//    node arguments-custom-processing 2
+//    node arguments-custom-processing 12 56

--- a/examples/options-custom-processing.js
+++ b/examples/options-custom-processing.js
@@ -12,7 +12,7 @@ function myParseInt(value, dummyPrevious) {
   // parseInt takes a string and a radix
   const parsedValue = parseInt(value, 10);
   if (isNaN(parsedValue)) {
-    throw new commander.InvalidOptionArgumentError('Not a number.');
+    throw new commander.InvalidArgumentError('Not a number.');
   }
   return parsedValue;
 }

--- a/index.js
+++ b/index.js
@@ -1626,7 +1626,6 @@ class Command extends EventEmitter {
       } else if (index < this.args.length) {
         value = this.args[index];
         if (declaredArg.parseArg) {
-          // defaultValue passed for consistency, albeit not likely to be useful.
           value = myParseArg(declaredArg, value, declaredArg.defaultValue);
         }
       }

--- a/index.js
+++ b/index.js
@@ -442,7 +442,7 @@ class Argument {
   };
 
   /**
-   * Set the custom handler for processing CLI option arguments into option values.
+   * Set the custom handler for processing CLI command arguments into argument values.
    *
    * @param {Function} [fn]
    * @return {Argument}

--- a/index.js
+++ b/index.js
@@ -258,6 +258,13 @@ class Help {
    */
 
   argumentDescription(argument) {
+    const extraInfo = [];
+    if (argument.defaultValue !== undefined) {
+      extraInfo.push(`default: ${argument.defaultValueDescription || JSON.stringify(argument.defaultValue)}`);
+    }
+    if (extraInfo.length > 0) {
+      return `${argument.description} (${extraInfo.join(', ')})`;
+    }
     return argument.description;
   }
 
@@ -937,7 +944,7 @@ class Command extends EventEmitter {
   addArgument(argument) {
     const previousArgument = this._args.slice(-1)[0];
     if (previousArgument && previousArgument.variadic) {
-      throw new Error(`only the last argument can be variadic: '${previousArgument.name()}'`);
+      throw new Error(`only the last argument can be variadic '${previousArgument.name()}'`);
     }
     if (argument.required && argument.defaultValue !== undefined && argument.parseArg === undefined) {
       throw new Error(`a default value for a required argument is never used: '${argument.name()}'`);

--- a/index.js
+++ b/index.js
@@ -901,7 +901,7 @@ class Command extends EventEmitter {
    * @param {string} name
    * @param {string} [description]
    * @param {Function|*} [fn] - custom argument processing function
-   * @param {*} [defaultValue] Not implemented yet
+   * @param {*} [defaultValue]
    * @return {Command} `this` command for chaining
    */
   argument(name, description, fn, defaultValue) {

--- a/index.js
+++ b/index.js
@@ -1640,8 +1640,8 @@ class Command extends EventEmitter {
               value = this.args.slice(index);
               if (declaredArg.parseArg) {
                 value = value.reduce((processed, v) => {
-                  return declaredArg.parseArg(v, processed === undefined ? declaredArg.defaultValue : processed);
-                }, undefined);
+                  return declaredArg.parseArg(v, processed);
+                }, declaredArg.defaultValue);
               }
             } else if (value === undefined) {
               value = [];

--- a/index.js
+++ b/index.js
@@ -937,7 +937,10 @@ class Command extends EventEmitter {
   addArgument(argument) {
     const previousArgument = this._args.slice(-1)[0];
     if (previousArgument && previousArgument.variadic) {
-      throw new Error(`only the last argument can be variadic '${previousArgument.name()}'`);
+      throw new Error(`only the last argument can be variadic: '${previousArgument.name()}'`);
+    }
+    if (argument.required && argument.defaultValue !== undefined && argument.parseArg === undefined) {
+      throw new Error(`a default value for a required argument is never used: '${argument.name()}'`);
     }
     this._args.push(argument);
     return this;

--- a/tests/argument.custom-processing.test.js
+++ b/tests/argument.custom-processing.test.js
@@ -45,6 +45,19 @@ test('when starting value is defined and argument not specified then action argu
   expect(actionValue).toEqual(startingValue);
 });
 
+test('when default value is defined (without custom processing) and argument not specified then action argument is default value', () => {
+  const defaultValue = 1;
+  let actionValue;
+  const program = new commander.Command();
+  program
+    .argument('[n]', 'number', defaultValue)
+    .action((arg) => {
+      actionValue = arg;
+    });
+  program.parse([], { from: 'user' });
+  expect(actionValue).toEqual(defaultValue);
+});
+
 test('when argument specified then callback called with value', () => {
   const mockCoercion = jest.fn();
   const value = '1';

--- a/tests/argument.custom-processing.test.js
+++ b/tests/argument.custom-processing.test.js
@@ -22,7 +22,7 @@ test('when argument not specified then action argument undefined', () => {
   expect(actionValue).toBeUndefined();
 });
 
-test('when starting value is defined and argument not specified then callback not called', () => {
+test('when custom with starting value and argument not specified then callback not called', () => {
   const mockCoercion = jest.fn();
   const program = new commander.Command();
   program
@@ -32,7 +32,7 @@ test('when starting value is defined and argument not specified then callback no
   expect(mockCoercion).not.toHaveBeenCalled();
 });
 
-test('when starting value is defined and argument not specified then action argument is starting value', () => {
+test('when custom with starting value and argument not specified then action argument is starting value', () => {
   const startingValue = 1;
   let actionValue;
   const program = new commander.Command();
@@ -97,7 +97,7 @@ test('when argument specified then program.args has original rather than custom'
   expect(program.args).toEqual(['alpha']);
 });
 
-test('when starting value is defined and argument specified then callback called with value and starting value', () => {
+test('when custom with starting value and argument specified then callback called with value and starting value', () => {
   const mockCoercion = jest.fn();
   const startingValue = 1;
   const value = '2';
@@ -122,7 +122,7 @@ test('when variadic argument specified multiple times then callback called with 
   expect(mockCoercion).toHaveBeenNthCalledWith(2, '2', 'callback');
 });
 
-test('when parseFloat "1e2" then value is 100', () => {
+test('when parseFloat "1e2" then action argument is 100', () => {
   let actionValue;
   const program = new commander.Command();
   program

--- a/tests/argument.custom-processing.test.js
+++ b/tests/argument.custom-processing.test.js
@@ -1,5 +1,7 @@
 const commander = require('../');
 
+// Testing default value and custom processing behaviours.
+
 test('when argument not specified then callback not called', () => {
   const mockCoercion = jest.fn();
   const program = new commander.Command();
@@ -132,4 +134,11 @@ test('when parseFloat "1e2" then action argument is 100', () => {
     });
   program.parse(['1e2'], { from: 'user' });
   expect(actionValue).toEqual(100);
+});
+
+test('when defined default value for required argument then throw', () => {
+  const program = new commander.Command();
+  expect(() => {
+    program.argument('<number>', 'float argument', 4);
+  }).toThrow();
 });

--- a/tests/argument.custom-processing.test.js
+++ b/tests/argument.custom-processing.test.js
@@ -1,0 +1,122 @@
+const commander = require('../');
+
+test('when argument not specified then callback not called', () => {
+  const mockCoercion = jest.fn();
+  const program = new commander.Command();
+  program
+    .argument('[n]', 'number', mockCoercion)
+    .action(() => {});
+  program.parse([], { from: 'user' });
+  expect(mockCoercion).not.toHaveBeenCalled();
+});
+
+test('when argument not specified then action argument undefined', () => {
+  let actionValue = 'foo';
+  const program = new commander.Command();
+  program
+    .argument('[n]', 'number', parseFloat)
+    .action((arg) => {
+      actionValue = arg;
+    });
+  program.parse([], { from: 'user' });
+  expect(actionValue).toBeUndefined();
+});
+
+test('when starting value is defined and argument not specified then callback not called', () => {
+  const mockCoercion = jest.fn();
+  const program = new commander.Command();
+  program
+    .argument('[n]', 'number', parseFloat, 1)
+    .action(() => {});
+  program.parse([], { from: 'user' });
+  expect(mockCoercion).not.toHaveBeenCalled();
+});
+
+test('when starting value is defined and argument not specified then action argument is starting value', () => {
+  const startingValue = 1;
+  let actionValue;
+  const program = new commander.Command();
+  program
+    .argument('[n]', 'number', parseFloat, startingValue)
+    .action((arg) => {
+      actionValue = arg;
+    });
+  program.parse([], { from: 'user' });
+  expect(actionValue).toEqual(startingValue);
+});
+
+test('when argument specified then callback called with value', () => {
+  const mockCoercion = jest.fn();
+  const value = '1';
+  const program = new commander.Command();
+  program
+    .argument('[n]', 'number', mockCoercion)
+    .action(() => {});
+  program.parse([value], { from: 'user' });
+  expect(mockCoercion).toHaveBeenCalledWith(value, undefined);
+});
+
+test('when argument specified then action value is as returned from callback', () => {
+  const callbackResult = 2;
+  let actionValue;
+  const program = new commander.Command();
+  program
+    .argument('[n]', 'number', () => {
+      return callbackResult;
+    })
+    .action((arg) => {
+      actionValue = arg;
+    });
+  program.parse(['node', 'test', 'alpha']);
+  expect(actionValue).toEqual(callbackResult);
+});
+
+test('when argument specified then program.args has original rather than custom', () => {
+  // This is as intended, so check behaviour.
+  const callbackResult = 2;
+  const program = new commander.Command();
+  program
+    .argument('[n]', 'number', () => {
+      return callbackResult;
+    })
+    .action(() => {});
+  program.parse(['node', 'test', 'alpha']);
+  expect(program.args).toEqual(['alpha']);
+});
+
+test('when starting value is defined and argument specified then callback called with value and starting value', () => {
+  const mockCoercion = jest.fn();
+  const startingValue = 1;
+  const value = '2';
+  const program = new commander.Command()
+    .argument('[n]', 'number', mockCoercion, startingValue)
+    .action(() => {});
+  program.parse(['node', 'test', value]);
+  expect(mockCoercion).toHaveBeenCalledWith(value, startingValue);
+});
+
+test('when variadic argument specified multiple times then callback called with value and previousValue', () => {
+  const mockCoercion = jest.fn().mockImplementation(() => {
+    return 'callback';
+  });
+  const program = new commander.Command();
+  program
+    .argument('<n...>', 'number', mockCoercion)
+    .action(() => {});
+  program.parse(['1', '2'], { from: 'user' });
+  expect(mockCoercion).toHaveBeenCalledTimes(2);
+  expect(mockCoercion).toHaveBeenNthCalledWith(1, '1', undefined);
+  expect(mockCoercion).toHaveBeenNthCalledWith(2, '2', 'callback');
+});
+
+test('when parseFloat "1e2" then value is 100', () => {
+  let actionValue;
+  const program = new commander.Command();
+  program
+    .argument('<number>', 'float argument', parseFloat)
+    .action((arg) => {
+      actionValue = arg;
+    });
+  program.parse(['1e2'], { from: 'user' });
+  expect(actionValue).toEqual(100);
+});

--- a/tests/command.exitOverride.test.js
+++ b/tests/command.exitOverride.test.js
@@ -272,12 +272,12 @@ describe('.exitOverride and error details', () => {
       caughtErr = err;
     }
 
-    expectCommanderError(caughtErr, 1, 'commander.invalidOptionArgument', "error: option '--colour <shade>' argument 'green' is invalid. Allowed choices are red, blue.");
+    expectCommanderError(caughtErr, 1, 'commander.invalidArgument', "error: option '--colour <shade>' argument 'green' is invalid. Allowed choices are red, blue.");
   });
 
-  test('when custom processing throws InvalidOptionArgumentError then throw CommanderError', () => {
+  test('when custom processing for option throws InvalidArgumentError then catch CommanderError', () => {
     function justSayNo(value) {
-      throw new commander.InvalidOptionArgumentError('NO');
+      throw new commander.InvalidArgumentError('NO');
     }
     const optionFlags = '--colour <shade>';
     const program = new commander.Command();
@@ -292,7 +292,27 @@ describe('.exitOverride and error details', () => {
       caughtErr = err;
     }
 
-    expectCommanderError(caughtErr, 1, 'commander.invalidOptionArgument', "error: option '--colour <shade>' argument 'green' is invalid. NO");
+    expectCommanderError(caughtErr, 1, 'commander.invalidArgument', "error: option '--colour <shade>' argument 'green' is invalid. NO");
+  });
+
+  test('when custom processing for argument throws InvalidArgumentError then catch CommanderError', () => {
+    function justSayNo(value) {
+      throw new commander.InvalidArgumentError('NO');
+    }
+    const program = new commander.Command();
+    program
+      .exitOverride()
+      .argument('[n]', 'number', justSayNo)
+      .action(() => {});
+
+    let caughtErr;
+    try {
+      program.parse(['green'], { from: 'user' });
+    } catch (err) {
+      caughtErr = err;
+    }
+
+    expectCommanderError(caughtErr, 1, 'commander.invalidArgument', "error: command-argument value 'green' is invalid for argument 'n'. NO");
   });
 });
 

--- a/tests/command.help.test.js
+++ b/tests/command.help.test.js
@@ -253,6 +253,15 @@ test('when argument described then included in helpInformation', () => {
   expect(helpInformation).toMatch(/Arguments:\n +file +input source/);
 });
 
+test('when argument described with default then included in helpInformation', () => {
+  const program = new commander.Command();
+  program
+    .argument('[file]', 'input source', 'test.txt')
+    .helpOption(false);
+  const helpInformation = program.helpInformation();
+  expect(helpInformation).toMatch(/Arguments:\n +file +input source \(default: "test.txt"\)/);
+});
+
 test('when arguments described in deprecated way then included in helpInformation', () => {
   const program = new commander.Command();
   program

--- a/tests/esm-imports-test.mjs
+++ b/tests/esm-imports-test.mjs
@@ -1,4 +1,4 @@
-import { program, Command, Option, Argument, CommanderError, InvalidOptionArgumentError, Help, createCommand, createArgument, createOption } from '../esm.mjs';
+import { program, Command, Option, Argument, CommanderError, InvalidArgumentError, Help, createCommand, createArgument, createOption } from '../esm.mjs';
 
 // Do some simple checks that expected imports are available at runtime.
 // Run using `npm run test-esm`.
@@ -24,7 +24,7 @@ check(program.constructor.name === 'Command', 'program is class Command');
 checkClass(new Command(), 'Command');
 checkClass(new Option('-e, --example'), 'Option');
 checkClass(new CommanderError(1, 'code', 'failed'), 'CommanderError');
-checkClass(new InvalidOptionArgumentError('failed'), 'InvalidOptionArgumentError');
+checkClass(new InvalidArgumentError('failed'), 'InvalidArgumentError');
 checkClass(new Help(), 'Help');
 checkClass(new Argument('<file>'), 'Argument');
 

--- a/tests/help.argumentDescription.test.js
+++ b/tests/help.argumentDescription.test.js
@@ -4,26 +4,26 @@ const commander = require('../');
 
 describe('argumentDescription', () => {
   test('when argument has no description then empty string', () => {
-    const argument = new commander.Argument('<n>');
+    const argument = new commander.Argument('[n]');
     const helper = new commander.Help();
     expect(helper.argumentDescription(argument)).toEqual('');
   });
 
   test('when argument has description then return description', () => {
     const description = 'description';
-    const argument = new commander.Argument('<a>', description);
+    const argument = new commander.Argument('[n]', description);
     const helper = new commander.Help();
     expect(helper.argumentDescription(argument)).toEqual(description);
   });
 
   test('when argument has default value then return description and default value', () => {
-    const argument = new commander.Argument('<n>', 'description').default('default');
+    const argument = new commander.Argument('[n]', 'description').default('default');
     const helper = new commander.Help();
     expect(helper.argumentDescription(argument)).toEqual('description (default: "default")');
   });
 
   test('when argument has default value description then return description and custom default description', () => {
-    const argument = new commander.Argument('<n>', 'description').default('default value', 'custom');
+    const argument = new commander.Argument('[n]', 'description').default('default value', 'custom');
     const helper = new commander.Help();
     expect(helper.argumentDescription(argument)).toEqual('description (default: custom)');
   });

--- a/tests/help.argumentDescription.test.js
+++ b/tests/help.argumentDescription.test.js
@@ -1,0 +1,30 @@
+const commander = require('../');
+
+// These are tests of the Help class, not of the Command help.
+
+describe('argumentDescription', () => {
+  test('when argument has no description then empty string', () => {
+    const argument = new commander.Argument('<n>');
+    const helper = new commander.Help();
+    expect(helper.argumentDescription(argument)).toEqual('');
+  });
+
+  test('when argument has description then return description', () => {
+    const description = 'description';
+    const argument = new commander.Argument('<a>', description);
+    const helper = new commander.Help();
+    expect(helper.argumentDescription(argument)).toEqual(description);
+  });
+
+  test('when argument has default value then return description and default value', () => {
+    const argument = new commander.Argument('<n>', 'description').default('default');
+    const helper = new commander.Help();
+    expect(helper.argumentDescription(argument)).toEqual('description (default: "default")');
+  });
+
+  test('when argument has default value description then return description and custom default description', () => {
+    const argument = new commander.Argument('<n>', 'description').default('default value', 'custom');
+    const helper = new commander.Help();
+    expect(helper.argumentDescription(argument)).toEqual('description (default: custom)');
+  });
+});

--- a/tests/ts-imports.test.ts
+++ b/tests/ts-imports.test.ts
@@ -1,4 +1,4 @@
-import { program, Command, Option, CommanderError, InvalidOptionArgumentError, Help, createCommand } from '../';
+import { program, Command, Option, CommanderError, InvalidArgumentError, InvalidOptionArgumentError, Help, createCommand } from '../';
 
 import * as commander from '../';
 
@@ -35,9 +35,14 @@ test('CommanderError', () => {
   checkClass(new CommanderError(1, 'code', 'failed'), 'CommanderError');
 });
 
-test('InvalidOptionArgumentError', () => {
-  checkClass(new InvalidOptionArgumentError('failed'), 'InvalidOptionArgumentError');
+test('InvalidArgumentError', () => {
+  checkClass(new InvalidArgumentError('failed'), 'InvalidArgumentError');
 });
+
+test('InvalidOptionArgumentError', () => { // Deprecated
+  checkClass(new InvalidOptionArgumentError('failed'), 'InvalidArgumentError');
+});
+
 
 test('Help', () => {
   checkClass(new Help(), 'Help');

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -16,9 +16,9 @@ declare namespace commander {
   type CommanderErrorConstructor = new (exitCode: number, code: string, message: string) => CommanderError;
 
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
-  interface InvalidOptionArgumentError extends CommanderError {
+  interface InvalidArgumentError extends CommanderError {
   }
-  type InvalidOptionArgumentErrorConstructor = new (message: string) => InvalidOptionArgumentError;
+  type InvalidArgumentErrorConstructor = new (message: string) => InvalidArgumentError;
 
   interface Argument {
     description: string;
@@ -672,7 +672,9 @@ declare namespace commander {
     Option: OptionConstructor;
     Argument: ArgumentConstructor;
     CommanderError: CommanderErrorConstructor;
-    InvalidOptionArgumentError: InvalidOptionArgumentErrorConstructor;
+    InvalidArgumentError: InvalidArgumentErrorConstructor;
+    /** @deprecated since v8, replaced by InvalidArgumentError */
+    InvalidOptionArgumentError: InvalidArgumentErrorConstructor;
     Help: HelpConstructor;
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -270,7 +270,8 @@ declare namespace commander {
      *
      * @returns `this` command for chaining
      */
-    argument(name: string, description?: string): this;
+     argument<T>(flags: string, description: string, fn: (value: string, previous: T) => T, defaultValue?: T): this;
+     argument(name: string, description?: string, defaultValue?: any): this;
 
     /**
      * Define argument syntax for command, adding a prepared argument.

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -15,7 +15,8 @@ expectType<commander.Command>(new commander.Command());
 expectType<commander.Command>(new commander.Command('name'));
 expectType<commander.Option>(new commander.Option('-f'));
 expectType<commander.CommanderError>(new commander.CommanderError(1, 'code', 'message'));
-expectType<commander.InvalidOptionArgumentError>(new commander.InvalidOptionArgumentError('message'));
+expectType<commander.InvalidArgumentError>(new commander.InvalidArgumentError('message'));
+expectType<commander.InvalidArgumentError>(new commander.InvalidOptionArgumentError('message'));
 expectType<commander.Command>(commander.createCommand());
 
 // Command properties

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -40,6 +40,9 @@ expectType<commander.Command>(program.addCommand(new commander.Command('abc')));
 // argument
 expectType<commander.Command>(program.argument('<value>'));
 expectType<commander.Command>(program.argument('<value>', 'description'));
+expectType<commander.Command>(program.argument('[value]', 'description', 'default'));
+expectType<commander.Command>(program.argument('[value]', 'description', parseFloat));
+expectType<commander.Command>(program.argument('[value]', 'description', parseFloat, 1.23));
 
 // arguments
 expectType<commander.Command>(program.arguments('<cmd> [env]'));


### PR DESCRIPTION
# Pull Request

## Problem

Follow through with the idea that `.argument()` follow same pattern as `.option()`, with support for default value (for optional arguments) and custom command-argument parsing.

## Solution

Support for default value (for optional arguments) and custom command-argument parsing.

Implementation notes:
- not emitting events for the arguments
- only processing the arguments for the action handler, not for `program.args`
- custom processing for arguments uses same style function as for options

## ChangeLog

- add default value for optional command-arguments
- add custom processing  function for command-arguments
- deprecate `InvalidOptionArgumentError` (replaced by `InvalidArgumentError`)
- `CommanderError` code `commander.invalidOptionArgument` renamed `commander.invalidArgument`