### PR TITLE
Add hooks for life cycle events: using .hook()

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -574,6 +574,8 @@ program
   });
 ```
 
+The callback hook can be `async`, in which case you call `.parseAsync` rather than `.parse`. You can add multiple hooks per event.
+
 The supported events are:
 
 - `beforeAction`: called before action handler for this command and its subcommands

--- a/Readme.md
+++ b/Readme.md
@@ -564,9 +564,8 @@ Example file: [hook.js](./examples/hook.js)
 ```js
 program
   .option('-t, --trace', 'display trace statements for commands')
-  .hook('beforeAction', (context) => {
-    if (context.hookedCommand.opts().trace) {
-      const actionCommand = context.command;
+  .hook('preAction', (thisCommand, actionCommand) => {
+    if (thisCommand.opts().trace) {
       console.log(`About to call action handler for subcommand: ${actionCommand.name()}`);
       console.log('arguments: %O', actionCommand.args);
       console.log('options: %o', actionCommand.opts());
@@ -578,13 +577,10 @@ The callback hook can be `async`, in which case you call `.parseAsync` rather th
 
 The supported events are:
 
-- `beforeAction`: called before action handler for this command and its subcommands
-- `afterAction`: called after action handler for this command and its subcommands
+- `preAction`: called before action handler for this command and its subcommands
+- `postAction`: called after action handler for this command and its subcommands
 
-The hook callback is passed a context object with properties:
-
-- `command`: the command running the action handler
-- `hookedCommand`: the command which the hook was added to
+The hook is passed the command it was added to, and the command running the action handler.
 
 ## Automated help
 

--- a/Readme.md
+++ b/Readme.md
@@ -26,6 +26,7 @@ Read this in other languages: English | [简体中文](./Readme_zh-CN.md)
     - [Custom argument processing](#custom-argument-processing)
     - [Action handler](#action-handler)
     - [Stand-alone executable (sub)commands](#stand-alone-executable-subcommands)
+  - [Life cycle hooks](#life-cycle-hooks)
   - [Automated help](#automated-help)
     - [Custom help](#custom-help)
     - [Display help from code](#display-help-from-code)
@@ -553,6 +554,35 @@ program.parse(process.argv);
 ```
 
 If the program is designed to be installed globally, make sure the executables have proper modes, like `755`.
+
+## Life cycle hooks
+
+You can add callback hooks to a command for life cycle events.
+
+Example file: [hook](./examples/hook.js)
+
+```js
+program
+  .option('-t, --trace', 'display trace statements for commands')
+  .hook('beforeAction', (context) => {
+    if (context.hookedCommand.opts().trace) {
+      const actionCommand = context.command;
+      console.log(`About to call action handler for subcommand: ${actionCommand.name()}`);
+      console.log('arguments: %O', actionCommand.args);
+      console.log('options: %o', actionCommand.opts());
+    }
+  });
+```
+
+The supported events are:
+
+- `beforeAction`: called before action handler for this command and its subcommands
+- `afterAction`: called after action handler for this command and its subcommands
+
+The hook callback is passed a context object with properties:
+
+- `command`: the command running the action handler
+- `hookedCommand`: the command which the hook was added to
 
 ## Automated help
 

--- a/Readme.md
+++ b/Readme.md
@@ -26,7 +26,7 @@ Read this in other languages: English | [简体中文](./Readme_zh-CN.md)
     - [Custom argument processing](#custom-argument-processing)
     - [Action handler](#action-handler)
     - [Stand-alone executable (sub)commands](#stand-alone-executable-subcommands)
-  - [Life cycle hooks](#life-cycle-hooks)
+    - [Life cycle hooks](#life-cycle-hooks)
   - [Automated help](#automated-help)
     - [Custom help](#custom-help)
     - [Display help from code](#display-help-from-code)
@@ -555,11 +555,11 @@ program.parse(process.argv);
 
 If the program is designed to be installed globally, make sure the executables have proper modes, like `755`.
 
-## Life cycle hooks
+### Life cycle hooks
 
 You can add callback hooks to a command for life cycle events.
 
-Example file: [hook](./examples/hook.js)
+Example file: [hook.js](./examples/hook.js)
 
 ```js
 program

--- a/examples/hook.js
+++ b/examples/hook.js
@@ -45,7 +45,7 @@ program.command('hello')
   .option('-e, --example')
   .action(() => console.log('Hello, world'));
 
-// Some of the hooks are async, so call parseAsync rather than parse.
+// Some of the hooks or actions are async, so call parseAsync rather than parse.
 program.parseAsync().then(() => {});
 
 // Try the following:

--- a/examples/hook.js
+++ b/examples/hook.js
@@ -9,22 +9,21 @@ const program = new commander.Command();
 const timeLabel = 'command duration';
 program
   .option('-p, --profile', 'show how long command takes')
-  .hook('beforeAction', (context) => {
-    if (context.hookedCommand.opts().profile) {
+  .hook('preAction', (thisCommand) => {
+    if (thisCommand.opts().profile) {
       console.time(timeLabel);
     }
   })
-  .hook('afterAction', (context) => {
-    if (context.hookedCommand.opts().profile) {
+  .hook('postAction', (thisCommand) => {
+    if (thisCommand.opts().profile) {
       console.timeEnd(timeLabel);
     }
   });
 
 program
   .option('-t, --trace', 'display trace statements for commands')
-  .hook('beforeAction', (context) => {
-    if (context.hookedCommand.opts().trace) {
-      const actionCommand = context.command;
+  .hook('preAction', (thisCommand, actionCommand) => {
+    if (thisCommand.opts().trace) {
       console.log('>>>>');
       console.log(`About to call action handler for subcommand: ${actionCommand.name()}`);
       console.log('arguments: %O', actionCommand.args);

--- a/examples/hook.js
+++ b/examples/hook.js
@@ -52,5 +52,5 @@ program.parseAsync().then(() => {});
 //  node hook.js --profile hello
 //  node hook.js --trace hello --example
 //  node hook.js delay
-//  node hook.js --trace delay --message bye 5
+//  node hook.js --trace delay 5 --message bye
 //  node hook.js --profile delay

--- a/examples/hook.js
+++ b/examples/hook.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+// const commander = require('commander'); // (normal include)
+const commander = require('../'); // include commander in git clone of commander repo
+const program = new commander.Command();
+
+// This example shows using some hooks for life cycle events.
+
+const timeLabel = 'command duration';
+program
+  .option('-p, --profile', 'show how long command takes')
+  .hook('beforeAction', (context) => {
+    if (context.hookedCommand.opts().profile) {
+      console.time(timeLabel);
+    }
+  })
+  .hook('afterAction', (context) => {
+    if (context.hookedCommand.opts().profile) {
+      console.timeEnd(timeLabel);
+    }
+  });
+
+program
+  .option('-t, --trace', 'display trace statements for commands')
+  .hook('beforeAction', (context) => {
+    if (context.hookedCommand.opts().trace) {
+      const actionCommand = context.command;
+      console.log('>>>>');
+      console.log(`About to call action handler for subcommand: ${actionCommand.name()}`);
+      console.log('arguments: %O', actionCommand.args);
+      console.log('options: %o', actionCommand.opts());
+      console.log('<<<<');
+    }
+  });
+
+program.command('delay')
+  .option('--message <value>', 'custom message to display', 'Thanks for waiting')
+  .argument('[seconds]', 'how long to delay', '1')
+  .action(async(waitSeconds, options) => {
+    await new Promise(resolve => setTimeout(resolve, parseInt(waitSeconds) * 1000));
+    console.log(options.message);
+  });
+
+program.command('hello')
+  .option('-e, --example')
+  .action(() => console.log('Hello, world'));
+
+// Some of the hooks are async, so call parseAsync rather than parse.
+program.parseAsync().then(() => {});
+
+// Try the following:
+//  node hook.js hello
+//  node hook.js --profile hello
+//  node hook.js --trace hello --example
+//  node hook.js delay
+//  node hook.js --trace delay --message bye 5
+//  node hook.js --profile delay

--- a/index.js
+++ b/index.js
@@ -990,7 +990,7 @@ class Command extends EventEmitter {
   };
 
   /**
-   * Add hook for life-cycle event.
+   * Add hook for life cycle event.
    *
    * @param {string} event
    * @param {Function} listener

--- a/index.js
+++ b/index.js
@@ -998,6 +998,11 @@ class Command extends EventEmitter {
    */
 
   hook(event, listener) {
+    const allowedValues = ['beforeAction', 'afterAction'];
+    if (!allowedValues.includes(event)) {
+      throw new Error(`Unexpected value for event passed to hook : '${event}'.
+Expecting one of '${allowedValues.join("', '")}'`);
+    }
     this._lifeCycleHook[event] = listener;
     return this;
   }

--- a/index.js
+++ b/index.js
@@ -1684,7 +1684,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
   /**
    *
    * @param {Promise|undefined} promise
-   * @param {string} evemt
+   * @param {string} event
    * @return {Promise|undefined}
    * @api private
    */

--- a/index.js
+++ b/index.js
@@ -998,7 +998,7 @@ class Command extends EventEmitter {
    */
 
   hook(event, listener) {
-    const allowedValues = ['beforeAction', 'afterAction'];
+    const allowedValues = ['preAction', 'postAction'];
     if (!allowedValues.includes(event)) {
       throw new Error(`Unexpected value for event passed to hook : '${event}'.
 Expecting one of '${allowedValues.join("', '")}'`);
@@ -1700,13 +1700,13 @@ Expecting one of '${allowedValues.join("', '")}'`);
           hooks.push({ hookedCommand, callback });
         });
       });
-    if (event.startsWith('after')) {
+    if (event === 'postAction') {
       hooks.reverse();
     }
 
     hooks.forEach((hookDetail) => {
       result = this._chainOrCall(result, () => {
-        return hookDetail.callback({ command: this, hookedCommand: hookDetail.hookedCommand });
+        return hookDetail.callback(hookDetail.hookedCommand, this);
       });
     });
     return result;
@@ -1774,10 +1774,10 @@ Expecting one of '${allowedValues.join("', '")}'`);
       checkNumberOfArguments();
 
       let actionResult;
-      actionResult = this._chainOrCallHooks(actionResult, 'beforeAction');
+      actionResult = this._chainOrCallHooks(actionResult, 'preAction');
       actionResult = this._chainOrCall(actionResult, () => this._actionHandler(this._getActionArguments()));
       if (this.parent) this.parent.emit(commandEvent, operands, unknown); // legacy
-      actionResult = this._chainOrCallHooks(actionResult, 'afterAction');
+      actionResult = this._chainOrCallHooks(actionResult, 'postAction');
       return actionResult;
     }
     if (this.parent && this.parent.listenerCount(commandEvent)) {

--- a/tests/command.chain.test.js
+++ b/tests/command.chain.test.js
@@ -165,4 +165,10 @@ describe('Command methods that should return this for chaining', () => {
     const result = program.enablePositionalOptions();
     expect(result).toBe(program);
   });
+
+  test('when call .hook() then returns this', () => {
+    const program = new Command();
+    const result = program.hook('beforeAction', () => {});
+    expect(result).toBe(program);
+  });
 });

--- a/tests/command.chain.test.js
+++ b/tests/command.chain.test.js
@@ -168,7 +168,7 @@ describe('Command methods that should return this for chaining', () => {
 
   test('when call .hook() then returns this', () => {
     const program = new Command();
-    const result = program.hook('beforeAction', () => {});
+    const result = program.hook('preAction', () => {});
     expect(result).toBe(program);
   });
 });

--- a/tests/command.hook.test.js
+++ b/tests/command.hook.test.js
@@ -11,74 +11,74 @@ test('when no action then action hooks not called', () => {
   const hook = jest.fn();
   const program = new commander.Command();
   program
-    .hook('beforeAction', hook)
-    .hook('afterAction', hook);
+    .hook('preAction', hook)
+    .hook('postAction', hook);
   program.parse([], { from: 'user' });
   expect(hook).not.toHaveBeenCalled();
 });
 
 describe('action hooks with synchronous hooks, order', () => {
-  test('when hook beforeAction then hook called before action', () => {
+  test('when hook preAction then hook called before action', () => {
     const calls = [];
     const program = new commander.Command();
     program
-      .hook('beforeAction', () => calls.push('before'))
+      .hook('preAction', () => calls.push('before'))
       .action(() => calls.push('action'));
     program.parse([], { from: 'user' });
     expect(calls).toEqual(['before', 'action']);
   });
 
-  test('when hook afterAction then hook called after action', () => {
+  test('when hook postAction then hook called after action', () => {
     const calls = [];
     const program = new commander.Command();
     program
-      .hook('afterAction', () => calls.push('after'))
+      .hook('postAction', () => calls.push('after'))
       .action(() => calls.push('action'));
     program.parse([], { from: 'user' });
     expect(calls).toEqual(['action', 'after']);
   });
 
-  test('when hook beforeAction twice then hooks called FIFO', () => {
+  test('when hook preAction twice then hooks called FIFO', () => {
     const calls = [];
     const program = new commander.Command();
     program
-      .hook('beforeAction', () => calls.push('1'))
-      .hook('beforeAction', () => calls.push('2'))
+      .hook('preAction', () => calls.push('1'))
+      .hook('preAction', () => calls.push('2'))
       .action(() => calls.push('action'));
     program.parse([], { from: 'user' });
     expect(calls).toEqual(['1', '2', 'action']);
   });
 
-  test('when hook afterAction twice then hooks called LIFO', () => {
+  test('when hook postAction twice then hooks called LIFO', () => {
     const calls = [];
     const program = new commander.Command();
     program
-      .hook('afterAction', () => calls.push('1'))
-      .hook('afterAction', () => calls.push('2'))
+      .hook('postAction', () => calls.push('1'))
+      .hook('postAction', () => calls.push('2'))
       .action(() => calls.push('action'));
     program.parse([], { from: 'user' });
     expect(calls).toEqual(['action', '2', '1']);
   });
 
-  test('when hook beforeAction at program and sub then hooks called program then sub', () => {
+  test('when hook preAction at program and sub then hooks called program then sub', () => {
     const calls = [];
     const program = new commander.Command();
     program
-      .hook('beforeAction', () => calls.push('program'));
+      .hook('preAction', () => calls.push('program'));
     program.command('sub')
-      .hook('beforeAction', () => calls.push('sub'))
+      .hook('preAction', () => calls.push('sub'))
       .action(() => calls.push('action'));
     program.parse(['sub'], { from: 'user' });
     expect(calls).toEqual(['program', 'sub', 'action']);
   });
 
-  test('when hook afterAction at program and sub then hooks called sub then program', () => {
+  test('when hook postAction at program and sub then hooks called sub then program', () => {
     const calls = [];
     const program = new commander.Command();
     program
-      .hook('afterAction', () => calls.push('program'));
+      .hook('postAction', () => calls.push('program'));
     program.command('sub')
-      .hook('afterAction', () => calls.push('sub'))
+      .hook('postAction', () => calls.push('sub'))
       .action(() => calls.push('action'));
     program.parse(['sub'], { from: 'user' });
     expect(calls).toEqual(['action', 'sub', 'program']);
@@ -88,14 +88,14 @@ describe('action hooks with synchronous hooks, order', () => {
     const calls = [];
     const program = new commander.Command();
     program
-      .hook('beforeAction', () => calls.push('pb1'))
-      .hook('afterAction', () => calls.push('pa1'));
+      .hook('preAction', () => calls.push('pb1'))
+      .hook('postAction', () => calls.push('pa1'));
     program
-      .hook('beforeAction', () => calls.push('pb2'))
-      .hook('afterAction', () => calls.push('pa2'));
+      .hook('preAction', () => calls.push('pb2'))
+      .hook('postAction', () => calls.push('pa2'));
     program.command('sub')
-      .hook('beforeAction', () => calls.push('sb'))
-      .hook('afterAction', () => calls.push('sa'))
+      .hook('preAction', () => calls.push('sb'))
+      .hook('postAction', () => calls.push('sa'))
       .action(() => calls.push('action'));
     program.parse(['sub'], { from: 'user' });
     expect(calls).toEqual(['pb1', 'pb2', 'sb', 'action', 'sa', 'pa2', 'pa1']);
@@ -103,68 +103,68 @@ describe('action hooks with synchronous hooks, order', () => {
 });
 
 describe('action hooks context', () => {
-  test('when hook on program then context is program/program', () => {
+  test('when hook on program then passed program/program', () => {
     const hook = jest.fn();
     const program = new commander.Command();
     program
-      .hook('beforeAction', hook)
+      .hook('preAction', hook)
       .action(() => {});
     program.parse([], { from: 'user' });
-    expect(hook).toHaveBeenCalledWith({ command: program, hookedCommand: program });
+    expect(hook).toHaveBeenCalledWith(program, program);
   });
 
-  test('when hook on program and call sub then context is sub/program', () => {
+  test('when hook on program and call sub then passed program/sub', () => {
     const hook = jest.fn();
     const program = new commander.Command();
     program
-      .hook('beforeAction', hook);
+      .hook('preAction', hook);
     const sub = program.command('sub')
       .action(() => {});
     program.parse(['sub'], { from: 'user' });
-    expect(hook).toHaveBeenCalledWith({ command: sub, hookedCommand: program });
+    expect(hook).toHaveBeenCalledWith(program, sub);
   });
 
-  test('when hook on sub and call sub then context is sub/sub', () => {
+  test('when hook on sub and call sub then passed sub/sub', () => {
     const hook = jest.fn();
     const program = new commander.Command();
     const sub = program.command('sub')
-      .hook('beforeAction', hook)
+      .hook('preAction', hook)
       .action(() => {});
     program.parse(['sub'], { from: 'user' });
-    expect(hook).toHaveBeenCalledWith({ command: sub, hookedCommand: sub });
+    expect(hook).toHaveBeenCalledWith(sub, sub);
   });
 
-  test('when hook program on beforeAction then command has options set', () => {
+  test('when hook program on preAction then thisCommand has options set', () => {
     expect.assertions(1);
     const program = new commander.Command();
     program
       .option('--debug')
-      .hook('beforeAction', (context) => {
-        expect(context.command.opts().debug).toEqual(true);
+      .hook('preAction', (thisCommand) => {
+        expect(thisCommand.opts().debug).toEqual(true);
       })
       .action(() => {});
     program.parse(['--debug'], { from: 'user' });
   });
 
-  test('when hook program on beforeAction and call sub then hookedCommand has program options set', () => {
+  test('when hook program on preAction and call sub then thisCommand has program options set', () => {
     expect.assertions(1);
     const program = new commander.Command();
     program
       .option('--debug')
-      .hook('beforeAction', (context) => {
-        expect(context.hookedCommand.opts().debug).toEqual(true);
+      .hook('preAction', (thisCommand) => {
+        expect(thisCommand.opts().debug).toEqual(true);
       });
     program.command('sub')
       .action(() => {});
     program.parse(['sub', '--debug'], { from: 'user' });
   });
 
-  test('when hook program on beforeAction and call sub then command has sub options set', () => {
+  test('when hook program on preAction and call sub then actionCommand has sub options set', () => {
     expect.assertions(1);
     const program = new commander.Command();
     program
-      .hook('beforeAction', (context) => {
-        expect(context.command.opts().debug).toEqual(true);
+      .hook('preAction', (thisCommand, actionCommand) => {
+        expect(actionCommand.opts().debug).toEqual(true);
       });
     program.command('sub')
       .option('--debug')
@@ -172,50 +172,50 @@ describe('action hooks context', () => {
     program.parse(['sub', '--debug'], { from: 'user' });
   });
 
-  test('when hook program on beforeAction then command has args set', () => {
+  test('when hook program on preAction then actionCommand has args set', () => {
     expect.assertions(1);
     const program = new commander.Command();
     program
       .argument('[arg]')
-      .hook('beforeAction', (context) => {
-        expect(context.command.args).toEqual(['value']);
+      .hook('preAction', (thisCommand, actionCommand) => {
+        expect(actionCommand.args).toEqual(['value']);
       })
       .action(() => {});
     program.parse(['value'], { from: 'user' });
   });
 
-  test('when hook program on beforeAction then command has args set with options removed', () => {
+  test('when hook program on preAction then actionCommand has args set with options removed', () => {
     expect.assertions(1);
     const program = new commander.Command();
     program
       .argument('[arg]')
       .option('--debug')
-      .hook('beforeAction', (context) => {
-        expect(context.command.args).toEqual(['value']);
+      .hook('preAction', (thisCommand, actionCommand) => {
+        expect(actionCommand.args).toEqual(['value']);
       })
       .action(() => {});
     program.parse(['value', '--debug'], { from: 'user' });
   });
 
-  test('when hook program on beforeAction and call sub then hookedCommand has program args set', () => {
+  test('when hook program on preAction and call sub then thisCommand has program args set', () => {
     expect.assertions(1);
     const program = new commander.Command();
     program
       .argument('[arg]')
-      .hook('beforeAction', (context) => {
-        expect(context.hookedCommand.args).toEqual(['sub', 'value']);
+      .hook('preAction', (thisCommand) => {
+        expect(thisCommand.args).toEqual(['sub', 'value']);
       });
     program.command('sub')
       .action(() => {});
     program.parse(['sub', 'value'], { from: 'user' });
   });
 
-  test('when hook program on beforeAction and call sub then command has sub args set', () => {
+  test('when hook program on preAction and call sub then actionCommand has sub args set', () => {
     expect.assertions(1);
     const program = new commander.Command();
     program
-      .hook('beforeAction', (context) => {
-        expect(context.command.args).toEqual(['value']);
+      .hook('preAction', (thisCommand, actionCommand) => {
+        expect(actionCommand.args).toEqual(['value']);
       });
     program.command('sub')
       .action(() => {});
@@ -224,11 +224,11 @@ describe('action hooks context', () => {
 });
 
 describe('action hooks async', () => {
-  test('when async beforeAction then async from beforeAction', async() => {
+  test('when async preAction then async from preAction', async() => {
     const calls = [];
     const program = new commander.Command();
     program
-      .hook('beforeAction', async() => {
+      .hook('preAction', async() => {
         await 0;
         calls.push('before');
       })
@@ -239,11 +239,11 @@ describe('action hooks async', () => {
     expect(calls).toEqual(['before', 'action']);
   });
 
-  test('when async afterAction then async from afterAction', async() => {
+  test('when async postAction then async from postAction', async() => {
     const calls = [];
     const program = new commander.Command();
     program
-      .hook('afterAction', async() => {
+      .hook('postAction', async() => {
         await 0;
         calls.push('after');
       })
@@ -258,8 +258,8 @@ describe('action hooks async', () => {
     const calls = [];
     const program = new commander.Command();
     program
-      .hook('beforeAction', () => calls.push('before'))
-      .hook('afterAction', () => calls.push('after'))
+      .hook('preAction', () => calls.push('before'))
+      .hook('postAction', () => calls.push('after'))
       .action(async() => {
         await 0;
         calls.push('action');
@@ -270,15 +270,15 @@ describe('action hooks async', () => {
     expect(calls).toEqual(['before', 'action', 'after']);
   });
 
-  test('when async first beforeAction then async from first beforeAction', async() => {
+  test('when async first preAction then async from first preAction', async() => {
     const calls = [];
     const program = new commander.Command();
     program
-      .hook('beforeAction', async() => {
+      .hook('preAction', async() => {
         await 0;
         calls.push('1');
       })
-      .hook('beforeAction', () => calls.push('2'))
+      .hook('preAction', () => calls.push('2'))
       .action(() => calls.push('action'));
     const result = program.parseAsync([], { from: 'user' });
     expect(calls).toEqual([]);
@@ -286,12 +286,12 @@ describe('action hooks async', () => {
     expect(calls).toEqual(['1', '2', 'action']);
   });
 
-  test('when async second beforeAction then async from second beforeAction', async() => {
+  test('when async second preAction then async from second preAction', async() => {
     const calls = [];
     const program = new commander.Command();
     program
-      .hook('beforeAction', () => calls.push('1'))
-      .hook('beforeAction', async() => {
+      .hook('preAction', () => calls.push('1'))
+      .hook('preAction', async() => {
         await 0;
         calls.push('2');
       })
@@ -306,14 +306,14 @@ describe('action hooks async', () => {
     const calls = [];
     const program = new commander.Command();
     program
-      .hook('beforeAction', async() => { await 0; calls.push('pb1'); })
-      .hook('afterAction', async() => { await 0; calls.push('pa1'); });
+      .hook('preAction', async() => { await 0; calls.push('pb1'); })
+      .hook('postAction', async() => { await 0; calls.push('pa1'); });
     program
-      .hook('beforeAction', async() => { await 0; calls.push('pb2'); })
-      .hook('afterAction', async() => { await 0; calls.push('pa2'); });
+      .hook('preAction', async() => { await 0; calls.push('pb2'); })
+      .hook('postAction', async() => { await 0; calls.push('pa2'); });
     program.command('sub')
-      .hook('beforeAction', async() => { await 0; calls.push('sb'); })
-      .hook('afterAction', async() => { await 0; calls.push('sa'); })
+      .hook('preAction', async() => { await 0; calls.push('sb'); })
+      .hook('postAction', async() => { await 0; calls.push('sa'); })
       .action(async() => { await 0; calls.push('action'); });
     const result = program.parseAsync(['sub'], { from: 'user' });
     expect(calls).toEqual([]);

--- a/tests/command.hook.test.js
+++ b/tests/command.hook.test.js
@@ -224,7 +224,7 @@ describe('action hooks context', () => {
 });
 
 describe('action hooks async', () => {
-  test('when async beforeAction then async from before', async() => {
+  test('when async beforeAction then async from beforeAction', async() => {
     const calls = [];
     const program = new commander.Command();
     program
@@ -239,7 +239,7 @@ describe('action hooks async', () => {
     expect(calls).toEqual(['before', 'action']);
   });
 
-  test('when async afterAction then async from after', async() => {
+  test('when async afterAction then async from afterAction', async() => {
     const calls = [];
     const program = new commander.Command();
     program
@@ -270,7 +270,7 @@ describe('action hooks async', () => {
     expect(calls).toEqual(['before', 'action', 'after']);
   });
 
-  test('when async first beforeAction then async from first before', async() => {
+  test('when async first beforeAction then async from first beforeAction', async() => {
     const calls = [];
     const program = new commander.Command();
     program
@@ -286,7 +286,7 @@ describe('action hooks async', () => {
     expect(calls).toEqual(['1', '2', 'action']);
   });
 
-  test('when async second beforeAction then async from second before', async() => {
+  test('when async second beforeAction then async from second beforeAction', async() => {
     const calls = [];
     const program = new commander.Command();
     program

--- a/tests/command.hook.test.js
+++ b/tests/command.hook.test.js
@@ -133,6 +133,94 @@ describe('action hooks context', () => {
     program.parse(['sub'], { from: 'user' });
     expect(hook).toHaveBeenCalledWith({ command: sub, hookedCommand: sub });
   });
+
+  test('when hook program on beforeAction then command has options set', () => {
+    expect.assertions(1);
+    const program = new commander.Command();
+    program
+      .option('--debug')
+      .hook('beforeAction', (context) => {
+        expect(context.command.opts().debug).toEqual(true);
+      })
+      .action(() => {});
+    program.parse(['--debug'], { from: 'user' });
+  });
+
+  test('when hook program on beforeAction and call sub then hookedCommand has program options set', () => {
+    expect.assertions(1);
+    const program = new commander.Command();
+    program
+      .option('--debug')
+      .hook('beforeAction', (context) => {
+        expect(context.hookedCommand.opts().debug).toEqual(true);
+      });
+    program.command('sub')
+      .action(() => {});
+    program.parse(['sub', '--debug'], { from: 'user' });
+  });
+
+  test('when hook program on beforeAction and call sub then command has sub options set', () => {
+    expect.assertions(1);
+    const program = new commander.Command();
+    program
+      .hook('beforeAction', (context) => {
+        expect(context.command.opts().debug).toEqual(true);
+      });
+    program.command('sub')
+      .option('--debug')
+      .action(() => {});
+    program.parse(['sub', '--debug'], { from: 'user' });
+  });
+
+  test('when hook program on beforeAction then command has args set', () => {
+    expect.assertions(1);
+    const program = new commander.Command();
+    program
+      .argument('[arg]')
+      .hook('beforeAction', (context) => {
+        expect(context.command.args).toEqual(['value']);
+      })
+      .action(() => {});
+    program.parse(['value'], { from: 'user' });
+  });
+
+  test('when hook program on beforeAction then command has args set with options removed', () => {
+    expect.assertions(1);
+    const program = new commander.Command();
+    program
+      .argument('[arg]')
+      .option('--debug')
+      .hook('beforeAction', (context) => {
+        expect(context.command.args).toEqual(['value']);
+      })
+      .action(() => {});
+    program.parse(['value', '--debug'], { from: 'user' });
+  });
+
+  test('when hook program on beforeAction and call sub then hookedCommand has program args set', () => {
+    expect.assertions(1);
+    const program = new commander.Command();
+    program
+      .argument('[arg]')
+      .hook('beforeAction', (context) => {
+        expect(context.hookedCommand.args).toEqual(['sub', 'value']);
+      });
+    program.command('sub')
+      .action(() => {});
+    program.parse(['sub', 'value'], { from: 'user' });
+  });
+
+  test('when hook program on beforeAction and call sub then command has sub args set', () => {
+    expect.assertions(1);
+    const program = new commander.Command();
+    program
+      .hook('beforeAction', (context) => {
+        expect(context.command.args).toEqual(['value']);
+      });
+    program.command('sub')
+      .action(() => {});
+    program.parse(['sub', 'value'], { from: 'user' });
+  });
 });
 
 describe('action hooks async', () => {

--- a/tests/command.hook.test.js
+++ b/tests/command.hook.test.js
@@ -1,0 +1,136 @@
+const commander = require('../');
+
+test('when hook event wrong then throw', () => {
+  const program = new commander.Command();
+  expect(() => {
+    program.hook('silly', () => {});
+  }).toThrow();
+});
+
+test('when no action then action hooks not called', () => {
+  const hook = jest.fn();
+  const program = new commander.Command();
+  program
+    .hook('beforeAction', hook)
+    .hook('afterAction', hook);
+  program.parse([], { from: 'user' });
+  expect(hook).not.toHaveBeenCalled();
+});
+
+describe('action hooks with synchronous hooks, order', () => {
+  test('when hook beforeAction then hook called before action', () => {
+    const calls = [];
+    const program = new commander.Command();
+    program
+      .hook('beforeAction', () => calls.push('before'))
+      .action(() => calls.push('action'));
+    program.parse([], { from: 'user' });
+    expect(calls).toEqual(['before', 'action']);
+  });
+
+  test('when hook afterAction then hook called after action', () => {
+    const calls = [];
+    const program = new commander.Command();
+    program
+      .hook('afterAction', () => calls.push('after'))
+      .action(() => calls.push('action'));
+    program.parse([], { from: 'user' });
+    expect(calls).toEqual(['action', 'after']);
+  });
+
+  test('when hook beforeAction twice then hooks called FIFO', () => {
+    const calls = [];
+    const program = new commander.Command();
+    program
+      .hook('beforeAction', () => calls.push('1'))
+      .hook('beforeAction', () => calls.push('2'))
+      .action(() => calls.push('action'));
+    program.parse([], { from: 'user' });
+    expect(calls).toEqual(['1', '2', 'action']);
+  });
+
+  test('when hook afterAction twice then hooks called LIFO', () => {
+    const calls = [];
+    const program = new commander.Command();
+    program
+      .hook('afterAction', () => calls.push('1'))
+      .hook('afterAction', () => calls.push('2'))
+      .action(() => calls.push('action'));
+    program.parse([], { from: 'user' });
+    expect(calls).toEqual(['action', '2', '1']);
+  });
+
+  test('when hook beforeAction at program and sub then hooks called program then sub', () => {
+    const calls = [];
+    const program = new commander.Command();
+    program
+      .hook('beforeAction', () => calls.push('program'));
+    program.command('sub')
+      .hook('beforeAction', () => calls.push('sub'))
+      .action(() => calls.push('action'));
+    program.parse(['sub'], { from: 'user' });
+    expect(calls).toEqual(['program', 'sub', 'action']);
+  });
+
+  test('when hook afterAction at program and sub then hooks called sub then program', () => {
+    const calls = [];
+    const program = new commander.Command();
+    program
+      .hook('afterAction', () => calls.push('program'));
+    program.command('sub')
+      .hook('afterAction', () => calls.push('sub'))
+      .action(() => calls.push('action'));
+    program.parse(['sub'], { from: 'user' });
+    expect(calls).toEqual(['action', 'sub', 'program']);
+  });
+
+  test('when hook everything then hooks called nested', () => {
+    const calls = [];
+    const program = new commander.Command();
+    program
+      .hook('beforeAction', () => calls.push('pb1'))
+      .hook('afterAction', () => calls.push('pa1'));
+    program
+      .hook('beforeAction', () => calls.push('pb2'))
+      .hook('afterAction', () => calls.push('pa2'));
+    program.command('sub')
+      .hook('beforeAction', () => calls.push('sb'))
+      .hook('afterAction', () => calls.push('sa'))
+      .action(() => calls.push('action'));
+    program.parse(['sub'], { from: 'user' });
+    expect(calls).toEqual(['pb1', 'pb2', 'sb', 'action', 'sa', 'pa2', 'pa1']);
+  });
+});
+
+describe('action hooks context', () => {
+  test('when hook on program then context is program/program', () => {
+    const hook = jest.fn();
+    const program = new commander.Command();
+    program
+      .hook('beforeAction', hook)
+      .action(() => {});
+    program.parse([], { from: 'user' });
+    expect(hook).toHaveBeenCalledWith({ command: program, hookedCommand: program });
+  });
+
+  test('when hook on program and call sub then context is sub/program', () => {
+    const hook = jest.fn();
+    const program = new commander.Command();
+    program
+      .hook('beforeAction', hook);
+    const sub = program.command('sub')
+      .action(() => {});
+    program.parse(['sub'], { from: 'user' });
+    expect(hook).toHaveBeenCalledWith({ command: sub, hookedCommand: program });
+  });
+
+  test('when hook on sub and call sub then context is sub/sub', () => {
+    const hook = jest.fn();
+    const program = new commander.Command();
+    const sub = program.command('sub')
+      .hook('beforeAction', hook)
+      .action(() => {});
+    program.parse(['sub'], { from: 'user' });
+    expect(hook).toHaveBeenCalledWith({ command: sub, hookedCommand: sub });
+  });
+});

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -161,10 +161,6 @@ declare namespace commander {
     error: boolean;
     command: Command;
   }
-  interface HookContext { // passed to listener used with .hook()
-    command: Command;
-    hookedCommand: Command;
-  }
   interface OutputConfiguration {
     writeOut?(str: string): void;
     writeErr?(str: string): void;
@@ -175,7 +171,7 @@ declare namespace commander {
   }
 
   type AddHelpTextPosition = 'beforeAll' | 'before' | 'after' | 'afterAll';
-  type HookEvent = 'beforeAction' | 'afterAction';
+  type HookEvent = 'preAction' | 'postAction';
 
   interface OptionValues {
     [key: string]: any;
@@ -312,7 +308,7 @@ declare namespace commander {
     /**
      * Add hook for life cycle event.
      */
-    hook(event: HookEvent, listener: (context: HookContext) => void | Promise<void>): this;
+    hook(event: HookEvent, listener: (thisCommand: Command, actionCommand: Command) => void | Promise<void>): this;
 
     /**
      * Register callback to use as replacement for calling process.exit.

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -310,7 +310,7 @@ declare namespace commander {
     addHelpCommand(enableOrNameAndArgs?: string | boolean, description?: string): this;
 
     /**
-     * Add hook for life-cycle event.
+     * Add hook for life cycle event.
      */
     hook(event: HookEvent, listener: (context: HookContext) => void | Promise<void>): this;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -161,6 +161,10 @@ declare namespace commander {
     error: boolean;
     command: Command;
   }
+  interface HookContext { // passed to listener used with .hook()
+    command: Command;
+    hookedCommand: Command;
+  }
   interface OutputConfiguration {
     writeOut?(str: string): void;
     writeErr?(str: string): void;
@@ -171,6 +175,7 @@ declare namespace commander {
   }
 
   type AddHelpTextPosition = 'beforeAll' | 'before' | 'after' | 'afterAll';
+  type HookEvent = 'beforeAction' | 'afterAction';
 
   interface OptionValues {
     [key: string]: any;
@@ -303,6 +308,11 @@ declare namespace commander {
      * @returns `this` command for chaining
      */
     addHelpCommand(enableOrNameAndArgs?: string | boolean, description?: string): this;
+
+    /**
+     * Add hook for life-cycle event.
+     */
+    hook(event: HookEvent, listener: (context: HookContext) => void | Promise<void>): this;
 
     /**
      * Register callback to use as replacement for calling process.exit.

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -3,6 +3,8 @@ import {expectType, expectAssignable} from 'tsd';
 
 // We are are not just checking return types here, we are also implicitly checking that the expected syntax is allowed.
 
+/* eslint-disable @typescript-eslint/no-empty-function */
+
 const program: commander.Command = new commander.Command();
 // program.silly; // <-- Error, hurrah!
 
@@ -68,13 +70,19 @@ expectType<commander.Command>(program.exitOverride((err): void => {
   }
 }));
 
+// hook
+expectType<commander.Command>(program.hook('beforeAction', () => {}));
+expectType<commander.Command>(program.hook('afterAction', () => {}));
+expectType<commander.Command>(program.hook('beforeAction', async() => {}));
+expectType<commander.Command>(program.hook('beforeAction', (context) => {
+  // implicit HookContext
+  expectType<commander.Command>(context.command);
+  expectType<commander.Command>(context.hookedCommand);
+}));
+
 // action
-expectType<commander.Command>(program.action(() => {
-  // do nothing.
-}));
-expectType<commander.Command>(program.action(async() => {
-  // do nothing.
-}));
+expectType<commander.Command>(program.action(() => {}));
+expectType<commander.Command>(program.action(async() => {}));
 
 // option
 expectType<commander.Command>(program.option('-a,--alpha'));
@@ -232,9 +240,7 @@ expectType<commander.Command>(program.addHelpText('beforeAll', (context: command
 }));
 
 // on
-expectType<commander.Command>(program.on('command:foo', () => {
-  // do nothing.
-}));
+expectType<commander.Command>(program.on('command:foo', () => {}));
 
 // createCommand
 expectType<commander.Command>(program.createCommand());

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -71,13 +71,13 @@ expectType<commander.Command>(program.exitOverride((err): void => {
 }));
 
 // hook
-expectType<commander.Command>(program.hook('beforeAction', () => {}));
-expectType<commander.Command>(program.hook('afterAction', () => {}));
-expectType<commander.Command>(program.hook('beforeAction', async() => {}));
-expectType<commander.Command>(program.hook('beforeAction', (context) => {
+expectType<commander.Command>(program.hook('preAction', () => {}));
+expectType<commander.Command>(program.hook('postAction', () => {}));
+expectType<commander.Command>(program.hook('preAction', async() => {}));
+expectType<commander.Command>(program.hook('preAction', (thisCommand, actionCommand) => {
   // implicit HookContext
-  expectType<commander.Command>(context.command);
-  expectType<commander.Command>(context.hookedCommand);
+  expectType<commander.Command>(thisCommand);
+  expectType<commander.Command>(actionCommand);
 }));
 
 // action

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -77,7 +77,7 @@ expectType<commander.Command>(program.hook('preAction', () => {}));
 expectType<commander.Command>(program.hook('postAction', () => {}));
 expectType<commander.Command>(program.hook('preAction', async() => {}));
 expectType<commander.Command>(program.hook('preAction', (thisCommand, actionCommand) => {
-  // implicit HookContext
+  // implicit parameter types
   expectType<commander.Command>(thisCommand);
   expectType<commander.Command>(actionCommand);
 }));


### PR DESCRIPTION
# Pull Request

## Problem

People ask for a way to run code before the action handler with access to the parsed options. And also some requests for a hook after the action.

Main issue: #1197
Related issues: #76 #229 #936 #996 #1158 #1457

## Solution

Add `.hook(event, callback)` method
- supports async callbacks
- supports multiple hooks for same event on single command

Supported hooks: `preAction`, `postAction`. Triggered by action handler for hooked command and its subcommands.

Callback is passed the hooked command and the command running the action handler.

## ChangeLog

- add `.hook()` with support for `"preAction"` and `"postAction"` callbacks
