### PR TITLE
Add support for merging config into option values, and get+set option value source

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -1463,6 +1463,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     this.options.forEach((option) => {
       if (option.envVar && option.envVar in process.env) {
         const optionKey = option.attributeName();
+        // Priority check
         if (this.getOptionValue(optionKey) === undefined || ['default', 'config', 'env'].includes(this._optionValueSources[optionKey])) {
           if (option.required || option.optional) { // option can take a value
             // keep very simple, optional always takes value

--- a/lib/command.js
+++ b/lib/command.js
@@ -580,6 +580,12 @@ Expecting one of '${allowedValues.join("', '")}'`);
       });
     }
 
+    // This pattern is to avoid changing the existing behaviour while adding new feature!
+    this.on('optionConfig:' + oname, (val) => {
+      const invalidValueMessage = `error: option '${option.flags}' value '${val}' from config is invalid.`;
+      handleOptionValue(val, invalidValueMessage, 'config');
+    });
+
     return this;
   }
 
@@ -1464,6 +1470,44 @@ Expecting one of '${allowedValues.join("', '")}'`);
           } else { // boolean
             // keep very simple, only care that envVar defined and not the value
             this.emit(`optionEnv:${option.name()}`);
+          }
+        }
+      }
+    });
+  }
+
+  /**
+   * Set option values using configuration object parameter, if option does
+   * not have a value from cli or client code.
+   *
+   * @param {object} config
+   */
+  mergeConfigOptions(config) {
+    Object.keys(config).forEach(configKey => {
+      const option = this.options.find(option => option.attributeName() === configKey || option.is(configKey));
+      if (option) {
+        const optionKey = option.attributeName();
+        const optionValueSource = this._optionValueSources[optionKey] || 'unknown';
+        if (this.getOptionValue(optionKey) === undefined || ['default', 'env', 'config'].includes(optionValueSource)) {
+          const value = config[configKey];
+          // if (!(['string', 'boolean'].includes(typeof value))) {
+          //   const message = `error: option '${option.flags}' type '${typeof value}' from config is not string or boolean.`;
+          //   this._displayError(1, 'commander.configError', message);
+          // }
+          // arrays ???? (just for variadic?)
+          const eventName = `optionConfig:${option.name()}`;
+          if (option.required) {
+            // enforce string
+            this.emit(`${eventName}`, value);
+          } else if (option.optional) {
+            // enforce string or boolean
+            // true/false ????
+            this.emit(`${eventName}`, typeof value === 'string' ? value : undefined);
+          } else { // boolean
+            // enforce boolean ????
+            // true/false ????
+            // negatable????
+            this.emit(`${eventName}`);
           }
         }
       }

--- a/lib/command.js
+++ b/lib/command.js
@@ -36,7 +36,7 @@ class Command extends EventEmitter {
     this._scriptPath = null;
     this._name = name || '';
     this._optionValues = {};
-    this._optionValueSources = {}; // default < env < cli
+    this._optionValueSources = {}; // default < config < env < cli
     this._storeOptionsAsProperties = false;
     this._actionHandler = null;
     this._executableHandler = false;
@@ -527,7 +527,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
       }
       // preassign only if we have a default
       if (defaultValue !== undefined) {
-        this._setOptionValueWithSource(name, defaultValue, 'default');
+        this.setOptionValueWithSource(name, defaultValue, 'default');
       }
     }
 
@@ -558,13 +558,13 @@ Expecting one of '${allowedValues.join("', '")}'`);
       if (typeof oldValue === 'boolean' || typeof oldValue === 'undefined') {
         // if no value, negate false, and we have a default, then use it!
         if (val == null) {
-          this._setOptionValueWithSource(name, option.negate ? false : defaultValue || true, valueSource);
+          this.setOptionValueWithSource(name, option.negate ? false : defaultValue || true, valueSource);
         } else {
-          this._setOptionValueWithSource(name, val, valueSource);
+          this.setOptionValueWithSource(name, val, valueSource);
         }
       } else if (val !== null) {
         // reassign
-        this._setOptionValueWithSource(name, option.negate ? false : val, valueSource);
+        this.setOptionValueWithSource(name, option.negate ? false : val, valueSource);
       }
     };
 
@@ -799,12 +799,30 @@ Expecting one of '${allowedValues.join("', '")}'`);
   };
 
   /**
-   * @api private
+   * Set option value, and record source for later use.
+   *
+   * @param {string} key
+   * @param {Object} value
+   * @param {string} source - expected values are default/config/env/cli
+   * @return {Command} `this` command for chaining
    */
