### PR TITLE
Add copyInheritedSettings

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -76,13 +76,12 @@ class Command extends EventEmitter {
   /**
    * Copy settings that are useful to have in common across root command and subcommands.
    *
-   * (Used internally when adding a command using `.command()` to copy settings
-   * from the parent command to the subcommand.)
+   * (Used internally when adding a command using `.command()` so subcommands inherit parent settings.)
    *
    * @param {Command} sourceCommand
    * @return {Command} returns `this` for executable command
    */
-  copySettings(sourceCommand) {
+  copyInheritedSettings(sourceCommand) {
     this._outputConfiguration = sourceCommand._outputConfiguration;
     this._hasHelpOption = sourceCommand._hasHelpOption;
     this._helpFlags = sourceCommand._helpFlags;
@@ -150,7 +149,7 @@ class Command extends EventEmitter {
     if (args) cmd.arguments(args);
     this.commands.push(cmd);
     cmd.parent = this;
-    cmd.copySettings(this);
+    cmd.copyInheritedSettings(this);
 
     if (desc) return this;
     return cmd;

--- a/lib/command.js
+++ b/lib/command.js
@@ -76,8 +76,8 @@ class Command extends EventEmitter {
   /**
    * Copy settings that are useful to have in common across root command and subcommands.
    *
-   * copySettings is used internally when adding a command using `.command()` to copy settings
-   * from the parent command to the subcommand.
+   * (Used internally when adding a command using `.command()` to copy settings
+   * from the parent command to the subcommand.)
    *
    * @param {Command} sourceCommand
    * @return {Command} returns `this` for executable command

--- a/lib/command.js
+++ b/lib/command.js
@@ -74,6 +74,36 @@ class Command extends EventEmitter {
   }
 
   /**
+   * Copy settings that are useful to have in common across root command and subcommands.
+   *
+   * copySettings is used internally when adding a command using `.command()` to copy settings
+   * from the parent command to the subcommand.
+   *
+   * @param {Command} sourceCommand
+   * @return {Command} returns `this` for executable command
+   */
+  copySettings(sourceCommand) {
+    this._outputConfiguration = sourceCommand._outputConfiguration;
+    this._hasHelpOption = sourceCommand._hasHelpOption;
+    this._helpFlags = sourceCommand._helpFlags;
+    this._helpDescription = sourceCommand._helpDescription;
+    this._helpShortFlag = sourceCommand._helpShortFlag;
+    this._helpLongFlag = sourceCommand._helpLongFlag;
+    this._helpCommandName = sourceCommand._helpCommandName;
+    this._helpCommandnameAndArgs = sourceCommand._helpCommandnameAndArgs;
+    this._helpCommandDescription = sourceCommand._helpCommandDescription;
+    this._helpConfiguration = sourceCommand._helpConfiguration;
+    this._exitCallback = sourceCommand._exitCallback;
+    this._storeOptionsAsProperties = sourceCommand._storeOptionsAsProperties;
+    this._combineFlagAndOptionalValue = sourceCommand._combineFlagAndOptionalValue;
+    this._allowExcessArguments = sourceCommand._allowExcessArguments;
+    this._enablePositionalOptions = sourceCommand._enablePositionalOptions;
+    this._showHelpAfterError = sourceCommand._showHelpAfterError;
+
+    return this;
+  }
+
+  /**
    * Define a command.
    *
    * There are two styles of command: pay attention to where to put the description.
@@ -108,37 +138,19 @@ class Command extends EventEmitter {
     }
     opts = opts || {};
     const [, name, args] = nameAndArgs.match(/([^ ]+) *(.*)/);
-    const cmd = this.createCommand(name);
 
+    const cmd = this.createCommand(name);
     if (desc) {
       cmd.description(desc);
       cmd._executableHandler = true;
     }
     if (opts.isDefault) this._defaultCommandName = cmd._name;
-
-    cmd._outputConfiguration = this._outputConfiguration;
-
     cmd._hidden = !!(opts.noHelp || opts.hidden); // noHelp is deprecated old name for hidden
-    cmd._hasHelpOption = this._hasHelpOption;
-    cmd._helpFlags = this._helpFlags;
-    cmd._helpDescription = this._helpDescription;
-    cmd._helpShortFlag = this._helpShortFlag;
-    cmd._helpLongFlag = this._helpLongFlag;
-    cmd._helpCommandName = this._helpCommandName;
-    cmd._helpCommandnameAndArgs = this._helpCommandnameAndArgs;
-    cmd._helpCommandDescription = this._helpCommandDescription;
-    cmd._helpConfiguration = this._helpConfiguration;
-    cmd._exitCallback = this._exitCallback;
-    cmd._storeOptionsAsProperties = this._storeOptionsAsProperties;
-    cmd._combineFlagAndOptionalValue = this._combineFlagAndOptionalValue;
-    cmd._allowExcessArguments = this._allowExcessArguments;
-    cmd._enablePositionalOptions = this._enablePositionalOptions;
-    cmd._showHelpAfterError = this._showHelpAfterError;
-
     cmd._executableFile = opts.executableFile || null; // Custom name for executable file, set missing to null to match constructor
     if (args) cmd.arguments(args);
     this.commands.push(cmd);
     cmd.parent = this;
+    cmd.copySettings(this);
 
     if (desc) return this;
     return cmd;

--- a/tests/command.chain.test.js
+++ b/tests/command.chain.test.js
@@ -184,10 +184,10 @@ describe('Command methods that should return this for chaining', () => {
     expect(result).toBe(program);
   });
 
-  test('when call .copySettings() then returns this', () => {
+  test('when call .copyInheritedSettings() then returns this', () => {
     const program = new Command();
     const cmd = new Command();
-    const result = cmd.copySettings(program);
+    const result = cmd.copyInheritedSettings(program);
     expect(result).toBe(cmd);
   });
 });

--- a/tests/command.chain.test.js
+++ b/tests/command.chain.test.js
@@ -183,4 +183,11 @@ describe('Command methods that should return this for chaining', () => {
     const result = program.showHelpAfterError();
     expect(result).toBe(program);
   });
+
+  test('when call .copySettings() then returns this', () => {
+    const program = new Command();
+    const cmd = new Command();
+    const result = cmd.copySettings(program);
+    expect(result).toBe(cmd);
+  });
 });

--- a/tests/command.copySettings.test.js
+++ b/tests/command.copySettings.test.js
@@ -1,9 +1,12 @@
 const commander = require('../');
 
+// Tests some private properties as simpler than pure tests of observable behaviours.
+// Testing before and after values in some cases, to ensure value actually changes (when copied).
+
 test('when add subcommand with .command() then calls copySettings from parent', () => {
   const program = new commander.Command();
 
-  // This is a bit intrusive, but check that copySettings is called internally.
+  // This is a bit intrusive, but check expectation that copySettings is called internally.
   const copySettingMock = jest.fn();
   program.createCommand = (name) => {
     const cmd = new commander.Command(name);
@@ -16,11 +19,115 @@ test('when add subcommand with .command() then calls copySettings from parent', 
 });
 
 describe('copySettings property tests', () => {
-  test('outputConfiguration', () => {
+  test('when copySettings then copies outputConfiguration(config)', () => {
     const source = new commander.Command();
-    source.configureOutput({ foo: 'bar' });
     const cmd = new commander.Command();
+
+    source.configureOutput({ foo: 'bar' });
     cmd.copySettings(source);
     expect(cmd.configureOutput().foo).toEqual('bar');
+  });
+
+  test('when copySettings then copies helpOption(false)', () => {
+    const source = new commander.Command();
+    const cmd = new commander.Command();
+    expect(cmd._hasHelpOption).toBeTruthy();
+
+    source.helpOption(false);
+    cmd.copySettings(source);
+    expect(cmd._hasHelpOption).toBeFalsy();
+  });
+
+  test('when copySettings then copies helpOption(flags, description)', () => {
+    const source = new commander.Command();
+    const cmd = new commander.Command();
+
+    source.helpOption('-Z, --zz', 'ddd');
+    cmd.copySettings(source);
+    expect(cmd._helpFlags).toBe('-Z, --zz');
+    expect(cmd._helpDescription).toBe('ddd');
+    expect(cmd._helpShortFlag).toBe('-Z');
+    expect(cmd._helpLongFlag).toBe('--zz');
+  });
+
+  test('when copySettings then copies addHelpCommand(name, description)', () => {
+    const source = new commander.Command();
+    const cmd = new commander.Command();
+
+    source.addHelpCommand('HELP [cmd]', 'ddd');
+    cmd.copySettings(source);
+    expect(cmd._helpCommandName).toBe('HELP');
+    expect(cmd._helpCommandnameAndArgs).toBe('HELP [cmd]');
+    expect(cmd._helpCommandDescription).toBe('ddd');
+  });
+
+  test('when copySettings then copies configureHelp(config)', () => {
+    const source = new commander.Command();
+    const cmd = new commander.Command();
+
+    const configuration = { foo: 'bar', helpWidth: 123, sortSubcommands: true };
+    source.configureHelp(configuration);
+    cmd.copySettings(source);
+    expect(cmd.configureHelp()).toEqual(configuration);
+  });
+
+  test('when copySettings then copies exitOverride()', () => {
+    const source = new commander.Command();
+    const cmd = new commander.Command();
+
+    expect(cmd._exitCallback).toBeFalsy();
+    source.exitOverride();
+    cmd.copySettings(source);
+    expect(cmd._exitCallback).toBeTruthy(); // actually a function
+  });
+
+  test('when copySettings then copies storeOptionsAsProperties()', () => {
+    const source = new commander.Command();
+    const cmd = new commander.Command();
+
+    expect(cmd._storeOptionsAsProperties).toBeFalsy();
+    source.storeOptionsAsProperties();
+    cmd.copySettings(source);
+    expect(cmd._storeOptionsAsProperties).toBeTruthy();
+  });
+
+  test('when copySettings then copies combineFlagAndOptionalValue()', () => {
+    const source = new commander.Command();
+    const cmd = new commander.Command();
+
+    expect(cmd._combineFlagAndOptionalValue).toBeTruthy();
+    source.combineFlagAndOptionalValue(false);
+    cmd.copySettings(source);
+    expect(cmd._combineFlagAndOptionalValue).toBeFalsy();
+  });
+
+  test('when copySettings then copies allowExcessArguments()', () => {
+    const source = new commander.Command();
+    const cmd = new commander.Command();
+
+    expect(cmd._allowExcessArguments).toBeTruthy();
+    source.allowExcessArguments(false);
+    cmd.copySettings(source);
+    expect(cmd._allowExcessArguments).toBeFalsy();
+  });
+
+  test('when copySettings then copies enablePositionalOptions()', () => {
+    const source = new commander.Command();
+    const cmd = new commander.Command();
+
+    expect(cmd._enablePositionalOptions).toBeFalsy();
+    source.enablePositionalOptions();
+    cmd.copySettings(source);
+    expect(cmd._enablePositionalOptions).toBeTruthy();
+  });
+
+  test('when copySettings then copies showHelpAfterError()', () => {
+    const source = new commander.Command();
+    const cmd = new commander.Command();
+
+    expect(cmd._showHelpAfterError).toBeFalsy();
+    source.showHelpAfterError();
+    cmd.copySettings(source);
+    expect(cmd._showHelpAfterError).toBeTruthy();
   });
 });

--- a/tests/command.copySettings.test.js
+++ b/tests/command.copySettings.test.js
@@ -1,0 +1,26 @@
+const commander = require('../');
+
+test('when add subcommand with .command() then calls copySettings from parent', () => {
+  const program = new commander.Command();
+
+  // This is a bit intrusive, but check that copySettings is called internally.
+  const copySettingMock = jest.fn();
+  program.createCommand = (name) => {
+    const cmd = new commander.Command(name);
+    cmd.copySettings = copySettingMock;
+    return cmd;
+  };
+  program.command('sub');
+
+  expect(copySettingMock).toHaveBeenCalledWith(program);
+});
+
+describe('copySettings property tests', () => {
+  test('outputConfiguration', () => {
+    const source = new commander.Command();
+    source.configureOutput({ foo: 'bar' });
+    const cmd = new commander.Command();
+    cmd.copySettings(source);
+    expect(cmd.configureOutput().foo).toEqual('bar');
+  });
+});

--- a/tests/command.copySettings.test.js
+++ b/tests/command.copySettings.test.js
@@ -3,14 +3,14 @@ const commander = require('../');
 // Tests some private properties as simpler than pure tests of observable behaviours.
 // Testing before and after values in some cases, to ensure value actually changes (when copied).
 
-test('when add subcommand with .command() then calls copySettings from parent', () => {
+test('when add subcommand with .command() then calls copyInheritedSettings from parent', () => {
   const program = new commander.Command();
 
-  // This is a bit intrusive, but check expectation that copySettings is called internally.
+  // This is a bit intrusive, but check expectation that copyInheritedSettings is called internally.
   const copySettingMock = jest.fn();
   program.createCommand = (name) => {
     const cmd = new commander.Command(name);
-    cmd.copySettings = copySettingMock;
+    cmd.copyInheritedSettings = copySettingMock;
     return cmd;
   };
   program.command('sub');
@@ -18,116 +18,116 @@ test('when add subcommand with .command() then calls copySettings from parent', 
   expect(copySettingMock).toHaveBeenCalledWith(program);
 });
 
-describe('copySettings property tests', () => {
-  test('when copySettings then copies outputConfiguration(config)', () => {
+describe('copyInheritedSettings property tests', () => {
+  test('when copyInheritedSettings then copies outputConfiguration(config)', () => {
     const source = new commander.Command();
     const cmd = new commander.Command();
 
     source.configureOutput({ foo: 'bar' });
-    cmd.copySettings(source);
+    cmd.copyInheritedSettings(source);
     expect(cmd.configureOutput().foo).toEqual('bar');
   });
 
-  test('when copySettings then copies helpOption(false)', () => {
+  test('when copyInheritedSettings then copies helpOption(false)', () => {
     const source = new commander.Command();
     const cmd = new commander.Command();
     expect(cmd._hasHelpOption).toBeTruthy();
 
     source.helpOption(false);
-    cmd.copySettings(source);
+    cmd.copyInheritedSettings(source);
     expect(cmd._hasHelpOption).toBeFalsy();
   });
 
-  test('when copySettings then copies helpOption(flags, description)', () => {
+  test('when copyInheritedSettings then copies helpOption(flags, description)', () => {
     const source = new commander.Command();
     const cmd = new commander.Command();
 
     source.helpOption('-Z, --zz', 'ddd');
-    cmd.copySettings(source);
+    cmd.copyInheritedSettings(source);
     expect(cmd._helpFlags).toBe('-Z, --zz');
     expect(cmd._helpDescription).toBe('ddd');
     expect(cmd._helpShortFlag).toBe('-Z');
     expect(cmd._helpLongFlag).toBe('--zz');
   });
 
-  test('when copySettings then copies addHelpCommand(name, description)', () => {
+  test('when copyInheritedSettings then copies addHelpCommand(name, description)', () => {
     const source = new commander.Command();
     const cmd = new commander.Command();
 
     source.addHelpCommand('HELP [cmd]', 'ddd');
-    cmd.copySettings(source);
+    cmd.copyInheritedSettings(source);
     expect(cmd._helpCommandName).toBe('HELP');
     expect(cmd._helpCommandnameAndArgs).toBe('HELP [cmd]');
     expect(cmd._helpCommandDescription).toBe('ddd');
   });
 
-  test('when copySettings then copies configureHelp(config)', () => {
+  test('when copyInheritedSettings then copies configureHelp(config)', () => {
     const source = new commander.Command();
     const cmd = new commander.Command();
 
     const configuration = { foo: 'bar', helpWidth: 123, sortSubcommands: true };
     source.configureHelp(configuration);
-    cmd.copySettings(source);
+    cmd.copyInheritedSettings(source);
     expect(cmd.configureHelp()).toEqual(configuration);
   });
 
-  test('when copySettings then copies exitOverride()', () => {
+  test('when copyInheritedSettings then copies exitOverride()', () => {
     const source = new commander.Command();
     const cmd = new commander.Command();
 
     expect(cmd._exitCallback).toBeFalsy();
     source.exitOverride();
-    cmd.copySettings(source);
+    cmd.copyInheritedSettings(source);
     expect(cmd._exitCallback).toBeTruthy(); // actually a function
   });
 
-  test('when copySettings then copies storeOptionsAsProperties()', () => {
+  test('when copyInheritedSettings then copies storeOptionsAsProperties()', () => {
     const source = new commander.Command();
     const cmd = new commander.Command();
 
     expect(cmd._storeOptionsAsProperties).toBeFalsy();
     source.storeOptionsAsProperties();
-    cmd.copySettings(source);
+    cmd.copyInheritedSettings(source);
     expect(cmd._storeOptionsAsProperties).toBeTruthy();
   });
 
-  test('when copySettings then copies combineFlagAndOptionalValue()', () => {
+  test('when copyInheritedSettings then copies combineFlagAndOptionalValue()', () => {
     const source = new commander.Command();
     const cmd = new commander.Command();
 
     expect(cmd._combineFlagAndOptionalValue).toBeTruthy();
     source.combineFlagAndOptionalValue(false);
-    cmd.copySettings(source);
+    cmd.copyInheritedSettings(source);
     expect(cmd._combineFlagAndOptionalValue).toBeFalsy();
   });
 
-  test('when copySettings then copies allowExcessArguments()', () => {
+  test('when copyInheritedSettings then copies allowExcessArguments()', () => {
     const source = new commander.Command();
     const cmd = new commander.Command();
 
     expect(cmd._allowExcessArguments).toBeTruthy();
     source.allowExcessArguments(false);
-    cmd.copySettings(source);
+    cmd.copyInheritedSettings(source);
     expect(cmd._allowExcessArguments).toBeFalsy();
   });
 
-  test('when copySettings then copies enablePositionalOptions()', () => {
+  test('when copyInheritedSettings then copies enablePositionalOptions()', () => {
     const source = new commander.Command();
     const cmd = new commander.Command();
 
     expect(cmd._enablePositionalOptions).toBeFalsy();
     source.enablePositionalOptions();
-    cmd.copySettings(source);
+    cmd.copyInheritedSettings(source);
     expect(cmd._enablePositionalOptions).toBeTruthy();
   });
 
-  test('when copySettings then copies showHelpAfterError()', () => {
+  test('when copyInheritedSettings then copies showHelpAfterError()', () => {
     const source = new commander.Command();
     const cmd = new commander.Command();
 
     expect(cmd._showHelpAfterError).toBeFalsy();
     source.showHelpAfterError();
-    cmd.copySettings(source);
+    cmd.copyInheritedSettings(source);
     expect(cmd._showHelpAfterError).toBeTruthy();
   });
 });

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -392,10 +392,9 @@ export class Command {
   /**
    * Copy settings that are useful to have in common across root command and subcommands.
    *
-   * (Used internally when adding a command using `.command()` to copy settings
-   * from the parent command to the subcommand.)
+   * (Used internally when adding a command using `.command()` so subcommands inherit parent settings.)
    */
-   copySettings(sourceCommand: Command): this;
+   copyInheritedSettings(sourceCommand: Command): this;
 
   /**
    * Display the help or a custom message after an error occurs.

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -390,6 +390,14 @@ export class Command {
   configureOutput(): OutputConfiguration;
 
   /**
+   * Copy settings that are useful to have in common across root command and subcommands.
+   *
+   * (Used internally when adding a command using `.command()` to copy settings
+   * from the parent command to the subcommand.)
+   */
+   copySettings(sourceCommand: Command): this;
+
+  /**
    * Display the help or a custom message after an error occurs.
    */
   showHelpAfterError(displayHelp?: boolean | string): this;

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -285,8 +285,8 @@ expectType<commander.Command>(program.configureHelp({
 }));
 expectType<commander.HelpConfiguration>(program.configureHelp());
 
-// copySettings
-expectType<commander.Command>(program.copySettings(new commander.Command()));
+// copyInheritedSettings
+expectType<commander.Command>(program.copyInheritedSettings(new commander.Command()));
 
 // showHelpAfterError
 expectType<commander.Command>(program.showHelpAfterError());

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -285,6 +285,9 @@ expectType<commander.Command>(program.configureHelp({
 }));
 expectType<commander.HelpConfiguration>(program.configureHelp());
 
+// copySettings
+expectType<commander.Command>(program.copySettings(new commander.Command()));
+
 // showHelpAfterError
 expectType<commander.Command>(program.showHelpAfterError());
 expectType<commander.Command>(program.showHelpAfterError(true));


### PR DESCRIPTION
# Pull Request

## Problem

Adding a subcommand using `.command()` implicitly copies a bunch of inherited settings from the parent command to the subcommand. There is not currently any public way to transfer inherited settings, say if using `.addCommand()`, and many are not accessible using public routines or properties.

Related: #1186 https://github.com/tj/commander.js/pull/1185#issuecomment-584559274

## Solution

Add `.copyInheritedSettings()` so available for explicit use, particularly if using `.addCommand()'.

Adding for completeness, and not planning to add this to README for now. Has not come up in issues so far.

## ChangeLog

- add `.copyInheritedSettings()`
