### PR TITLE
Wrap emit to preserve callback order when async

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -1225,7 +1225,11 @@ Expecting one of '${allowedValues.join("', '")}'`);
       let actionResult;
       actionResult = this._chainOrCallHooks(actionResult, 'preAction');
       actionResult = this._chainOrCall(actionResult, () => this._actionHandler(this.processedArgs));
-      if (this.parent) this.parent.emit(commandEvent, operands, unknown); // legacy
+      if (this.parent) {
+        actionResult = this._chainOrCall(actionResult, () => {
+          this.parent.emit(commandEvent, operands, unknown); // legacy
+        });
+      }
       actionResult = this._chainOrCallHooks(actionResult, 'postAction');
       return actionResult;
     }


### PR DESCRIPTION
# Pull Request

## Problem

(Noticed while reading code.)

The emit for a subcommand listener was not being chained, so could happen before the action handler if there were async hooks or action.

## Solution

Wrap emit in a function and chain too.

## ChangeLog

- Emit subcommand event in correct order when using async callbacks.
