### PR TITLE
feat: add generics to OptionValues

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -156,9 +156,9 @@ declare namespace commander {
 
   type AddHelpTextPosition = 'beforeAll' | 'before' | 'after' | 'afterAll';
 
-  type OptionValues<T = {[key: string]: any}> = {
-    [key in keyof T]: T[key]
-  };
+  interface OptionValues {
+    [key: string]: any;
+  }
 
   interface Command {
     args: string[];
@@ -384,8 +384,8 @@ declare namespace commander {
      *
      * @returns `this` command for chaining
      */
-    storeOptionsAsProperties<T = any>(): this & OptionValues<T>;
-    storeOptionsAsProperties<T = any>(storeAsProperties: true): this & OptionValues<T>;
+    storeOptionsAsProperties<T extends OptionValues>(): this & T;
+    storeOptionsAsProperties<T extends OptionValues>(storeAsProperties: true): this & T;
     storeOptionsAsProperties(storeAsProperties?: boolean): this;
 
     /**
@@ -485,7 +485,7 @@ declare namespace commander {
     /**
      * Return an object containing options as key-value pairs
      */
-    opts<T = any>(): OptionValues<T>;
+    opts<T extends OptionValues>(): T;
 
     /**
      * Set the description.

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -156,9 +156,9 @@ declare namespace commander {
 
   type AddHelpTextPosition = 'beforeAll' | 'before' | 'after' | 'afterAll';
 
-  interface OptionValues {
-    [key: string]: any;
-  }
+  type OptionValues<T = {[key: string]: any}> = {
+    [key in keyof T]: T[key]
+  };
 
   interface Command {
     args: string[];
@@ -384,8 +384,8 @@ declare namespace commander {
      *
      * @returns `this` command for chaining
      */
-    storeOptionsAsProperties(): this & OptionValues;
-    storeOptionsAsProperties(storeAsProperties: true): this & OptionValues;
+    storeOptionsAsProperties<T = any>(): this & OptionValues<T>;
+    storeOptionsAsProperties<T = any>(storeAsProperties: true): this & OptionValues<T>;
     storeOptionsAsProperties(storeAsProperties?: boolean): this;
 
     /**
@@ -485,7 +485,7 @@ declare namespace commander {
     /**
      * Return an object containing options as key-value pairs
      */
-    opts(): OptionValues;
+    opts<T = any>(): OptionValues<T>;
 
     /**
      * Set the description.

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -171,6 +171,15 @@ expectType<commander.OptionValues>(opts);
 expectType(opts.foo);
 expectType(opts['bar']);
 
+// opts with generics
+interface MyCheeseOption {
+  cheese: string;
+}
+const myCheeseOption = program.opts<MyCheeseOption>();
+expectType<string>(myCheeseOption.cheese);
+// @ts-expect-error Check that options strongly typed and does not allow arbitrary properties
+expectType(myCheeseOption.foo);
+
 // description
 expectType<commander.Command>(program.description('my description'));
 expectType<string>(program.description());


### PR DESCRIPTION
# Pull Request

<!--
The text in these markdown comments is instructions that will not appear in the displayed pull request,
and can be deleted.

Please submit pull requests against the develop branch.

Follow the existing code style. Check the tests succeed, including lint.
  npm run test
  npm run lint

Don't update the CHANGELOG or command version number. That gets done by maintainers when preparing the release.

Commander currently has zero production dependencies. That isn't a hard requirement, but is a simple story. Requests which 
add a dependency are much less likely to be accepted, and we are likely to ask if there alternative approaches to avoid the dependency.
-->

## Problem

<!--
What problem are you solving?
What Issues does this relate to?
Show the broken output if appropriate.
-->

close #1536 

## Solution

<!--
How did you solve the problem? 
Show the fixed output if appropriate.

There are a lot of forms of documentation which could need updating for a change in functionality. It
is ok if you want to show us the code to discuss before doing the extra work, and
you should say so in your comments so we focus on the concept first before talking about all the other pieces:

- TypeScript typings
- JSDoc documentation in code
- tests
- README
- examples/
-->

TypeScript typings
- add generics to OptionValues
- add default generics to storeOptionsAsProperties and opts method

## ChangeLog

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->
