### PR TITLE
Add tips about showing help instead of just missing arguments error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,21 +15,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 If you have a simple program without an action handler, you will now get an error if
 there are missing command-arguments.
 
-```
+```js
 program
-   .option('-d, --debug')
-   .arguments('<file>');
+  .option('-d, --debug')
+  .arguments('<file>');
 program.parse();
 ```
 
-```
+```sh
 $ node trivial.js 
 error: missing required argument 'file'
 ```
 
 If you want to show the help in this situation, you could check the arguments before parsing:
 
-```
+```js
 if (process.argv.length === 2)
   program.help();
 program.parse();
@@ -37,7 +37,7 @@ program.parse();
 
 Or, you might choose to show the help after any user error:
 
-```
+```js
 program.showHelpAfterError();
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,39 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 <!-- markdownlint-disable MD024 -->
 <!-- markdownlint-disable MD004 -->
 
+## [Unreleased] (date goes here)
+
+### Migration Tips
+
+If you have a simple program without an action handler, you will now get an error if
+there are missing command-arguments.
+
+```
+program
+   .option('-d, --debug')
+   .arguments('<file>');
+program.parse();
+```
+
+```
+$ node trivial.js 
+error: missing required argument 'file'
+```
+
+If you want to show the help in this situation, you could check the arguments before parsing:
+
+```
+if (process.argv.length === 2)
+  program.help();
+program.parse();
+```
+
+Or, you might choose to show the help after any user error:
+
+```
+program.showHelpAfterError();
+```
+
 ## [8.0.0-2] (2021-06-06)
 
 ### Added


### PR DESCRIPTION
# Pull Request

## Problem

The behaviour is changing in Commander 8 for very simple programs which previously could decide after parsing what to do (if anything) about missing command-arguments.

## Solution

Add a couple of simple approaches to Migration Tips in CHANGELOG.

I am not sure whether this come up much, but I'm thinking of the fairly casual users of Commander.