### PR TITLE
Fix comments to refer to argument rather than option

### DIFF
--- a/lib/argument.js
+++ b/lib/argument.js
@@ -90,7 +90,7 @@ class Argument {
   };
 
   /**
-   * Only allow option value to be one of choices.
+   * Only allow argument value to be one of choices.
    *
    * @param {string[]} values
    * @return {Argument}
@@ -111,7 +111,7 @@ class Argument {
   };
 
   /**
-   * Make option-argument required.
+   * Make argument required.
    */
   argRequired() {
     this.required = true;
@@ -119,7 +119,7 @@ class Argument {
   }
 
   /**
-   * Make option-argument optional.
+   * Make argument optional.
    */
   argOptional() {
     this.required = false;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -64,12 +64,12 @@ export class Argument {
   choices(values: string[]): this;
 
   /**
-   * Make option-argument required.
+   * Make argument required.
    */
   argRequired(): this;
 
   /**
-   * Make option-argument optional.
+   * Make argument optional.
    */
   argOptional(): this;
   }


### PR DESCRIPTION
Fix up comments which were copied from Option or written assuming method on Option (rather than Argument).