### PR TITLE
Remove mention of Commander 2

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1004,7 +1004,7 @@ More samples can be found in the [examples](https://github.com/tj/commander.js/t
 ## Support
 
 The current version of Commander is fully supported on Long Term Support versions of node, and requires at least node v12.
-(For older versions of node, use an older version of Commander. Commander version 2.x has the widest support.)
+(For older versions of node, use an older version of Commander.)
 
 The main forum for free and community support is the project [Issues](https://github.com/tj/commander.js/issues) on GitHub.
 


### PR DESCRIPTION
# Pull Request

Minor tweak to description of supported node versions.

The mention of Commander v2 seemed useful for Command v3 (which required node 4) and Commander v4 (required node 6, supported from node 8). Does not seem useful now.