### PR TITLE
Conditional exports to simply ECMAScript import

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -65,30 +65,26 @@ Commander exports a global object which is convenient for quick programs.
 This is used in the examples in this README for brevity.
 
 ```js
+// CommonJS (.cjs)
 const { program } = require('commander');
-program.version('0.0.1');
 ```
 
 For larger programs which may use commander in multiple ways, including unit testing, it is better to create a local Command object to use.
 
 ```js
+// CommonJS (.cjs)
 const { Command } = require('commander');
 const program = new Command();
-program.version('0.0.1');
 ```
 
-For named imports in ECMAScript modules, import from `commander/esm.mjs`.
-
 ```js
-// index.mjs
-import { Command } from 'commander/esm.mjs';
+// ECMAScript (.mjs)
+import { Command } from 'commander';
 const program = new Command();
 ```
 
-And in TypeScript:
-
 ```ts
-// index.ts
+// TypeScript (.ts)
 import { Command } from 'commander';
 const program = new Command();
 ```
@@ -994,8 +990,8 @@ More samples can be found in the [examples](https://github.com/tj/commander.js/t
 
 ## Support
 
-The current version of Commander is fully supported on Long Term Support versions of node, and requires at least node v12.
-(For older versions of node, use an older version of Commander. Commander version 2.x has the widest support.)
+The current version of Commander is fully supported on Long Term Support versions of Node.js, and requires at least v12.20.0.
+(For older versions of Node.js, use an older version of Commander. Commander version 2.x has the widest support.)
 
 The main forum for free and community support is the project [Issues](https://github.com/tj/commander.js/issues) on GitHub.
 

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     ]
   },
   "engines": {
-    "node": ">= 12"
+    "node": "^12.20.0 || >=14"
   },
   "support": true
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "typescript-checkJS": "tsc --allowJS --checkJS index.js lib/*.js --noEmit",
     "test-all": "npm run test && npm run lint && npm run typescript-lint && npm run typescript-checkJS && npm run test-esm"
   },
-  "main": "./index.js",
   "files": [
     "index.js",
     "lib/*.js",
@@ -36,6 +35,14 @@
     "package-support.json"
   ],
   "type": "commonjs",
+  "main": "./index.js",
+  "exports": {
+    ".": {
+      "require": "./index.js",
+      "import": "./esm.mjs"
+      },
+    "./esm.mjs": "./esm.mjs"
+  },
   "dependencies": {},
   "devDependencies": {
     "@types/jest": "^26.0.23",


### PR DESCRIPTION
# Pull Request

## Problem

We are currently using a subpath for ECMAScript imports.

```
import { Command } from 'commander/esm.mjs';
```

Node.js has added support for conditional imports to mask the differences between CommonJs and ECMAScript:
- https://nodejs.org/dist/latest-v14.x/docs/api/packages.html#packages_conditional_exports

but the combination of ECMAScript without a warning and the conditional export support are only available from Node.js v12.20.0.

Node.js v12 is still LTS until 2022-04-30:

- https://nodejs.org/en/about/releases/

Related: #1284

## Solution

Add conditional exports to `package.json` for unqualified import. Still support the old subpath import. Update required Node.js version to v12.20.0.

v12.20.0	was released 2020-11-24, so by the time Commander v9 is released it will have been available for over a year.

## ChangeLog

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->