-  _setOptionValueWithSource(key, value, source) {
+  setOptionValueWithSource(key, value, source) {
     this.setOptionValue(key, value);
     this._optionValueSources[key] = source;
+    return this;
   }
+
+  /**
+   * Get source of option value.
+   * Expected values are default/config/env/cli
+   *
+   * @param {string} key
+   * @return {string}
+   */
+
+  getOptionValueSource(key) {
+    return this._optionValueSources[key];
+  };
 
   /**
    * Get user arguments implied or explicit arguments.
@@ -1464,7 +1482,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
       if (option.envVar && option.envVar in process.env) {
         const optionKey = option.attributeName();
         // Priority check
-        if (this.getOptionValue(optionKey) === undefined || ['default', 'config', 'env'].includes(this._optionValueSources[optionKey])) {
+        if (this.getOptionValue(optionKey) === undefined || ['default', 'config', 'env'].includes(this.getOptionValueSource(optionKey))) {
           if (option.required || option.optional) { // option can take a value
             // keep very simple, optional always takes value
             this.emit(`optionEnv:${option.name()}`, process.env[option.envVar]);
@@ -1495,7 +1513,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
       const option = this.options.find(option => option.attributeName() === configKey || option.is(configKey));
       if (option) {
         const optionKey = option.attributeName();
-        const optionValueSource = this._optionValueSources[optionKey] || 'unknown';
+        const optionValueSource = this.getOptionValueSource(optionKey) || 'unknown';
         // Priority check
         if (this.getOptionValue(optionKey) === undefined || ['default', 'config'].includes(optionValueSource)) {
           const value = config[configKey];

--- a/lib/command.js
+++ b/lib/command.js
@@ -1483,12 +1483,20 @@ Expecting one of '${allowedValues.join("', '")}'`);
    *
    * @param {object} config
    */
-  mergeConfigOptions(config) {
+  mergeConfigOptions(config, configDescription) {
+    const configError = (key, explanation) => {
+      // WIP
+      const extraDetail = configDescription ? ` in ${configDescription}` : '';
+      console.error(`error: invalid value for config key '${key}'${extraDetail}\n${explanation}`);
+      process.exit(1);
+    };
+
     Object.keys(config).forEach(configKey => {
       const option = this.options.find(option => option.attributeName() === configKey || option.is(configKey));
       if (option) {
         const optionKey = option.attributeName();
         const optionValueSource = this._optionValueSources[optionKey] || 'unknown';
+        // Priority check
         if (this.getOptionValue(optionKey) === undefined || ['default', 'env', 'config'].includes(optionValueSource)) {
           if (optionValueSource === 'env') {
             // Experiment, work-in-progress. ????
@@ -1496,13 +1504,10 @@ Expecting one of '${allowedValues.join("', '")}'`);
             this._setOptionValueWithSource(option.name(), option.defaultValue, 'default');
           }
 
-          // Got the syntax checking pretty tight, but error messages would be easier for user
-          // to understand if based on option rather than config value!
-
           const value = config[configKey];
           if (value === false) {
             if (configKey.startsWith('-')) {
-              throw new Error('error TBA: config value false can not be used with an option flag, only with a property name');
+              configError(configKey, "Config value 'false' can only be used with a property name, not a flag.");
             }
             let negatedOption = option.negate ? option : null;
             if (!option.negate && option.long) {
@@ -1510,20 +1515,20 @@ Expecting one of '${allowedValues.join("', '")}'`);
               negatedOption = this._findOption(negativeLongFlag);
             }
             if (!negatedOption) {
-              throw new Error('error TBA: config value false can only be used there is a matching negated option');
+              configError(configKey, "Config value is 'false' and no matching negated option.");
             }
             this.emit(`optionConfig:${negatedOption.name()}`);
           } else if (value === true) {
             if (option.required) {
-              throw new Error(`error TBA: 'true' not valid for '${configKey}' with a required value`);
+              configError(configKey, 'Expecting string value.');
             }
             if (option.negate && !configKey.startsWith('-')) {
-              throw new Error(`error TBA: 'true' not valid for '${configKey}', use 'false' or specify flag`);
+              configError(configKey, "Use value 'false' or property as key.");
             }
             this.emit(`optionConfig:${option.name()}`, option.optional ? null : undefined);
           } else if (typeof value === 'string') {
             if (!option.required && !option.optional) {
-              throw new Error('error TBA: config value true can only be used with optional and boolean options');
+              configError(configKey, 'Boolean and negated options do no accept strings.');
             }
             this.emit(`optionConfig:${option.name()}`, value);
           } else if (Array.isArray(value)) {
@@ -1533,7 +1538,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
               this.mergeConfigOptions(configItem);
             });
           } else {
-            throw new Error(`error TBA: unexpected config value type for '${configKey}'`);
+            configError(configKey, `Unsupported config value type '${typeof value}'`);
           }
         }
       }

--- a/lib/command.js
+++ b/lib/command.js
@@ -1118,6 +1118,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    * @param {Promise|undefined} promise
    * @param {Function} fn
    * @return {Promise|undefined}
+   * @api private
    */
 
   _chainOrCall(promise, fn) {
@@ -1489,41 +1490,50 @@ Expecting one of '${allowedValues.join("', '")}'`);
         const optionKey = option.attributeName();
         const optionValueSource = this._optionValueSources[optionKey] || 'unknown';
         if (this.getOptionValue(optionKey) === undefined || ['default', 'env', 'config'].includes(optionValueSource)) {
+          if (optionValueSource === 'env') {
+            // Experiment, work-in-progress. ????
+            // reset to defaults to before applying config to avoid including env (can't undo side-affects though).
+            this._setOptionValueWithSource(option.name(), option.defaultValue, 'default');
+          }
+
+          // Got the syntax checking pretty tight, but error messages would be easier for user
+          // to understand if based on option rather than config value!
+
           const value = config[configKey];
           if (value === false) {
-            // Only supported for a negated option
+            if (configKey.startsWith('-')) {
+              throw new Error('error TBA: config value false can not be used with an option flag, only with a property name');
+            }
             let negatedOption = option.negate ? option : null;
             if (!option.negate && option.long) {
               const negativeLongFlag = option.long.replace(/^--/, '--no-');
               negatedOption = this._findOption(negativeLongFlag);
             }
-            if (negatedOption) {
-              this.emit(`optionConfig:${negatedOption.name()}`);
-            } else {
-              throw new Error('error TBA: config value false can only be used when there is a matching negated option');
+            if (!negatedOption) {
+              throw new Error('error TBA: config value false can only be used there is a matching negated option');
             }
-          } else {
-            // if (!(['string', 'boolean'].includes(typeof value))) {
-            //   const message = `error: option '${option.flags}' type '${typeof value}' from config is not string or boolean.`;
-            //   this._displayError(1, 'commander.configError', message);
-            // }
-            // arrays ???? (just for variadic?)
-            // negatable???? Lookup type of value first ???? YAML supports boolean.
-            const eventName = `optionConfig:${option.name()}`;
+            this.emit(`optionConfig:${negatedOption.name()}`);
+          } else if (value === true) {
             if (option.required) {
-              // enforce string
-              this.emit(`${eventName}`, value);
-            } else if (option.optional) {
-              // enforce string or boolean
-              // true/false ????
-              this.emit(`${eventName}`, typeof value === 'string' ? value : undefined);
-            } else { // boolean
-              // enforce boolean ????
-              // or string or boolean and use truthy, in case parsing can not produce boolean? YAML supports boolean. Could be fixed by client.
-              // true/false ????
-              // negatable????
-              this.emit(`${eventName}`);
+              throw new Error(`error TBA: 'true' not valid for '${configKey}' with a required value`);
             }
+            if (option.negate && !configKey.startsWith('-')) {
+              throw new Error(`error TBA: 'true' not valid for '${configKey}', use 'false' or specify flag`);
+            }
+            this.emit(`optionConfig:${option.name()}`, option.optional ? null : undefined);
+          } else if (typeof value === 'string') {
+            if (!option.required && !option.optional) {
+              throw new Error('error TBA: config value true can only be used with optional and boolean options');
+            }
+            this.emit(`optionConfig:${option.name()}`, value);
+          } else if (Array.isArray(value)) {
+            value.forEach((item) => {
+              const configItem = {};
+              configItem[configKey] = item;
+              this.mergeConfigOptions(configItem);
+            });
+          } else {
+            throw new Error(`error TBA: unexpected config value type for '${configKey}'`);
           }
         }
       }

--- a/lib/command.js
+++ b/lib/command.js
@@ -1473,7 +1473,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
   /**
    * Apply any option related environment variables, if option does
-   * not have a value from cli or client code.
+   * not already have a value from a higher priority source (cli).
    *
    * @api private
    */
@@ -1496,10 +1496,11 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   /**
-   * Set option values using configuration object parameter, if option does
-   * not have a value from cli or client code.
+   * Merge option values from config, if option does
+   * not already have a value from a higher priority source (env, cli).
    *
    * @param {object} config
+   * @param {string} [configDescription]
    */
   mergeConfig(config, configDescription) {
     const configError = (key, explanation) => {

--- a/lib/command.js
+++ b/lib/command.js
@@ -1490,26 +1490,40 @@ Expecting one of '${allowedValues.join("', '")}'`);
         const optionValueSource = this._optionValueSources[optionKey] || 'unknown';
         if (this.getOptionValue(optionKey) === undefined || ['default', 'env', 'config'].includes(optionValueSource)) {
           const value = config[configKey];
-          // if (!(['string', 'boolean'].includes(typeof value))) {
-          //   const message = `error: option '${option.flags}' type '${typeof value}' from config is not string or boolean.`;
-          //   this._displayError(1, 'commander.configError', message);
-          // }
-          // arrays ???? (just for variadic?)
-          // negatable???? Lookup type of value first ???? YAML supports boolean.
-          const eventName = `optionConfig:${option.name()}`;
-          if (option.required) {
-            // enforce string
-            this.emit(`${eventName}`, value);
-          } else if (option.optional) {
-            // enforce string or boolean
-            // true/false ????
-            this.emit(`${eventName}`, typeof value === 'string' ? value : undefined);
-          } else { // boolean
-            // enforce boolean ????
-            // or string or boolean and use truthy, in case parsing can not produce boolean? YAML supports boolean. Could be fixed by client.
-            // true/false ????
-            // negatable????
-            this.emit(`${eventName}`);
+          if (value === false) {
+            // Only supported for a negated option
+            let negatedOption = option.negate ? option : null;
+            if (!option.negate && option.long) {
+              const negativeLongFlag = option.long.replace(/^--/, '--no-');
+              negatedOption = this._findOption(negativeLongFlag);
+            }
+            if (negatedOption) {
+              this.emit(`optionConfig:${negatedOption.name()}`);
+            } else {
+              throw new Error('error TBA: config value false can only be used when there is a matching negated option');
+            }
+          } else {
+            // if (!(['string', 'boolean'].includes(typeof value))) {
+            //   const message = `error: option '${option.flags}' type '${typeof value}' from config is not string or boolean.`;
+            //   this._displayError(1, 'commander.configError', message);
+            // }
+            // arrays ???? (just for variadic?)
+            // negatable???? Lookup type of value first ???? YAML supports boolean.
+            const eventName = `optionConfig:${option.name()}`;
+            if (option.required) {
+              // enforce string
+              this.emit(`${eventName}`, value);
+            } else if (option.optional) {
+              // enforce string or boolean
+              // true/false ????
+              this.emit(`${eventName}`, typeof value === 'string' ? value : undefined);
+            } else { // boolean
+              // enforce boolean ????
+              // or string or boolean and use truthy, in case parsing can not produce boolean? YAML supports boolean. Could be fixed by client.
+              // true/false ????
+              // negatable????
+              this.emit(`${eventName}`);
+            }
           }
         }
       }

--- a/lib/command.js
+++ b/lib/command.js
@@ -1495,6 +1495,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
           //   this._displayError(1, 'commander.configError', message);
           // }
           // arrays ???? (just for variadic?)
+          // negatable???? Lookup type of value first ???? YAML supports boolean.
           const eventName = `optionConfig:${option.name()}`;
           if (option.required) {
             // enforce string
@@ -1505,6 +1506,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
             this.emit(`${eventName}`, typeof value === 'string' ? value : undefined);
           } else { // boolean
             // enforce boolean ????
+            // or string or boolean and use truthy, in case parsing can not produce boolean? YAML supports boolean. Could be fixed by client.
             // true/false ????
             // negatable????
             this.emit(`${eventName}`);

--- a/lib/command.js
+++ b/lib/command.js
@@ -1507,7 +1507,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
           const value = config[configKey];
           if (value === false) {
             if (configKey.startsWith('-')) {
-              configError(configKey, "Config value 'false' can only be used with a property name, not a flag.");
+              configError(configKey, 'Config value false can only be used with a property name, not a flag.');
             }
             let negatedOption = option.negate ? option : null;
             if (!option.negate && option.long) {
@@ -1515,7 +1515,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
               negatedOption = this._findOption(negativeLongFlag);
             }
             if (!negatedOption) {
-              configError(configKey, "Config value is 'false' and no matching negated option.");
+              configError(configKey, 'Config value is false and no matching negated option.');
             }
             this.emit(`optionConfig:${negatedOption.name()}`);
           } else if (value === true) {
@@ -1523,12 +1523,12 @@ Expecting one of '${allowedValues.join("', '")}'`);
               configError(configKey, 'Expecting string value.');
             }
             if (option.negate && !configKey.startsWith('-')) {
-              configError(configKey, "Use value 'false' or property as key.");
+              configError(configKey, 'Use value false with property or true with flag for negated option.');
             }
             this.emit(`optionConfig:${option.name()}`, option.optional ? null : undefined);
           } else if (typeof value === 'string') {
             if (!option.required && !option.optional) {
-              configError(configKey, 'Boolean and negated options do no accept strings.');
+              configError(configKey, 'Boolean and negated options require boolean values, not a string.');
             }
             this.emit(`optionConfig:${option.name()}`, value);
           } else if (Array.isArray(value)) {

--- a/lib/command.js
+++ b/lib/command.js
@@ -1463,8 +1463,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     this.options.forEach((option) => {
       if (option.envVar && option.envVar in process.env) {
         const optionKey = option.attributeName();
-        // env is second lowest priority source, above default
-        if (this.getOptionValue(optionKey) === undefined || this._optionValueSources[optionKey] === 'default') {
+        if (this.getOptionValue(optionKey) === undefined || ['default', 'config', 'env'].includes(this._optionValueSources[optionKey])) {
           if (option.required || option.optional) { // option can take a value
             // keep very simple, optional always takes value
             this.emit(`optionEnv:${option.name()}`, process.env[option.envVar]);
@@ -1483,7 +1482,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    *
    * @param {object} config
    */
-  mergeConfigOptions(config, configDescription) {
+  mergeConfig(config, configDescription) {
     const configError = (key, explanation) => {
       // WIP
       const extraDetail = configDescription ? ` in ${configDescription}` : '';
@@ -1497,13 +1496,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
         const optionKey = option.attributeName();
         const optionValueSource = this._optionValueSources[optionKey] || 'unknown';
         // Priority check
-        if (this.getOptionValue(optionKey) === undefined || ['default', 'env', 'config'].includes(optionValueSource)) {
-          if (optionValueSource === 'env') {
-            // Experiment, work-in-progress. ????
-            // reset to defaults to before applying config to avoid including env (can't undo side-affects though).
-            this._setOptionValueWithSource(option.name(), option.defaultValue, 'default');
-          }
-
+        if (this.getOptionValue(optionKey) === undefined || ['default', 'config'].includes(optionValueSource)) {
           const value = config[configKey];
           if (value === false) {
             if (configKey.startsWith('-')) {
@@ -1535,7 +1528,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
             value.forEach((item) => {
               const configItem = {};
               configItem[configKey] = item;
-              this.mergeConfigOptions(configItem);
+              this.mergeConfig(configItem);
             });
           } else {
             configError(configKey, `Unsupported config value type '${typeof value}'`);

--- a/lib/command.js
+++ b/lib/command.js
@@ -1501,13 +1501,14 @@ Expecting one of '${allowedValues.join("', '")}'`);
    *
    * @param {object} config
    * @param {string} [configDescription]
+   * @return {Command} `this` command for chaining
    */
   mergeConfig(config, configDescription) {
     const configError = (key, explanation) => {
       // WIP
       const extraDetail = configDescription ? ` in ${configDescription}` : '';
-      console.error(`error: invalid value for config key '${key}'${extraDetail}\n${explanation}`);
-      process.exit(1);
+      const message = `error: invalid value for config key '${key}'${extraDetail}\n${explanation}`;
+      this._displayError('commander.configError', 1, message);
     };
 
     Object.keys(config).forEach((configKey) => {
@@ -1556,6 +1557,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
         }
       }
     });
+    return this;
   }
 
   /**

--- a/lib/command.js
+++ b/lib/command.js
@@ -1510,7 +1510,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
       process.exit(1);
     };
 
-    Object.keys(config).forEach(configKey => {
+    Object.keys(config).forEach((configKey) => {
       const option = this.options.find(option => option.attributeName() === configKey || option.is(configKey));
       if (option) {
         const optionKey = option.attributeName();

--- a/tests/command.chain.test.js
+++ b/tests/command.chain.test.js
@@ -196,4 +196,10 @@ describe('Command methods that should return this for chaining', () => {
     const result = cmd.copyInheritedSettings(program);
     expect(result).toBe(cmd);
   });
+
+  test('when call .mergeConfig() then returns this', () => {
+    const program = new Command();
+    const result = program.mergeConfig({});
+    expect(result).toBe(program);
+  });
 });

--- a/tests/command.mergeConfig.test.js
+++ b/tests/command.mergeConfig.test.js
@@ -1,0 +1,209 @@
+const { Command, Option } = require('../');
+
+// Some repetition in test implementation across different blocks.
+
+describe('check config keys', () => {
+  test('when use short flag then merged', () => {
+    const program = new Command();
+    program.exitOverride();
+    program.option('-d, --debug');
+    program.mergeConfig({ '-d': true });
+    expect(program.opts().debug).toBe(true);
+  });
+
+  test('when use long flag then merged', () => {
+    const program = new Command();
+    program.exitOverride();
+    program.option('-d, --debug');
+    program.mergeConfig({ '--debug': true });
+    expect(program.opts().debug).toBe(true);
+  });
+
+  test('when use property name then merged', () => {
+    const program = new Command();
+    program.exitOverride();
+    program.option('--dashed-words');
+    program.mergeConfig({ dashedWords: true });
+    expect(program.opts().dashedWords).toBe(true);
+  });
+
+  test('when use property name of negated then merged', () => {
+    const program = new Command();
+    program.exitOverride();
+    program.option('--no-colour');
+    program.mergeConfig({ colour: false });
+    expect(program.opts().colour).toBe(false);
+  });
+});
+
+describe('check happy config values', () => {
+  test('when boolean option with true then merged', () => {
+    const program = new Command();
+    program.exitOverride();
+    program.option('-d, --debug');
+    program.mergeConfig({ debug: true });
+    expect(program.opts().debug).toBe(true);
+  });
+
+  test('when negated property name with false then merged', () => {
+    const program = new Command();
+    program.exitOverride();
+    program.option('--no-colour');
+    program.mergeConfig({ colour: false });
+    expect(program.opts().colour).toBe(false);
+  });
+
+  test('when negated flag with true then merged', () => {
+    const program = new Command();
+    program.exitOverride();
+    program.option('--no-colour');
+    program.mergeConfig({ '--no-colour': true });
+    expect(program.opts().colour).toBe(false);
+  });
+
+  test('when boolean option and negated with true then merged', () => {
+    const program = new Command();
+    program.exitOverride();
+    program.option('--colour');
+    program.option('--no-colour');
+    program.mergeConfig({ colour: true });
+    expect(program.opts().colour).toBe(true);
+  });
+
+  test('when boolean option and negated with false then merged', () => {
+    const program = new Command();
+    program.exitOverride();
+    program.option('--colour');
+    program.option('--no-colour');
+    program.mergeConfig({ colour: false });
+    expect(program.opts().colour).toBe(false);
+  });
+
+  test('when require with string then merged', () => {
+    const program = new Command();
+    program.exitOverride();
+    program.option('--port <number>');
+    program.mergeConfig({ port: '80' });
+    expect(program.opts().port).toBe('80');
+  });
+
+  test('when require with array of strings then merged', () => {
+    // Don't need variadic to use array. Treated same way as specifying multiple times on command-line.
+    const program = new Command();
+    program.exitOverride();
+    program.option('--port <number>');
+    program.mergeConfig({ port: ['1', '2'] });
+    expect(program.opts().port).toBe('2');
+  });
+
+  test('when require... with string then merged', () => {
+    const program = new Command();
+    program.exitOverride();
+    program.option('--port <number...>');
+    program.mergeConfig({ port: '80' });
+    expect(program.opts().port).toEqual(['80']);
+  });
+
+  test('when require... with array of strings then merged', () => {
+    // Don't need variadic to use array. Treated same way as specifying multiple times on command-line.
+    const program = new Command();
+    program.exitOverride();
+    program.option('--port <number...>');
+    program.mergeConfig({ port: ['1', '2'] });
+    expect(program.opts().port).toEqual(['1', '2']);
+  });
+
+  test('when optional with string then merged', () => {
+    const program = new Command();
+    program.exitOverride();
+    program.option('--port [number]');
+    program.mergeConfig({ port: '80' });
+    expect(program.opts().port).toBe('80');
+  });
+
+  test('when optional with true then merged', () => {
+    const program = new Command();
+    program.exitOverride();
+    program.option('--port [number]');
+    program.mergeConfig({ port: true });
+    expect(program.opts().port).toBe(true);
+  });
+});
+
+describe('check happy custom parsing', () => {
+  test('when boolean option with true then merged', () => {
+    const program = new Command();
+    program.exitOverride();
+    program.option('-f, --float <number>', 'description', parseFloat);
+    program.mergeConfig({ float: '1e3' });
+    expect(program.opts().float).toBe(1000);
+  });
+});
+
+describe('check priority', () => {
+  test('when default and config then option from config', () => {
+    const program = new Command();
+    program.option('--port <number>', 'description', 'default');
+    program.parse([], { from: 'user' });
+    program.mergeConfig({ port: 'config' });
+    expect(program.opts().port).toBe('config');
+  });
+
+  test('when env and config then option from env', () => {
+    const program = new Command();
+    process.env.PORT = 'env';
+    program.addOption(new Option('-p, --port <number>').env('PORT'));
+    program.parse([], { from: 'user' });
+    program.mergeConfig({ port: 'config' });
+    expect(program.opts().port).toBe('env');
+    delete process.env.PORT;
+  });
+
+  test('when cli and config then option from cli', () => {
+    const program = new Command();
+    program.option('--port <number>', 'description', 'default');
+    program.parse(['--port=cli'], { from: 'user' });
+    program.mergeConfig({ port: 'config' });
+    expect(program.opts().port).toBe('cli');
+  });
+});
+
+describe('merge of different priority with variadic does override not combine', () => {
+  test('when env and config then option from env', () => {
+    const program = new Command();
+    process.env.PORT = 'env';
+    program.addOption(new Option('-p, --port <number...>').env('PORT'));
+    program.parse([], { from: 'user' });
+    program.mergeConfig({ port: 'config' });
+    expect(program.opts().port).toEqual(['env']);
+    delete process.env.PORT;
+  });
+
+  test('when cli and config then option from cli', () => {
+    const program = new Command();
+    program.option('--port <number...>', 'description');
+    program.parse(['--port=cli'], { from: 'user' });
+    program.mergeConfig({ port: 'config' });
+    expect(program.opts().port).toEqual(['cli']);
+  });
+});
+
+describe('double config', () => {
+  test('when merge with different keys then both in option values', () => {
+    const program = new Command();
+    program
+      .option('-a <value>')
+      .option('-b <value>');
+    program.mergeConfig({ a: 'aa' });
+    program.mergeConfig({ b: 'bb' });
+    expect(program.opts()).toEqual({ a: 'aa', b: 'bb' });
+  });
+
+  test('when merge with same keys then combined', () => {
+    const program = new Command();
+    program.option('--port <number...>', 'description');
+    program.mergeConfig({ port: '1' });
+    program.mergeConfig({ port: '2' });
+    expect(program.opts().port).toEqual(['1', '2']);
+  });
+});

--- a/tests/options.env.test.js
+++ b/tests/options.env.test.js
@@ -27,6 +27,16 @@ describe.each(['-f, --foo <required-arg>', '-f, --foo [optional-arg]'])('option 
     delete process.env.BAR;
   });
 
+  test('when env defined and config then option from env', () => {
+    const program = new commander.Command();
+    process.env.BAR = 'env';
+    program.addOption(new commander.Option(fooFlags).env('BAR'));
+    program.parse([], { from: 'user' });
+    program.mergeConfig({ });
+    expect(program.opts().foo).toBe('env');
+    delete process.env.BAR;
+  });
+
   test('when default and env undefined and no cli then option from default', () => {
     const program = new commander.Command();
     program.addOption(new commander.Option(fooFlags).env('BAR').default('default'));


### PR DESCRIPTION
# Pull Request

Work in progress.

## Problem

People would like to load configuration, from files or elsewhere.

Resolves: #1584

Config file/hash: #151 #328 #665 https://github.com/tj/commander.js/issues/1197#issuecomment-673505653

At a lower-level:
- people ask about how to tell whether options were specified on the command-line. This is not easy when option takes optional value or has default value.
- people ask about managing priority of default/config/env/cli for rolling their own solutions

Related: #1394 #1541 #1595

## Solution

There are many different potential config file formats and file locations and patterns of usage. The goal here is to provide the tools to support author implementing their own desired config support. 

1) low level: expose the "source" of option values. i.e. default/config/env/cli

2) medium level: add method to merge configuration values. The priority order is default < config < env < cli. The merge is quite subtle to support full Commander functionality including option types and custom parsing.

The actual reading of a configuration file is left to author to support JSON/js/es/yaml/ini/TOML or `package.json` property or whatever they wish to offer.

## ChangeLog

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->
