### PR TITLE
Support argument processing without action handler

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -479,7 +479,9 @@ program
 
 ### Custom argument processing
 
-You may specify a function to do custom processing of command-arguments before they are passed to the action handler.
+You may specify a function to do custom processing of command-arguments. The processed argument values are
+passed to the action handler, and saved as `.processedArgs`.
+
 The callback function receives two parameters, the user specified command-argument and the previous value for the argument.
 It returns the new value for the argument.
 

--- a/index.js
+++ b/index.js
@@ -662,7 +662,7 @@ class Command extends EventEmitter {
     this._allowUnknownOption = false;
     this._allowExcessArguments = true;
     this._args = []; // array of Argument
-    this.args = undefined; // cli args with options removed
+    this.args = null; // cli args with options removed
     this.rawArgs = null;
     this.processedArgs = null; // like .args but after custom processing and collecting variadic
     this._scriptPath = null;

--- a/index.js
+++ b/index.js
@@ -662,7 +662,7 @@ class Command extends EventEmitter {
     this._allowUnknownOption = false;
     this._allowExcessArguments = true;
     this._args = []; // array of Argument
-    this.args = null; // cli args with options removed
+    this.args = null; // array of strings, cli args with options removed
     this.rawArgs = null;
     this.processedArgs = null; // like .args but after custom processing and collecting variadic
     this._scriptPath = null;

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ class Help {
     }
     if (this.sortSubcommands) {
       visibleCommands.sort((a, b) => {
+        // @ts-ignore: overloaded return type
         return a.name().localeCompare(b.name());
       });
     }
@@ -656,13 +657,17 @@ class Command extends EventEmitter {
 
   constructor(name) {
     super();
-    this.commands = []; // array of Command
-    this.options = []; // array of Option
+    /** @type {Command[]} */
+    this.commands = [];
+    /** @type {Option[]} */
+    this.options = [];
     this.parent = null;
     this._allowUnknownOption = false;
     this._allowExcessArguments = true;
-    this._args = []; // array of Argument
-    this.args = null; // array of strings, cli args with options removed
+    /** @type {Argument[]} */
+    this._args = [];
+    /** @type {string[]} */
+    this.args = null; // cli args with options removed
     this.rawArgs = null;
     this.processedArgs = null; // like .args but after custom processing and collecting variadic
     this._scriptPath = null;
@@ -2160,6 +2165,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
   alias(alias) {
     if (alias === undefined) return this._aliases[0]; // just return first, for backwards compatibility
 
+    /** @type {Command} */
     let command = this;
     if (this.commands.length !== 0 && this.commands[this.commands.length - 1]._executableHandler) {
       // assume adding alias for last added executable subcommand, rather than this

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -201,6 +201,7 @@ export interface OptionValues {
 
 export class Command {
   args: string[];
+  processedArgs: any[];
   commands: Command[];
   parent: Command | null;
 

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -25,6 +25,8 @@ expectType<commander.Argument>(commander.createArgument('<foo>'));
 
 // Command properties
 expectType<string[]>(program.args);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+expectType<any[]>(program.processedArgs);
 expectType<commander.Command[]>(program.commands);
 expectType<commander.Command | null>(program.parent);
 


### PR DESCRIPTION
# Pull Request

## Problem

The new processing of arguments is useful in a single command program without an action handler, but
argument defaults and custom processing and choices were only being applied if there was an action handler.

Prompted by `.choices()` not working without action handler.

## Solution

Refactor and process command-arguments whether or not action handler. 

When adding the functionality in #1508 I had decided that I preferred not to modify `this.args` with processed results.
Save processed arguments as `this.processedArgs` so accessible for simple program without action handler, and from the new hook support too.
