### PR TITLE
Remove incorrect example output

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -131,12 +131,9 @@ if (options.pizzaType) console.log(`- ${options.pizzaType}`);
 ```
 
 ```bash
-$ pizza-options -d
-{ debug: true, small: undefined, pizzaType: undefined }
-pizza details:
 $ pizza-options -p
 error: option '-p, --pizza-type <type>' argument missing
-$ pizza-options -ds -p vegetarian
+$ pizza-options -d -s -p vegetarian
 { debug: true, small: true, pizzaType: 'vegetarian' }
 pizza details:
 - small pizza size

--- a/examples/options-common.js
+++ b/examples/options-common.js
@@ -21,7 +21,6 @@ if (options.small) console.log('- small pizza size');
 if (options.pizzaType) console.log(`- ${options.pizzaType}`);
 
 // Try the following:
-//    node options-common.js -d
 //    node options-common.js -p
-//    node options-common.js -ds -p vegetarian
+//    node options-common.js -d -s -p vegetarian
 //    node options-common.js --pizza-type=cheese


### PR DESCRIPTION
# Pull Request

## Problem

Still showing old format for `.opts()` from before Commander 7 when `.storeOptionsAsProperties()` was default.

Issue: #1531

## Solution

Just remove the example, there is another "debug" example anyway, which as a bonus will display the same way independent of `.storeOptionsAsProperties()` setting as none undefined.

Also simplified the debug example by not combining the short flags.