### PR TITLE
Remove TypeScript declaration for Option.argumentRejected

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -126,12 +126,6 @@ export class Option {
   hideHelp(hide?: boolean): this;
 
   /**
-   * Validation of option argument failed.
-   * Intended for use from custom argument processing functions.
-   */
-  argumentRejected(messsage: string): never;
-
-  /**
    * Only allow option value to be one of choices.
    */
   choices(values: string[]): this;

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -368,9 +368,6 @@ expectType<commander.Option>(baseOption.hideHelp());
 expectType<commander.Option>(baseOption.hideHelp(true));
 expectType<commander.Option>(baseOption.hideHelp(false));
 
-// argumentRejected
-expectType<never>(baseOption.argumentRejected('failed'));
-
 // choices
 expectType<commander.Option>(baseOption.choices(['a', 'b']));
 


### PR DESCRIPTION
# Pull Request

## Problem

Have left over TypeScript declaration for `Option.argumentRejected ` which never shipped.

Resolves: #1598

See also: #1392

## Solution

Delete the declaration!

Normally deleting a method would be a breaking change, but in this case there is no implementation anyway so I think it is ok to ship in a minor version.

## ChangeLog

- remove stale TypeScript declaration of `Option.argumentRejected`
