### PR TITLE
Support argument processing without action handler

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -488,9 +488,11 @@ program
 
 #### Custom argument processing
 
-You may specify a function to do custom processing of command-arguments before they are passed to the action handler.
+You may specify a function to do custom processing of command-arguments (like for option-arguments).
 The callback function receives two parameters, the user specified command-argument and the previous value for the argument.
 It returns the new value for the argument.
+
+The processed argument values are passed to the action handler, and saved as `.processedArgs`.
 
 You can optionally specify the default/starting value for the argument after the function parameter.
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -19,13 +19,19 @@ class Command extends EventEmitter {
 
   constructor(name) {
     super();
+    /** @type {Command[]} */
     this.commands = [];
+    /** @type {Option[]} */
     this.options = [];
     this.parent = null;
     this._allowUnknownOption = false;
     this._allowExcessArguments = true;
+    /** @type {Argument[]} */
     this._args = [];
-    this.rawArgs = null;
+    /** @type {string[]} */
+    this.args = []; // cli args with options removed
+    this.rawArgs = [];
+    this.processedArgs = []; // like .args but after custom processing and collecting variadic
     this._scriptPath = null;
     this._name = name || '';
     this._optionValues = {};
@@ -976,13 +982,34 @@ Expecting one of '${allowedValues.join("', '")}'`);
   };
 
   /**
-   * Package arguments (this.args) for passing to action handler based
-   * on declared arguments (this._args).
+   * Check this.args against expected this._args.
    *
    * @api private
    */
 
-  _getActionArguments() {
+  _checkNumberOfArguments() {
+    // too few
+    this._args.forEach((arg, i) => {
+      if (arg.required && this.args[i] == null) {
+        this.missingArgument(arg.name());
+      }
+    });
+    // too many
+    if (this._args.length > 0 && this._args[this._args.length - 1].variadic) {
+      return;
+    }
+    if (this.args.length > this._args.length) {
+      this._excessArguments(this.args);
+    }
+  };
+
+  /**
+   * Process this.args using this._args and save as this.processedArgs!
+   *
+   * @api private
+   */
+
+  _processArguments() {
     const myParseArg = (argument, value, previous) => {
       // Extra processing for nice error message on parsing failure.
       let parsedValue = value;
@@ -1000,7 +1027,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
       return parsedValue;
     };
 
-    const actionArgs = [];
+    this._checkNumberOfArguments();
+
+    const processedArgs = [];
     this._args.forEach((declaredArg, index) => {
       let value = declaredArg.defaultValue;
       if (declaredArg.variadic) {
@@ -1021,9 +1050,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
           value = myParseArg(declaredArg, value, declaredArg.defaultValue);
         }
       }
-      actionArgs[index] = value;
+      processedArgs[index] = value;
     });
-    return actionArgs;
+    this.processedArgs = processedArgs;
   }
 
   /**
@@ -1115,37 +1144,22 @@ Expecting one of '${allowedValues.join("', '")}'`);
         this.unknownOption(parsed.unknown[0]);
       }
     };
-    const checkNumberOfArguments = () => {
-      // too few
-      this._args.forEach((arg, i) => {
-        if (arg.required && this.args[i] == null) {
-          this.missingArgument(arg.name());
-        }
-      });
-      // too many
-      if (this._args.length > 0 && this._args[this._args.length - 1].variadic) {
-        return;
-      }
-      if (this.args.length > this._args.length) {
-        this._excessArguments(this.args);
-      }
-    };
 
     const commandEvent = `command:${this.name()}`;
     if (this._actionHandler) {
       checkForUnknownOptions();
-      checkNumberOfArguments();
+      this._processArguments();
 
       let actionResult;
       actionResult = this._chainOrCallHooks(actionResult, 'preAction');
-      actionResult = this._chainOrCall(actionResult, () => this._actionHandler(this._getActionArguments()));
+      actionResult = this._chainOrCall(actionResult, () => this._actionHandler(this.processedArgs));
       if (this.parent) this.parent.emit(commandEvent, operands, unknown); // legacy
       actionResult = this._chainOrCallHooks(actionResult, 'postAction');
       return actionResult;
     }
     if (this.parent && this.parent.listenerCount(commandEvent)) {
       checkForUnknownOptions();
-      checkNumberOfArguments();
+      this._processArguments();
       this.parent.emit(commandEvent, operands, unknown); // legacy
     } else if (operands.length) {
       if (this._findCommand('*')) { // legacy default command
@@ -1158,14 +1172,14 @@ Expecting one of '${allowedValues.join("', '")}'`);
         this.unknownCommand();
       } else {
         checkForUnknownOptions();
-        checkNumberOfArguments();
+        this._processArguments();
       }
     } else if (this.commands.length) {
       // This command has subcommands and nothing hooked up at this level, so display help (and exit).
       this.help({ error: true });
     } else {
       checkForUnknownOptions();
-      checkNumberOfArguments();
+      this._processArguments();
       // fall through for caller to handle after calling .parse()
     }
   };
@@ -1513,6 +1527,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
   alias(alias) {
     if (alias === undefined) return this._aliases[0]; // just return first, for backwards compatibility
 
+    /** @type {Command} */
     let command = this;
     if (this.commands.length !== 0 && this.commands[this.commands.length - 1]._executableHandler) {
       // assume adding alias for last added executable subcommand, rather than this

--- a/lib/help.js
+++ b/lib/help.js
@@ -38,6 +38,7 @@ class Help {
     }
     if (this.sortSubcommands) {
       visibleCommands.sort((a, b) => {
+        // @ts-ignore: overloaded return type
         return a.name().localeCompare(b.name());
       });
     }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -201,6 +201,7 @@ export interface OptionValues {
 
 export class Command {
   args: string[];
+  processedArgs: any[];
   commands: Command[];
   parent: Command | null;
 

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -25,6 +25,8 @@ expectType<commander.Argument>(commander.createArgument('<foo>'));
 
 // Command properties
 expectType<string[]>(program.args);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+expectType<any[]>(program.processedArgs);
 expectType<commander.Command[]>(program.commands);
 expectType<commander.Command | null>(program.parent);
 


### PR DESCRIPTION
# Pull Request

## Problem

The new processing of arguments is also useful in a single command program without an action handler, but
argument defaults and custom processing and choices were only being applied if there was an action handler.

Prompted by realising `.choices()` would not work without action handler.

## Solution

Refactor and process command-arguments whether or not action handler. 

When adding the functionality in #1508 I had decided that I preferred not to modify `this.args` with processed results.
Save processed arguments as `this.processedArgs` so accessible for simple program without action handler, and from the new hook support too.

This PR includes some minor other improvements:
- added .arg to Command constructor
- initialise .arg to empty array (matches existing TypeScript declaration)
- add JSDoc types for some key Command properties

## Changelog

- Changed: `Command` property `.arg` initialised to empty array (was previously undefined)