### PR TITLE
Extend Option with argRequired and argOptional

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -278,9 +278,8 @@ class Command extends EventEmitter {
    * indicate this with <> around the name. Put [] around the name for an optional argument.
    *
    * @example
-   *
-   *     program.argument('<input-file>');
-   *     program.argument('[output-file]');
+   *   program.argument('<input-file>');
+   *   program.argument('[output-file]');
    *
    * @param {string} name
    * @param {string} [description]
@@ -305,8 +304,7 @@ class Command extends EventEmitter {
    * See also .argument().
    *
    * @example
-   *
-   *     program.arguments('<cmd> [env]');
+   *   program.arguments('<cmd> [env]');
    *
    * @param {string} names
    * @return {Command} `this` command for chaining
@@ -651,11 +649,10 @@ Expecting one of '${allowedValues.join("', '")}'`);
   /**
    * Alter parsing of short flags with optional values.
    *
-   * Examples:
-   *
-   *    // for `.option('-f,--flag [value]'):
-   *    .combineFlagAndOptionalValue(true)  // `-f80` is treated like `--flag=80`, this is the default behaviour
-   *    .combineFlagAndOptionalValue(false) // `-fb` is treated like `-f -b`
+   * @example
+   *   // for `.option('-f,--flag [value]'):
+   *   .combineFlagAndOptionalValue(true)  // `-f80` is treated like `--flag=80`, this is the default behaviour
+   *   .combineFlagAndOptionalValue(false) // `-fb` is treated like `-f -b`
    *
    * @param {Boolean} [combine=true] - if `true` or omitted, an optional value can be specified directly after the flag.
    */

--- a/lib/option.js
+++ b/lib/option.js
@@ -154,10 +154,12 @@ class Option {
   };
 
   /**
-   * Option on command-line will be followed by a required option-argument.
+   * Option on command-line must be followed by an option-argument.
    *
-   * Alternative to specifying an arg in angle brackets in constructor. e.g.
+   * Alternative to specifying an arg in angle brackets in constructor.
+   * @example
    *   new Option('--flag <arg>')
+   *   // or
    *   new Option('--flag').argRequired()
    *
    * @param {string} [argName='arg']
@@ -173,10 +175,12 @@ class Option {
   }
 
   /**
-   * Option on command-line may be followed by an optional option-argument.
+   * Option on command-line may be followed by an option-argument.
    *
-   * Alternative to specifying an arg in square brackets in constructor. e.g.
+   * Alternative to specifying an arg in square brackets in constructor.
+   * @example
    *   new Option('--flag [arg]')
+   *   // or
    *   new Option('--flag').argOptional()
    *
    * @param {string} [argName='arg']

--- a/lib/option.js
+++ b/lib/option.js
@@ -152,6 +152,44 @@ class Option {
   is(arg) {
     return this.short === arg || this.long === arg;
   };
+
+  /**
+   * Option on command-line will be followed by a required option-argument.
+   *
+   * Alternative to specifying an arg in angle brackets in constructor. e.g.
+   *   new Option('--flag <arg>')
+   *   new Option('--flag').argRequired()
+   *
+   * @param {string} [argName='arg']
+   * @return {Option}
+   */
+  argRequired(argName = 'arg') {
+    this.required = true;
+    this.optional = false;
+    if (!this.flags.includes('<')) {
+      this.flags = `${this.flags} <${argName}>`;
+    }
+    return this;
+  }
+
+  /**
+   * Option on command-line may be followed by an optional option-argument.
+   *
+   * Alternative to specifying an arg in square brackets in constructor. e.g.
+   *   new Option('--flag [arg]')
+   *   new Option('--flag').argOptional()
+   *
+   * @param {string} [argName='arg']
+   * @return {Option}
+   */
+  argOptional(argName = 'arg') {
+    this.optional = true;
+    this.required = false;
+    if (!this.flags.includes('[')) {
+      this.flags = `${this.flags} [${argName}]`;
+    }
+    return this;
+  }
 }
 
 /**

--- a/tests/option.chain.test.js
+++ b/tests/option.chain.test.js
@@ -30,4 +30,16 @@ describe('Option methods that should return this for chaining', () => {
     const result = option.choices(['a']);
     expect(result).toBe(option);
   });
+
+  test('when call .argRequired() then returns this', () => {
+    const option = new Option('-e,--example');
+    const result = option.argRequired();
+    expect(result).toBe(option);
+  });
+
+  test('when call .argOptional() then returns this', () => {
+    const option = new Option('-e,--example');
+    const result = option.argOptional();
+    expect(result).toBe(option);
+  });
 });

--- a/tests/options.optional.test.js
+++ b/tests/options.optional.test.js
@@ -68,3 +68,19 @@ describe('option with optional value, with default', () => {
     expect(program.opts().cheese).toBe(defaultValue);
   });
 });
+
+// Compare implicit and explicit for identical results, rather than test end-to-end.
+describe('Option calling argOptional', () => {
+  test('when Option calls argOptional() then same result as [arg] in flags', () => {
+    // Compare implicit and explicit for identical results, rather than test end-to-end.
+    const implicitSetting = new commander.Option('-f, --flag [arg]');
+    const explicitSetting = new commander.Option('-f, --flag').argOptional();
+    expect(explicitSetting).toEqual(implicitSetting);
+  });
+
+  test('when Option calls argOptional("value") then same result as [value] in flags', () => {
+    const implicitSetting = new commander.Option('-f, --flag [value]');
+    const explicitSetting = new commander.Option('-f, --flag').argOptional('value');
+    expect(explicitSetting).toEqual(implicitSetting);
+  });
+});

--- a/tests/options.required.test.js
+++ b/tests/options.required.test.js
@@ -80,3 +80,18 @@ describe('option with required value, with default', () => {
     expect(mockOptionMissingArgument).toHaveBeenCalled();
   });
 });
+
+// Compare implicit and explicit for identical results, rather than test end-to-end.
+describe('Option calling argRequired', () => {
+  test('when Option calls argRequired() then same result as <arg> in flags', () => {
+    const implicitSetting = new commander.Option('-f, --flag <arg>');
+    const explicitSetting = new commander.Option('-f, --flag').argRequired();
+    expect(explicitSetting).toEqual(implicitSetting);
+  });
+
+  test('when Option calls argRequired("value") then same result as <value> in flags', () => {
+    const implicitSetting = new commander.Option('-f, --flag <value>');
+    const explicitSetting = new commander.Option('-f, --flag').argRequired('value');
+    expect(explicitSetting).toEqual(implicitSetting);
+  });
+});

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -134,7 +134,25 @@ export class Option {
    * as a object attribute key.
    */
   attributeName(): string;
-}
+
+  /**
+   * Option on command-line will be followed by a required option-argument.
+   *
+   * Alternative to specifying an arg in angle brackets in constructor. e.g.
+   *   new Option('--flag <arg>')
+   *   new Option('--flag').argRequired()
+   */
+   argRequired(argName?: string): this;
+
+  /**
+   * Option on command-line may be followed by an optional option-argument.
+   *
+   * Alternative to specifying an arg in square brackets in constructor. e.g.
+   *   new Option('--flag [arg]')
+   *   new Option('--flag').argOptional()
+   */
+   argOptional(argName?: string): this;
+  }
 
 export class Help {
   /** output helpWidth, long lines are wrapped to fit */

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -136,20 +136,28 @@ export class Option {
   attributeName(): string;
 
   /**
-   * Option on command-line will be followed by a required option-argument.
+   * Option on command-line must be followed by an option-argument.
    *
-   * Alternative to specifying an arg in angle brackets in constructor. e.g.
+   * Alternative to specifying an arg in angle brackets in constructor.
+   * @example
+   * ```
    *   new Option('--flag <arg>')
+   *   // or
    *   new Option('--flag').argRequired()
+   * ```
    */
    argRequired(argName?: string): this;
 
   /**
-   * Option on command-line may be followed by an optional option-argument.
+   * Option on command-line may be followed by an option-argument.
    *
-   * Alternative to specifying an arg in square brackets in constructor. e.g.
+   * Alternative to specifying an arg in square brackets in constructor.
+   * @example
+   * ```
    *   new Option('--flag [arg]')
+   *   // or
    *   new Option('--flag').argOptional()
+   * ```
    */
    argOptional(argName?: string): this;
   }
@@ -258,13 +266,13 @@ export class Command {
    * The command description is supplied using `.description`, not as a parameter to `.command`.
    *
    * @example
-   * ```ts
-   *  program
-   *    .command('clone <source> [destination]')
-   *    .description('clone a repository into a newly created directory')
-   *    .action((source, destination) => {
-   *      console.log('clone command called');
-   *    });
+   * ```
+   *   program
+   *     .command('clone <source> [destination]')
+   *     .description('clone a repository into a newly created directory')
+   *     .action((source, destination) => {
+   *       console.log('clone command called');
+   *     });
    * ```
    *
    * @param nameAndArgs - command name and arguments, args are  `<required>` or `[optional]` and last may also be `variadic...`
@@ -279,10 +287,10 @@ export class Command {
    * The command description is supplied as the second parameter to `.command`.
    *
    * @example
-   * ```ts
-   *  program
-   *    .command('start <service>', 'start named service')
-   *    .command('stop [service]', 'stop named service, or all if no name supplied');
+   * ```
+   *   program
+   *     .command('start <service>', 'start named service')
+   *     .command('stop [service]', 'stop named service, or all if no name supplied');
    * ```
    *
    * @param nameAndArgs - command name and arguments, args are  `<required>` or `[optional]` and last may also be `variadic...`
@@ -324,9 +332,10 @@ export class Command {
    * indicate this with <> around the name. Put [] around the name for an optional argument.
    *
    * @example
-   *
-   *     program.argument('<input-file>');
-   *     program.argument('[output-file]');
+   * ```
+   *   program.argument('<input-file>');
+   *   program.argument('[output-file]');
+   * ```
    *
    * @returns `this` command for chaining
    */
@@ -346,8 +355,9 @@ export class Command {
    * See also .argument().
    *
    * @example
-   *
-   *     program.arguments('<cmd> [env]');
+   * ```
+   *   program.arguments('<cmd> [env]');
+   * ```
    *
    * @returns `this` command for chaining
    */
@@ -416,12 +426,14 @@ export class Command {
    * Register callback `fn` for the command.
    *
    * @example
-   *      program
-   *        .command('help')
-   *        .description('display verbose help')
-   *        .action(function() {
-   *           // output help here
-   *        });
+   * ```
+   *   program
+   *     .command('help')
+   *     .description('display verbose help')
+   *     .action(function() {
+   *       // output help here
+   *     });
+   * ```
    *
    * @returns `this` command for chaining
    */
@@ -440,32 +452,34 @@ export class Command {
    *    "-p --pepper"
    *
    * @example
-   *     // simple boolean defaulting to false
-   *     program.option('-p, --pepper', 'add pepper');
+   * ```
+   *   // simple boolean defaulting to false
+   *   program.option('-p, --pepper', 'add pepper');
    *
-   *     --pepper
-   *     program.pepper
-   *     // => Boolean
+   *   --pepper
+   *   program.pepper
+   *   // => Boolean
    *
-   *     // simple boolean defaulting to true
-   *     program.option('-C, --no-cheese', 'remove cheese');
+   *   // simple boolean defaulting to true
+   *   program.option('-C, --no-cheese', 'remove cheese');
    *
-   *     program.cheese
-   *     // => true
+   *   program.cheese
+   *   // => true
    *
-   *     --no-cheese
-   *     program.cheese
-   *     // => false
+   *   --no-cheese
+   *   program.cheese
+   *   // => false
    *
-   *     // required argument
-   *     program.option('-C, --chdir <path>', 'change the working directory');
+   *   // required argument
+   *   program.option('-C, --chdir <path>', 'change the working directory');
    *
-   *     --chdir /tmp
-   *     program.chdir
-   *     // => "/tmp"
+   *   --chdir /tmp
+   *   program.chdir
+   *   // => "/tmp"
    *
-   *     // optional argument
-   *     program.option('-c, --cheese [type]', 'add cheese [marble]');
+   *   // optional argument
+   *   program.option('-c, --cheese [type]', 'add cheese [marble]');
+   * ```
    *
    * @returns `this` command for chaining
    */
@@ -525,9 +539,11 @@ export class Command {
    * Alter parsing of short flags with optional values.
    *
    * @example
-   *    // for `.option('-f,--flag [value]'):
+   * ```
+   *   // for `.option('-f,--flag [value]'):
    *   .combineFlagAndOptionalValue(true)  // `-f80` is treated like `--flag=80`, this is the default behaviour
    *   .combineFlagAndOptionalValue(false) // `-fb` is treated like `-f -b`
+   * ```
    *
    * @returns `this` command for chaining
    */
@@ -607,11 +623,13 @@ export class Command {
    * and return argv split into operands and unknown arguments.
    *
    * @example
-   *    argv => operands, unknown
-   *    --known kkk op => [op], []
-   *    op --known kkk => [op], []
-   *    sub --unknown uuu op => [sub], [--unknown uuu op]
-   *    sub -- --unknown uuu op => [sub --unknown uuu op], []
+   * ```
+   *   argv => operands, unknown
+   *   --known kkk op => [op], []
+   *   op --known kkk => [op], []
+   *   sub --unknown uuu op => [sub], [--unknown uuu op]
+   *   sub -- --unknown uuu op => [sub --unknown uuu op], []
+   * ```
    */
   parseOptions(argv: string[]): ParseOptionsResult;
 

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -370,6 +370,14 @@ expectType<string>(baseOption.name());
 // attributeName
 expectType<string>(baseOption.attributeName());
 
+// argRequired
+expectType<commander.Option>(baseOption.argRequired());
+expectType<commander.Option>(baseOption.argRequired('value'));
+
+// argOptional
+expectType<commander.Option>(baseOption.argOptional());
+expectType<commander.Option>(baseOption.argOptional('value'));
+
 // Argument properties
 const baseArgument = new commander.Argument('<foo');
 expectType<string>(baseArgument.description);


### PR DESCRIPTION
# Pull Request

Fill out the Option methods to allow explicit configuration as alternative to implicit syntax from string.

This is not likely to be used much, and some downsides to having two ways to do something! Trying out an  idea. 

Method naming is intended to work with Argument too.

## Problem

The syntax for required (`<arg>`) and optional (`[arg]`) option-arguments needs to be learned. (However, this is consistent with the syntax shown in the help so is useful to learn!)

Related: #665 https://github.com/tj/commander.js/issues/1359#issuecomment-699580203 

## Solution

Add `.argRequired()` and `.argOptional()` to Option.

Adding for completeness, and not planning to add this to README for now. 

## ChangeLog

- add Option methods for `.argRequired()` and `.argOptional()` as alternative way of specifying option-argument
