### PR TITLE
Add strong typing of .opts() using generics

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -483,8 +483,8 @@ export class Command {
    *
    * @returns `this` command for chaining
    */
-  storeOptionsAsProperties(): this & OptionValues;
-  storeOptionsAsProperties(storeAsProperties: true): this & OptionValues;
+  storeOptionsAsProperties<T extends OptionValues>(): this & T;
+  storeOptionsAsProperties<T extends OptionValues>(storeAsProperties: true): this & T;
   storeOptionsAsProperties(storeAsProperties?: boolean): this;
 
   /**
@@ -594,7 +594,7 @@ export class Command {
   /**
    * Return an object containing options as key-value pairs
    */
-  opts(): OptionValues;
+  opts<T extends OptionValues>(): T;
 
   /**
    * Set the description.

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -196,6 +196,15 @@ expectType<commander.OptionValues>(opts);
 expectType(opts.foo);
 expectType(opts['bar']);
 
+// opts with generics
+interface MyCheeseOption {
+  cheese: string;
+}
+const myCheeseOption = program.opts<MyCheeseOption>();
+expectType<string>(myCheeseOption.cheese);
+// @ts-expect-error Check that options strongly typed and does not allow arbitrary properties
+expectType(myCheeseOption.foo);
+
 // description
 expectType<commander.Command>(program.description('my description'));
 expectType<string>(program.description());


### PR DESCRIPTION
# Pull Request

## Problem

Unable to specify `.opts()` return type in TypeScript client code.

Issue: #1536

Original Pull Request: #1537 (manually moved code between branches, with co-author credit on commit)

## Solution

Add generics so can call like:

```js
interface MyCheeseOption {
  cheese: string;
}
const myCheeseOption = program.opts<MyCheeseOption>();
```

## ChangeLog

- add client typing of `.opts()` return type using TypeScript generics
