### PR TITLE
Simplify addHelpText TypeScript signature and improve typings test

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -640,7 +640,7 @@ declare namespace commander {
      * and 'beforeAll' or 'afterAll' to affect this command and all its subcommands.
      */
     addHelpText(position: AddHelpTextPosition, text: string): this;
-    addHelpText(position: AddHelpTextPosition, text: (context: AddHelpTextContext) => string | undefined): this;
+    addHelpText(position: AddHelpTextPosition, text: (context: AddHelpTextContext) => string): this;
 
     /**
      * Add a listener (callback) for when events occur. (Implemented using EventEmitter.)

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -224,11 +224,10 @@ expectType<commander.Command>(program.helpOption(false));
 expectType<commander.Command>(program.addHelpText('after', 'text'));
 expectType<commander.Command>(program.addHelpText('afterAll', 'text'));
 expectType<commander.Command>(program.addHelpText('before', () => 'before'));
-expectType<commander.Command>(program.addHelpText('beforeAll', (context: commander.AddHelpTextContext) => {
-  if (context.error) {
-    return; // Can return nothing to skip display
-  }
-  return context.command.name();
+expectType<commander.Command>(program.addHelpText('beforeAll', (context) => {
+  expectType<boolean>(context.error);
+  expectType<commander.Command>(context.command);
+  return '';
 }));
 
 // on


### PR DESCRIPTION
# Pull Request

## Problem

Declaring that `.addHelpText()` callback may return `undefined` makes for a messy signature. The intent was to allow a falsey value returned to skip display, by just calling `return` in callback.

## Solution

Restrict to strings. User can easily return empty string to get the falsey behaviour of skipping display.

Improve the typings test of the callback.

## ChangeLog

- TypeScript definition for `.addTextHelp()` callback no longer allows result of undefined, now just string.
