### PR TITLE
Add date for 8.0.0-0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,12 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
-and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html). (Format adopted after v3.0.0.)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 <!-- markdownlint-disable MD024 -->
 <!-- markdownlint-disable MD004 -->
 
-## [8.0.0-0] (date goes here)
+## [8.0.0-0] (2021-05-23)
 
 ### Added
 


### PR DESCRIPTION
Add date into CHANGELOG for 8.0.0-0.

I am planning to tag and prerelease from `release/8.x` branch. 

(I think we can merge onto `develop` now too.)