### PR TITLE
Deprecate command:* command and event

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -778,13 +778,6 @@ You can execute custom actions by listening to command and option events.
 program.on('option:verbose', function () {
   process.env.VERBOSE = this.opts().verbose;
 });
-
-program.on('command:*', function (operands) {
-  console.error(`error: unknown command '${operands[0]}'`);
-  const availableCommands = program.commands.map(cmd => cmd.name());
-  mySuggestBestMatch(operands[0], availableCommands);
-  process.exitCode = 1;
-});
 ```
 
 ## Bits and pieces

--- a/Readme_zh-CN.md
+++ b/Readme_zh-CN.md
@@ -731,13 +731,6 @@ program.configureHelp({
 program.on('option:verbose', function () {
   process.env.VERBOSE = this.opts().verbose;
 });
-
-program.on('command:*', function (operands) {
-  console.error(`error: unknown command '${operands[0]}'`);
-  const availableCommands = program.commands.map(cmd => cmd.name());
-  mySuggestBestMatch(operands[0], availableCommands);
-  process.exitCode = 1;
-});
 ```
 
 ## 零碎知识

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -3,6 +3,17 @@
 These features are deprecated, which means they may go away in a future major version of Commander.
 They are currently still available for backwards compatibility, but should not be used in new code.
 
+- [Deprecated](#deprecated)
+  - [RegExp .option() parameter](#regexp-option-parameter)
+  - [noHelp](#nohelp)
+  - [Default import of global Command object](#default-import-of-global-command-object)
+  - [Callback to .help() and .outputHelp()](#callback-to-help-and-outputhelp)
+  - [.on('--help')](#on--help)
+  - [.on('command:*')](#oncommand)
+  - [.command('*')](#command)
+  - [cmd.description(cmdDescription, argDescriptions)](#cmddescriptioncmddescription-argdescriptions)
+  - [InvalidOptionArgumentError](#invalidoptionargumenterror)
+
 ## RegExp .option() parameter
 
 The `.option()` method allowed a RegExp as the third parameter to restrict what values were accepted.
@@ -23,7 +34,7 @@ This was an option passed to `.command()` to hide the command from the built-in 
 program.command('example', 'examnple command', { noHelp: true });
 ```
 
-The option was renamed `hidden` in Commander v5.1. Deprecated from Commander v7. 
+The option was renamed `hidden` in Commander v5.1. Deprecated from Commander v7.
 
 ## Default import of global Command object
 
@@ -43,7 +54,7 @@ const program = new Command()
 ```
 
 - Removed from README in Commander v5.
-- Deprecated from Commander v7. 
+- Deprecated from Commander v7.
 - Removed from TypeScript declarations in Commander v8.
 
 ## Callback to .help() and .outputHelp()
@@ -87,7 +98,38 @@ Examples:
 );
 ```
 
-Deprecated from Commander v7. 
+Deprecated from Commander v7.
+
+## .on('command:*')
+
+This was emitted when the command argument did not match a known subcommand (as part of the implementation of `.command('*')`).
+
+One use was for adding an error for an unknown subcommand. An error is now the default built-in behaviour.
+
+A second related use was for making a suggestion for an unknown subcommand. The replacement built-in support is `.showSuggestionAfterError()`,
+or for custom behaviour catch the `commander.unknownCommand` error.
+
+Deprecated from Commander v8.3.
+
+## .command('*')
+
+This was used to add a default command to the program.
+
+```js
+program
+  .command('*')
+  .action(() => console.log('List files by default...'));
+```
+
+You may now pass a configuration option of `isDefault: true` when adding a command, whether using a subcommand with an action handler or a stand-alone executable subcommand.
+
+```js
+program
+  .command('list', { isDefault: true })
+  .action(() => console.log('List files by default...'));
+```
+
+Removed from README in Commander v5. Deprecated from Commander v8.3.
 
 ## cmd.description(cmdDescription, argDescriptions)
 
@@ -109,7 +151,6 @@ program
   .description('show price of book')
   .argument('<book>', 'ISBN number for book');
 ```
-
 
 Deprecated from Commander v8.
 


### PR DESCRIPTION
# Pull Request

## Problem

The command events are an original implementation detail which has changed. They have been shown in the README to supply some missing functionality, so we keep them working.

The `.command('*')` and `.on('command:*')` events in particular are no longer needed as there are newer more explicit ways of doing what they were used for. 

This PR prompt by confusion in: #1609

I have not tracked down the commits that removed them, but back in v4 the README had these two code fragments:

```js
// error on unknown commands
program.on('command:*', function () {
  console.error('Invalid command: %s\nSee --help for a list of available commands.', program.args.join(' '));
  process.exit(1);
});
```

```js
program
  .command('*')
  .action(function(env){
    console.log('deploying "%s"', env);
  });
```

## Solution

Remove from README and add to deprecated.

## ChangeLog

- deprecated: `.command('*')`
- deprecated: `on('command:*')`