### PR TITLE
Add showHelpAfterError

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -672,7 +672,7 @@ The second parameter can be a string, or a function returning a string. The func
 ### Display help after errors
 
 The default behaviour for usage errors is to just display a short error message. 
-You can change the behaviour to show the full help after an error, or specify a custom help message.
+You can change the behaviour to show the full help or a custom help message after an error.
 
 ```js
 program.showHelpAfterError();

--- a/Readme.md
+++ b/Readme.md
@@ -30,6 +30,7 @@ Read this in other languages: English | [简体中文](./Readme_zh-CN.md)
     - [Life cycle hooks](#life-cycle-hooks)
   - [Automated help](#automated-help)
     - [Custom help](#custom-help)
+    - [Display help after errors](#display-help-after-errors)
     - [Display help from code](#display-help-from-code)
     - [.usage and .name](#usage-and-name)
     - [.helpOption(flags, description)](#helpoptionflags-description)
@@ -667,6 +668,23 @@ The second parameter can be a string, or a function returning a string. The func
 
 - error: a boolean for whether the help is being displayed due to a usage error
 - command: the Command which is displaying the help
+
+### Display help after errors
+
+The default behaviour for usage errors is to just display a short error message. 
+You can change the behaviour to show the full help after an error, or specify a custom help message.
+
+```js
+program.showHelpAfterError();
+// or
+program.showHelpAfterError('(add --help for additional information)');
+```
+
+```sh
+$ pizza --unknown
+error: unknown option '--unknown'
+(add --help for additional information)
+```
 
 ### Display help from code
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -203,7 +203,7 @@ class Command extends EventEmitter {
   }
 
   /**
-   * Also display the help or a custom message when an error occurs.
+   * Display the help or a custom message after an error occurs.
    *
    * @param {boolean|string} [displayHelp]
    * @return {Command} `this` command for chaining

--- a/lib/command.js
+++ b/lib/command.js
@@ -42,7 +42,7 @@ class Command extends EventEmitter {
     this._enablePositionalOptions = false;
     this._passThroughOptions = false;
     this._lifeCycleHooks = {}; // a hash of arrays
-    this._displayHelpWithError = false;
+    this._showHelpWithError = false;
 
     // see .configureOutput() for docs
     this._outputConfiguration = {
@@ -208,9 +208,9 @@ class Command extends EventEmitter {
    * @param {boolean|string} [displayHelp]
    * @return {Command} `this` command for chaining
    */
-  displayHelpWithError(displayHelp = true) {
+  showHelpWithError(displayHelp = true) {
     if (typeof displayHelp !== 'string') displayHelp = !!displayHelp;
-    this._displayHelpWithError = displayHelp;
+    this._showHelpWithError = displayHelp;
     return this;
   }
 
@@ -1383,9 +1383,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
   _displayError(exitCode, code, message) {
     this._outputConfiguration.outputError(`${message}\n`, this._outputConfiguration.writeErr);
-    if (typeof this._displayHelpWithError === 'string') {
-      this._outputConfiguration.writeErr(`${this._displayHelpWithError}\n`);
-    } else if (this._displayHelpWithError) {
+    if (typeof this._showHelpWithError === 'string') {
+      this._outputConfiguration.writeErr(`${this._showHelpWithError}\n`);
+    } else if (this._showHelpWithError) {
       this._outputConfiguration.writeErr('\n');
       this.outputHelp({ error: true });
     }

--- a/lib/command.js
+++ b/lib/command.js
@@ -1465,13 +1465,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   unknownCommand() {
-    const partCommands = [this.name()];
-    for (let parentCmd = this.parent; parentCmd; parentCmd = parentCmd.parent) {
-      partCommands.unshift(parentCmd.name());
-    }
-    const fullCommand = partCommands.join(' ');
-    const message = `error: unknown command '${this.args[0]}'.` +
-      (this._hasHelpOption ? ` See '${fullCommand} ${this._helpLongFlag}'.` : '');
+    const message = `error: unknown command '${this.args[0]}'`;
     this._displayError(1, 'commander.unknownCommand', message);
   };
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -42,7 +42,7 @@ class Command extends EventEmitter {
     this._enablePositionalOptions = false;
     this._passThroughOptions = false;
     this._lifeCycleHooks = {}; // a hash of arrays
-    this._showHelpWithError = false;
+    this._showHelpAfterError = false;
 
     // see .configureOutput() for docs
     this._outputConfiguration = {
@@ -208,9 +208,9 @@ class Command extends EventEmitter {
    * @param {boolean|string} [displayHelp]
    * @return {Command} `this` command for chaining
    */
-  showHelpWithError(displayHelp = true) {
+  showHelpAfterError(displayHelp = true) {
     if (typeof displayHelp !== 'string') displayHelp = !!displayHelp;
-    this._showHelpWithError = displayHelp;
+    this._showHelpAfterError = displayHelp;
     return this;
   }
 
@@ -1383,9 +1383,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
   _displayError(exitCode, code, message) {
     this._outputConfiguration.outputError(`${message}\n`, this._outputConfiguration.writeErr);
-    if (typeof this._showHelpWithError === 'string') {
-      this._outputConfiguration.writeErr(`${this._showHelpWithError}\n`);
-    } else if (this._showHelpWithError) {
+    if (typeof this._showHelpAfterError === 'string') {
+      this._outputConfiguration.writeErr(`${this._showHelpAfterError}\n`);
+    } else if (this._showHelpAfterError) {
       this._outputConfiguration.writeErr('\n');
       this.outputHelp({ error: true });
     }

--- a/lib/command.js
+++ b/lib/command.js
@@ -42,6 +42,7 @@ class Command extends EventEmitter {
     this._enablePositionalOptions = false;
     this._passThroughOptions = false;
     this._lifeCycleHooks = {}; // a hash of arrays
+    /** @type {boolean | string} */
     this._showHelpAfterError = false;
 
     // see .configureOutput() for docs

--- a/lib/command.js
+++ b/lib/command.js
@@ -42,6 +42,7 @@ class Command extends EventEmitter {
     this._enablePositionalOptions = false;
     this._passThroughOptions = false;
     this._lifeCycleHooks = {}; // a hash of arrays
+    this._displayHelpWithError = false;
 
     // see .configureOutput() for docs
     this._outputConfiguration = {
@@ -198,6 +199,18 @@ class Command extends EventEmitter {
     if (configuration === undefined) return this._outputConfiguration;
 
     Object.assign(this._outputConfiguration, configuration);
+    return this;
+  }
+
+  /**
+   * Also display the help or a custom message when an error occurs.
+   *
+   * @param {boolean|string} [displayHelp]
+   * @return {Command} `this` command for chaining
+   */
+  displayHelpWithError(displayHelp = true) {
+    if (typeof displayHelp !== 'string') displayHelp = !!displayHelp;
+    this._displayHelpWithError = displayHelp;
     return this;
   }
 
@@ -1370,6 +1383,12 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
   _displayError(exitCode, code, message) {
     this._outputConfiguration.outputError(`${message}\n`, this._outputConfiguration.writeErr);
+    if (typeof this._displayHelpWithError === 'string') {
+      this._outputConfiguration.writeErr(`${this._displayHelpWithError}\n`);
+    } else if (this._displayHelpWithError) {
+      this._outputConfiguration.writeErr('\n');
+      this.outputHelp({ error: true });
+    }
     this._exit(exitCode, code, message);
   }
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -127,6 +127,7 @@ class Command extends EventEmitter {
     cmd._combineFlagAndOptionalValue = this._combineFlagAndOptionalValue;
     cmd._allowExcessArguments = this._allowExcessArguments;
     cmd._enablePositionalOptions = this._enablePositionalOptions;
+    cmd._showHelpAfterError = this._showHelpAfterError;
 
     cmd._executableFile = opts.executableFile || null; // Custom name for executable file, set missing to null to match constructor
     if (args) cmd.arguments(args);

--- a/tests/command.chain.test.js
+++ b/tests/command.chain.test.js
@@ -177,4 +177,10 @@ describe('Command methods that should return this for chaining', () => {
     const result = program.setOptionValue();
     expect(result).toBe(program);
   });
+
+  test('when call .showHelpAfterError() then returns this', () => {
+    const program = new Command();
+    const result = program.showHelpAfterError();
+    expect(result).toBe(program);
+  });
 });

--- a/tests/command.exitOverride.test.js
+++ b/tests/command.exitOverride.test.js
@@ -62,7 +62,7 @@ describe('.exitOverride and error details', () => {
     }
 
     expect(stderrSpy).toHaveBeenCalled();
-    expectCommanderError(caughtErr, 1, 'commander.unknownCommand', "error: unknown command 'oops'. See 'prog --help'.");
+    expectCommanderError(caughtErr, 1, 'commander.unknownCommand', "error: unknown command 'oops'");
   });
 
   // Same error as above, but with custom handler.

--- a/tests/command.helpOption.test.js
+++ b/tests/command.helpOption.test.js
@@ -128,6 +128,6 @@ describe('helpOption', () => {
       .command('foo');
     expect(() => {
       program.parse(['UNKNOWN'], { from: 'user' });
-    }).toThrow("error: unknown command 'UNKNOWN'.");
+    }).toThrow("error: unknown command 'UNKNOWN'");
   });
 });

--- a/tests/command.showHelpAfterError.test.js
+++ b/tests/command.showHelpAfterError.test.js
@@ -1,0 +1,109 @@
+const commander = require('../');
+
+describe('showHelpAfterError with message', () => {
+  const customHelpMessage = 'See --help';
+
+  function makeProgram() {
+    const writeMock = jest.fn();
+    const program = new commander.Command();
+    program
+      .exitOverride()
+      .showHelpAfterError(customHelpMessage)
+      .configureOutput({ writeErr: writeMock });
+
+    return { program, writeMock };
+  }
+
+  test('when missing command-argument then shows help', () => {
+    const { program, writeMock } = makeProgram();
+    program.argument('<file>');
+    let caughtErr;
+    try {
+      program.parse([], { from: 'user' });
+    } catch (err) {
+      caughtErr = err;
+    }
+    expect(caughtErr.code).toBe('commander.missingArgument');
+    expect(writeMock).toHaveBeenLastCalledWith(`${customHelpMessage}\n`);
+  });
+
+  test('when missing option-argument then shows help', () => {
+    const { program, writeMock } = makeProgram();
+    program.option('--output <file>');
+    let caughtErr;
+    try {
+      program.parse(['--output'], { from: 'user' });
+    } catch (err) {
+      caughtErr = err;
+    }
+    expect(caughtErr.code).toBe('commander.optionMissingArgument');
+    expect(writeMock).toHaveBeenLastCalledWith(`${customHelpMessage}\n`);
+  });
+
+  test('when missing mandatory option then shows help', () => {
+    const { program, writeMock } = makeProgram();
+    program.requiredOption('--password <cipher>');
+    let caughtErr;
+    try {
+      program.parse([], { from: 'user' });
+    } catch (err) {
+      caughtErr = err;
+    }
+    expect(caughtErr.code).toBe('commander.missingMandatoryOptionValue');
+    expect(writeMock).toHaveBeenLastCalledWith(`${customHelpMessage}\n`);
+  });
+
+  test('when unknown option then shows help', () => {
+    const { program, writeMock } = makeProgram();
+    let caughtErr;
+    try {
+      program.parse(['--unknown-option'], { from: 'user' });
+    } catch (err) {
+      caughtErr = err;
+    }
+    expect(caughtErr.code).toBe('commander.unknownOption');
+    expect(writeMock).toHaveBeenLastCalledWith(`${customHelpMessage}\n`);
+  });
+
+  test('when too many command-arguments then shows help', () => {
+    const { program, writeMock } = makeProgram();
+    program
+      .allowExcessArguments(false);
+    let caughtErr;
+    try {
+      program.parse(['surprise'], { from: 'user' });
+    } catch (err) {
+      caughtErr = err;
+    }
+    expect(caughtErr.code).toBe('commander.excessArguments');
+    expect(writeMock).toHaveBeenLastCalledWith(`${customHelpMessage}\n`);
+  });
+
+  test('when unknown command then shows help', () => {
+    const { program, writeMock } = makeProgram();
+    program.command('sub1');
+    let caughtErr;
+    try {
+      program.parse(['sub2'], { from: 'user' });
+    } catch (err) {
+      caughtErr = err;
+    }
+    expect(caughtErr.code).toBe('commander.unknownCommand');
+    expect(writeMock).toHaveBeenLastCalledWith(`${customHelpMessage}\n`);
+  });
+});
+
+test('when showHelpAfterError() and error and then shows full help', () => {
+  const writeMock = jest.fn();
+  const program = new commander.Command();
+  program
+    .exitOverride()
+    .showHelpAfterError()
+    .configureOutput({ writeErr: writeMock });
+
+  try {
+    program.parse(['--unknown-option'], { from: 'user' });
+  } catch (err) {
+  }
+  expect(writeMock).toHaveBeenLastCalledWith(program.helpInformation());
+});

--- a/tests/command.showHelpAfterError.test.js
+++ b/tests/command.showHelpAfterError.test.js
@@ -91,6 +91,19 @@ describe('showHelpAfterError with message', () => {
     expect(caughtErr.code).toBe('commander.unknownCommand');
     expect(writeMock).toHaveBeenLastCalledWith(`${customHelpMessage}\n`);
   });
+
+  test('when invalid option choice then shows help', () => {
+    const { program, writeMock } = makeProgram();
+    program.addOption(new commander.Option('--color').choices(['red', 'blue']));
+    let caughtErr;
+    try {
+      program.parse(['--color', 'pink'], { from: 'user' });
+    } catch (err) {
+      caughtErr = err;
+    }
+    expect(caughtErr.code).toBe('commander.invalidArgument');
+    expect(writeMock).toHaveBeenLastCalledWith(`${customHelpMessage}\n`);
+  });
 });
 
 test('when showHelpAfterError() and error and then shows full help', () => {

--- a/tests/command.unknownCommand.test.js
+++ b/tests/command.unknownCommand.test.js
@@ -78,20 +78,4 @@ describe('unknownCommand', () => {
     }
     expect(caughtErr.code).toBe('commander.unknownCommand');
   });
-
-  test('when unknown subcommand then help suggestion includes command path', () => {
-    const program = new commander.Command();
-    program
-      .exitOverride()
-      .command('sub')
-      .command('subsub');
-    let caughtErr;
-    try {
-      program.parse('node test.js sub unknown'.split(' '));
-    } catch (err) {
-      caughtErr = err;
-    }
-    expect(caughtErr.code).toBe('commander.unknownCommand');
-    expect(writeErrorSpy.mock.calls[0][0]).toMatch('test sub');
-  });
 });

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -389,6 +389,11 @@ export class Command {
   configureOutput(): OutputConfiguration;
 
   /**
+   * Display the help or a custom message after an error occurs.
+   */
+  showHelpAfterError(displayHelp?: boolean | string): this;
+
+  /**
    * Register callback `fn` for the command.
    *
    * @example

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -274,6 +274,11 @@ expectType<commander.Command>(program.configureHelp({
 }));
 expectType<commander.HelpConfiguration>(program.configureHelp());
 
+// showHelpAfterError
+expectType<commander.Command>(program.showHelpAfterError());
+expectType<commander.Command>(program.showHelpAfterError(true));
+expectType<commander.Command>(program.showHelpAfterError('See --help'));
+
 // configureOutput
 expectType<commander.Command>(program.configureOutput({ }));
 expectType<commander.OutputConfiguration>(program.configureOutput());


### PR DESCRIPTION
# Pull Request

## Problem

Some users would like the help displayed along with the error, or a tip that the help is available.

Related: https://github.com/tj/commander.js/issues/7#issuecomment-824463733 #482 #766 #919 #1423

## Solution

Add `.showHelpAfterError()` to turn on displaying the help, and can optionally take a string to display (rather than the full help).

The form of the solution inspired in part by Yargs [showHelpOnFail](https://github.com/yargs/yargs/blob/master/docs/api.md#showhelponfailenable-message).

Example uses:

```js
program.showHelpAfterError('(see --help for additional information)'); // custom suggestion

program.showHelpAfterError(); // display full command help after the error message
```

## ChangeLog

- add: `.showHelpAfterError()` to display full help or a custom message after an error
- changed: remove help suggestion from "unknown command" error message (see `.showHelpAfteError()` )