### PR TITLE
Feature/argument arg explicit

### DIFF
--- a/lib/argument.js
+++ b/lib/argument.js
@@ -109,6 +109,22 @@ class Argument {
     };
     return this;
   };
+
+  /**
+   * Make option-argument required.
+   */
+  argRequired() {
+    this.required = true;
+    return this;
+  }
+
+  /**
+   * Make option-argument optional.
+   */
+  argOptional() {
+    this.required = false;
+    return this;
+  }
 }
 
 /**

--- a/tests/argument.chain.test.js
+++ b/tests/argument.chain.test.js
@@ -18,4 +18,16 @@ describe('Argument methods that should return this for chaining', () => {
     const result = argument.choices(['a']);
     expect(result).toBe(argument);
   });
+
+  test('when call .argRequired() then returns this', () => {
+    const argument = new Argument('<value>');
+    const result = argument.argRequired();
+    expect(result).toBe(argument);
+  });
+
+  test('when call .argOptional() then returns this', () => {
+    const argument = new Argument('<value>');
+    const result = argument.argOptional();
+    expect(result).toBe(argument);
+  });
 });

--- a/tests/argument.required.test.js
+++ b/tests/argument.required.test.js
@@ -1,0 +1,34 @@
+const commander = require('../');
+
+// Low-level tests of setting Argument.required.
+// Higher level tests of optional/required arguments elsewhere.
+
+test('when name with surrounding <> then argument required', () => {
+  const argument = new commander.Argument('<name>');
+  expect(argument.required).toBe(true);
+});
+
+test('when name with surrounding [] then argument optional', () => {
+  const argument = new commander.Argument('[name]');
+  expect(argument.required).toBe(false);
+});
+
+test('when name without surrounding brackets then argument required', () => {
+  // default behaviour, allowed from Commander 8
+  const argument = new commander.Argument('name');
+  expect(argument.required).toBe(true);
+});
+
+test('when call .argRequired() then argument required', () => {
+  const argument = new commander.Argument('name');
+  argument.required = false;
+  argument.argRequired();
+  expect(argument.required).toBe(true);
+});
+
+test('when call .argOptional() then argument optional', () => {
+  const argument = new commander.Argument('name');
+  argument.required = true;
+  argument.argOptional();
+  expect(argument.required).toBe(false);
+});

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -66,6 +66,15 @@ export class Argument {
    */
    choices(values: string[]): this;
 
+  /**
+   * Make option-argument required.
+   */
+   argRequired(): this;
+
+  /**
+   * Make option-argument optional.
+   */
+  argOptional(): this;
   }
 
 export class Option {

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -395,6 +395,12 @@ expectType<commander.Argument>(baseArgument.argParser((value: string, previous: 
 // choices
 expectType<commander.Argument>(baseArgument.choices(['a', 'b']));
 
+// argRequired
+expectType<commander.Argument>(baseArgument.argRequired());
+
+// argOptional
+expectType<commander.Argument>(baseArgument.argOptional());
+
 // createArgument
 expectType<commander.Argument>(program.createArgument('<name>'));
 expectType<commander.Argument>(program.createArgument('<name>', 'description'));


### PR DESCRIPTION
# Pull Request

Fill out the Argument methods to allow explicit configuration of required/optional with a fluent method. This is an alternative to implicit syntax using brackets in name string.

Related: https://github.com/tj/commander.js/issues/1359#issuecomment-699580203

## Problem

The syntax for required (`<arg>`) and optional (`[arg]`) command-arguments needs to be learned. (However, this is consistent with the syntax shown in the help so is actually useful to learn!)

## Solution

Offer an explicit method to set whether option is required or optional.

```js
program.addArgument(new Argument('foo').argRequired());
program.addArgument(new Argument('bar').argOptional());
```

The method naming is intended to be the same for adding matching methods to Option in future.

## ChangeLog

- add Argument methods for `.argRequired()` and `.argOptional()`.