### PR TITLE
Minor doc improvement for .action()

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -463,10 +463,10 @@ Expecting one of '${allowedValues.join("', '")}'`);
    *
    * @example
    * program
-   *   .command('help')
-   *   .description('display verbose help')
+   *   .command('serve')
+   *   .description('start service')
    *   .action(function() {
-   *      // output help here
+   *      // do work here
    *   });
    *
    * @param {Function} fn

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -424,10 +424,10 @@ export class Command {
    * @example
    * ```
    * program
-   *   .command('help')
-   *   .description('display verbose help')
+   *   .command('serve')
+   *   .description('start service')
    *   .action(function() {
-   *     // output help here
+   *     // do work here
    *   });
    * ```
    *


### PR DESCRIPTION
# Pull Request

## Problem

The example code in the JSDoc and TSDoc is to add a command named "help", but that is a poor example since usually can use the built-in help command.

## Solution

Change to adding command named "serve".
