### PR TITLE
docs(README): add quick start section with a simple code example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -11,6 +11,7 @@ Read this in other languages: English | [简体中文](./Readme_zh-CN.md)
 
 - [Commander.js](#commanderjs)
   - [Installation](#installation)
+  - [Quick Start](#quickstart)
   - [Declaring _program_ variable](#declaring-program-variable)
   - [Options](#options)
     - [Common option types, boolean and value](#common-option-types-boolean-and-value)
@@ -58,6 +59,21 @@ For information about terms used in this document see: [terminology](./docs/term
 ```bash
 npm install commander
 ```
+
+## Quick Start
+
+```js
+const { program } = require("commander");
+
+program
+    .command('list') // The name of your command
+    .description('List all pizza types available') // a discription of the command
+    .action(() => console.log("All pizza types")); // What will happen when the command is executed? as a callback function
+
+program.parse();
+```
+
+[More Examples](#examples)
 
 ## Declaring _program_ variable
 

--- a/Readme.md
+++ b/Readme.md
@@ -66,9 +66,9 @@ npm install commander
 const { program } = require("commander");
 
 program
-    .command('list') // The name of your command
-    .description('List all pizza types available') // a discription of the command
-    .action(() => console.log("All pizza types")); // What will happen when the command is executed? as a callback function
+    .command('list') // add a subcommand named "list"
+    .description('List all pizza types available') // a discription of the subcommand
+    .action(() => console.log("All pizza types")); // What will happen when the subcommand is executed? as a callback function
 
 program.parse();
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -12,6 +12,8 @@ Read this in other languages: English | [简体中文](./Readme_zh-CN.md)
 - [Commander.js](#commanderjs)
   - [Installation](#installation)
   - [Quick Start](#quickstart)
+    - [Subcommands](#subcommands)
+    - [Options](#options)
   - [Declaring _program_ variable](#declaring-program-variable)
   - [Options](#options)
     - [Common option types, boolean and value](#common-option-types-boolean-and-value)
@@ -62,6 +64,8 @@ npm install commander
 
 ## Quick Start
 
+### Subcommands
+
 ```js
 const { program } = require("commander");
 
@@ -71,6 +75,19 @@ program
     .action(() => console.log("All pizza types")); // What will happen when the subcommand is executed? as a callback function
 
 program.parse();
+```
+
+### Options
+
+```js
+program
+    .option('-d, --debug', 'output extra debugging')
+    .option('-s, --small', 'small pizza size')
+    .option('-p, --pizza-type <type>', 'flavour of pizza');
+
+program.parse();
+
+console.log(program.opts()); // output { debug: true, small: true, pizzaType: '<type>' }
 ```
 
 [More Examples](#examples)


### PR DESCRIPTION
# add quick start section 


<!--
The text in these markdown comments is instructions that will not appear in the displayed pull request,
and can be deleted.

Please submit pull requests against the develop branch.

Follow the existing code style. Check the tests succeed, including lint.
  npm run test
  npm run lint

Don't update the CHANGELOG or command version number. That gets done by maintainers when preparing the release.

Commander currently has zero production dependencies. That isn't a hard requirement, but is a simple story. Requests which 
add a dependency are much less likely to be accepted, and we are likely to ask if there alternative approaches to avoid the dependency.
-->

## Problem
Add a quick start section #1588 

<!--
What problem are you solving?
What Issues does this relate to?
Show the broken output if appropriate.
-->

## Solution

README

Add a quick start section with a link at the end to the Example section.

<!--
How did you solve the problem? 
Show the fixed output if appropriate.

There are a lot of forms of documentation which could need updating for a change in functionality. It
is ok if you want to show us the code to discuss before doing the extra work, and
you should say so in your comments so we focus on the concept first before talking about all the other pieces:

- TypeScript typings
- JSDoc documentation in code
- tests
- README
- examples/
-->

## ChangeLog

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->
