### PR TITLE
Fix deprecated documentation typo

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -39,7 +39,7 @@ The global Command object is exported as `program` from Commander v5, or import 
 const { program } = require('commander');
 // or
 const { Command } = require('commander');
-comnst program = new Command()
+const program = new Command()
 ```
 
 - Removed from README in Commander v5.


### PR DESCRIPTION
# Pull Request

Fixed a typo from deprecated.md in docs directory.
I replaced from `comnst` to `const`

## Problem

## Solution

## ChangeLog
