### PR TITLE
style: use `||=`

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -134,7 +134,7 @@ class Command extends EventEmitter {
       opts = desc;
       desc = null;
     }
-    opts = opts || {};
+    opts ||= {};
     const [, name, args] = nameAndArgs.match(/([^ ]+) *(.*)/);
 
     const cmd = this.createCommand(name);
@@ -257,7 +257,7 @@ class Command extends EventEmitter {
     }
     checkExplicitNames(cmd.commands);
 
-    opts = opts || {};
+    opts ||= {};
     if (opts.isDefault) this._defaultCommandName = cmd._name;
     if (opts.noHelp || opts.hidden) cmd._hidden = true; // modifying passed command due to existing implementation
 
@@ -778,7 +778,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     if (argv !== undefined && !Array.isArray(argv)) {
       throw new Error('first parameter to parse must be array or undefined');
     }
-    parseOptions = parseOptions || {};
+    parseOptions ||= {};
 
     // Default to using process.argv
     if (argv === undefined) {
@@ -818,7 +818,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     }
 
     // Guess name, used in usage in help.
-    this._name = this._name || (this._scriptPath && path.basename(this._scriptPath, path.extname(this._scriptPath)));
+    this._name ||= (this._scriptPath && path.basename(this._scriptPath, path.extname(this._scriptPath)));
 
     return userArgs;
   }
@@ -1505,8 +1505,8 @@ Expecting one of '${allowedValues.join("', '")}'`);
   version(str, flags, description) {
     if (str === undefined) return this._version;
     this._version = str;
-    flags = flags || '-V, --version';
-    description = description || 'output the version number';
+    flags ||= '-V, --version';
+    description ||= 'output the version number';
     const versionOption = this.createOption(flags, description);
     this._versionOptionName = versionOption.attributeName();
     this.options.push(versionOption);
@@ -1633,7 +1633,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   _getHelpContext(contextOptions) {
-    contextOptions = contextOptions || {};
+    contextOptions ||= {};
     const context = { error: !!contextOptions.error };
     let write;
     if (context.error) {


### PR DESCRIPTION
# Pull Request

<!--
The text in these markdown comments is instructions that will not appear in the displayed pull request,
and can be deleted.

Please submit pull requests against the develop branch.

Follow the existing code style. Check the tests succeed, including lint.
  npm run test
  npm run lint

Don't update the CHANGELOG or command version number. That gets done by maintainers when preparing the release.

Commander currently has zero production dependencies. That isn't a hard requirement, but is a simple story. Requests which 
add a dependency are much less likely to be accepted, and we are likely to ask if there alternative approaches to avoid the dependency.
-->

## Problem

<!--
What problem are you solving?
What Issues does this relate to?
Show the broken output if appropriate.
-->

## Solution

<!--
How did you solve the problem? 
Show the fixed output if appropriate.

There are a lot of forms of documentation which could need updating for a change in functionality. It
is ok if you want to show us the code to discuss before doing the extra work, and
you should say so in your comments so we focus on the concept first before talking about all the other pieces:

- TypeScript typings
- JSDoc documentation in code
- tests
- README
- examples/
-->

I think it's better to use a `||=`, what do you think?

## ChangeLog

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->
