### PR TITLE
New Option Constructor using config file

### DIFF
--- a/lib/option.js
+++ b/lib/option.js
@@ -34,6 +34,30 @@ class Option {
     this.argChoices = undefined;
   }
 
+  constructor(config) { // Config object that contains flags and description?
+    this.flags = config['flags'];
+    this.description = config['description'] || '';
+
+    this.required = flags.includes('<'); // A value must be supplied when the option is specified.
+    this.optional = flags.includes('['); // A value is optional when the option is specified.
+    // variadic test ignores <value,...> et al which might be used to describe custom splitting of single argument
+    this.variadic = /\w\.\.\.[>\]]$/.test(flags); // The option can take multiple values.
+    this.mandatory = false; // The option must have a value after parsing, which usually means it must be specified on command line.
+    const optionFlags = splitOptionFlags(flags);
+    this.short = optionFlags.shortFlag;
+    this.long = optionFlags.longFlag;
+    this.negate = false;
+    if (this.long) {
+      this.negate = this.long.startsWith('--no-');
+    }
+    this.defaultValue = undefined;
+    this.defaultValueDescription = undefined;
+    this.envVar = undefined;
+    this.parseArg = undefined;
+    this.hidden = false;
+    this.argChoices = undefined;
+  }
+
   /**
    * Set the default value, and optionally supply the description to be displayed in the help.
    *

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -72,7 +72,7 @@ export class Argument {
    * Make option-argument optional.
    */
   argOptional(): this;
-  }
+}
 
 export class Option {
   flags: string;
@@ -93,6 +93,8 @@ export class Option {
   argChoices?: string[];
 
   constructor(flags: string, description?: string);
+
+  constructor(config: { flags: string; description?: string });
 
   /**
    * Set the default value, and optionally supply the description to be displayed in the help.
@@ -188,7 +190,12 @@ export class Help {
    * Wrap the given string to width characters per line, with lines after the first indented.
    * Do not wrap if insufficient room for wrapping (minColumnWidth), or string is manually formatted.
    */
-  wrap(str: string, width: number, indent: number, minColumnWidth?: number): string;
+  wrap(
+    str: string,
+    width: number,
+    indent: number,
+    minColumnWidth?: number
+  ): string;
 
   /** Generate the built-in help text. */
   formatHelp(cmd: Command, helper: Help): string;
@@ -196,12 +203,14 @@ export class Help {
 export type HelpConfiguration = Partial<Help>;
 
 export interface ParseOptions {
-  from: 'node' | 'electron' | 'user';
+  from: "node" | "electron" | "user";
 }
-export interface HelpContext { // optional parameter for .help() and .outputHelp()
+export interface HelpContext {
+  // optional parameter for .help() and .outputHelp()
   error: boolean;
 }
-export interface AddHelpTextContext { // passed to text function used with .addHelpText()
+export interface AddHelpTextContext {
+  // passed to text function used with .addHelpText()
   error: boolean;
   command: Command;
 }
@@ -211,12 +220,11 @@ export interface OutputConfiguration {
   getOutHelpWidth?(): number;
   getErrHelpWidth?(): number;
   outputError?(str: string, write: (str: string) => void): void;
-
 }
 
-export type AddHelpTextPosition = 'beforeAll' | 'before' | 'after' | 'afterAll';
-export type HookEvent = 'preAction' | 'postAction';
-export type OptionValueSource = 'default' | 'env' | 'config' | 'cli';
+export type AddHelpTextPosition = "beforeAll" | "before" | "after" | "afterAll";
+export type HookEvent = "preAction" | "postAction";
+export type OptionValueSource = "default" | "env" | "config" | "cli";
 
 export interface OptionValues {
   [key: string]: any;
@@ -260,7 +268,10 @@ export class Command {
    * @param opts - configuration options
    * @returns new command
    */
-  command(nameAndArgs: string, opts?: CommandOptions): ReturnType<this['createCommand']>;
+  command(
+    nameAndArgs: string,
+    opts?: CommandOptions
+  ): ReturnType<this["createCommand"]>;
   /**
    * Define a command, implemented in a separate executable file.
    *
@@ -279,7 +290,11 @@ export class Command {
    * @param opts - configuration options
    * @returns `this` command for chaining
    */
-  command(nameAndArgs: string, description: string, opts?: ExecutableCommandOptions): this;
+  command(
+    nameAndArgs: string,
+    description: string,
+    opts?: ExecutableCommandOptions
+  ): this;
 
   /**
    * Factory routine to create a new unattached command.
@@ -320,8 +335,13 @@ export class Command {
    *
    * @returns `this` command for chaining
    */
-    argument<T>(flags: string, description: string, fn: (value: string, previous: T) => T, defaultValue?: T): this;
-    argument(name: string, description?: string, defaultValue?: unknown): this;
+  argument<T>(
+    flags: string,
+    description: string,
+    fn: (value: string, previous: T) => T,
+    defaultValue?: T
+  ): this;
+  argument(name: string, description?: string, defaultValue?: unknown): this;
 
   /**
    * Define argument syntax for command, adding a prepared argument.
@@ -356,17 +376,26 @@ export class Command {
    *
    * @returns `this` command for chaining
    */
-  addHelpCommand(enableOrNameAndArgs?: string | boolean, description?: string): this;
+  addHelpCommand(
+    enableOrNameAndArgs?: string | boolean,
+    description?: string
+  ): this;
 
   /**
    * Add hook for life cycle event.
    */
-  hook(event: HookEvent, listener: (thisCommand: Command, actionCommand: Command) => void | Promise<void>): this;
+  hook(
+    event: HookEvent,
+    listener: (
+      thisCommand: Command,
+      actionCommand: Command
+    ) => void | Promise<void>
+  ): this;
 
   /**
    * Register callback to use as replacement for calling process.exit.
    */
-  exitOverride(callback?: (err: CommanderError) => never|void): this;
+  exitOverride(callback?: (err: CommanderError) => never | void): this;
 
   /**
    * You can customise the help with a subclass of Help by overriding createHelp,
@@ -419,7 +448,7 @@ export class Command {
    */
   showSuggestionAfterError(displaySuggestion?: boolean): this;
 
-   /**
+  /**
    * Register callback `fn` for the command.
    *
    * @example
@@ -480,10 +509,24 @@ export class Command {
    *
    * @returns `this` command for chaining
    */
-  option(flags: string, description?: string, defaultValue?: string | boolean): this;
-  option<T>(flags: string, description: string, fn: (value: string, previous: T) => T, defaultValue?: T): this;
+  option(
+    flags: string,
+    description?: string,
+    defaultValue?: string | boolean
+  ): this;
+  option<T>(
+    flags: string,
+    description: string,
+    fn: (value: string, previous: T) => T,
+    defaultValue?: T
+  ): this;
   /** @deprecated since v7, instead use choices or a custom function */
-  option(flags: string, description: string, regexp: RegExp, defaultValue?: string | boolean): this;
+  option(
+    flags: string,
+    description: string,
+    regexp: RegExp,
+    defaultValue?: string | boolean
+  ): this;
 
   /**
    * Define a required option, which must have a value after parsing. This usually means
@@ -491,10 +534,24 @@ export class Command {
    *
    * The `flags` string contains the short and/or long flags, separated by comma, a pipe or space.
    */
-  requiredOption(flags: string, description?: string, defaultValue?: string | boolean): this;
-  requiredOption<T>(flags: string, description: string, fn: (value: string, previous: T) => T, defaultValue?: T): this;
+  requiredOption(
+    flags: string,
+    description?: string,
+    defaultValue?: string | boolean
+  ): this;
+  requiredOption<T>(
+    flags: string,
+    description: string,
+    fn: (value: string, previous: T) => T,
+    defaultValue?: T
+  ): this;
   /** @deprecated since v7, instead use choices or a custom function */
-  requiredOption(flags: string, description: string, regexp: RegExp, defaultValue?: string | boolean): this;
+  requiredOption(
+    flags: string,
+    description: string,
+    regexp: RegExp,
+    defaultValue?: string | boolean
+  ): this;
 
   /**
    * Factory routine to create a new unattached option.
@@ -519,7 +576,9 @@ export class Command {
    * @returns `this` command for chaining
    */
   storeOptionsAsProperties<T extends OptionValues>(): this & T;
-  storeOptionsAsProperties<T extends OptionValues>(storeAsProperties: true): this & T;
+  storeOptionsAsProperties<T extends OptionValues>(
+    storeAsProperties: true
+  ): this & T;
   storeOptionsAsProperties(storeAsProperties?: boolean): this;
 
   /**
@@ -535,14 +594,18 @@ export class Command {
   /**
    * Store option value and where the value came from.
    */
-  setOptionValueWithSource(key: string, value: unknown, source: OptionValueSource): this;
+  setOptionValueWithSource(
+    key: string,
+    value: unknown,
+    source: OptionValueSource
+  ): this;
 
   /**
    * Retrieve option value source.
    */
   getOptionValueSource(key: string): OptionValueSource;
 
-   /**
+  /**
    * Alter parsing of short flags with optional values.
    *
    * @example
@@ -652,7 +715,10 @@ export class Command {
 
   description(str: string): this;
   /** @deprecated since v8, instead use .argument to add command argument with description */
-  description(str: string, argsDescription: {[argName: string]: string}): this;
+  description(
+    str: string,
+    argsDescription: { [argName: string]: string }
+  ): this;
   /**
    * Get the description.
    */
@@ -744,7 +810,10 @@ export class Command {
    * and 'beforeAll' or 'afterAll' to affect this command and all its subcommands.
    */
   addHelpText(position: AddHelpTextPosition, text: string): this;
-  addHelpText(position: AddHelpTextPosition, text: (context: AddHelpTextContext) => string): this;
+  addHelpText(
+    position: AddHelpTextPosition,
+    text: (context: AddHelpTextContext) => string
+  ): this;
 
   /**
    * Add a listener (callback) for when events occur. (Implemented using EventEmitter.)

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -1,5 +1,5 @@
-import * as commander from './index';
-import {expectType} from 'tsd';
+import * as commander from "./index";
+import { expectType } from "tsd";
 
 // We are are not just checking return types here, we are also implicitly checking that the expected syntax is allowed.
 
@@ -14,14 +14,20 @@ expectType<commander.Command>(commander.program);
 
 // Check export classes and functions exist
 expectType<commander.Command>(new commander.Command());
-expectType<commander.Command>(new commander.Command('name'));
-expectType<commander.Option>(new commander.Option('-f'));
-expectType<commander.CommanderError>(new commander.CommanderError(1, 'code', 'message'));
-expectType<commander.InvalidArgumentError>(new commander.InvalidArgumentError('message'));
-expectType<commander.InvalidArgumentError>(new commander.InvalidOptionArgumentError('message'));
+expectType<commander.Command>(new commander.Command("name"));
+expectType<commander.Option>(new commander.Option("-f"));
+expectType<commander.CommanderError>(
+  new commander.CommanderError(1, "code", "message")
+);
+expectType<commander.InvalidArgumentError>(
+  new commander.InvalidArgumentError("message")
+);
+expectType<commander.InvalidArgumentError>(
+  new commander.InvalidOptionArgumentError("message")
+);
 expectType<commander.Command>(commander.createCommand());
-expectType<commander.Option>(commander.createOption('--demo'));
-expectType<commander.Argument>(commander.createArgument('<foo>'));
+expectType<commander.Option>(commander.createOption("--demo"));
+expectType<commander.Argument>(commander.createArgument("<foo>"));
 
 // Command properties
 expectType<string[]>(program.args);
@@ -31,69 +37,100 @@ expectType<commander.Command[]>(program.commands);
 expectType<commander.Command | null>(program.parent);
 
 // version
-expectType<commander.Command>(program.version('1.2.3'));
-expectType<commander.Command>(program.version('1.2.3', '-r,--revision'));
-expectType<commander.Command>(program.version('1.2.3', '-r,--revision', 'show revision information'));
+expectType<commander.Command>(program.version("1.2.3"));
+expectType<commander.Command>(program.version("1.2.3", "-r,--revision"));
+expectType<commander.Command>(
+  program.version("1.2.3", "-r,--revision", "show revision information")
+);
 
 // command (and CommandOptions)
-expectType<commander.Command>(program.command('action'));
-expectType<commander.Command>(program.command('action', { isDefault: true, hidden: true, noHelp: true }));
-expectType<commander.Command>(program.command('exec', 'exec description'));
-expectType<commander.Command>(program.command('exec', 'exec description', { isDefault: true, hidden: true, noHelp: true, executableFile: 'foo' }));
+expectType<commander.Command>(program.command("action"));
+expectType<commander.Command>(
+  program.command("action", { isDefault: true, hidden: true, noHelp: true })
+);
+expectType<commander.Command>(program.command("exec", "exec description"));
+expectType<commander.Command>(
+  program.command("exec", "exec description", {
+    isDefault: true,
+    hidden: true,
+    noHelp: true,
+    executableFile: "foo",
+  })
+);
 
 // addCommand
-expectType<commander.Command>(program.addCommand(new commander.Command('abc')));
+expectType<commander.Command>(program.addCommand(new commander.Command("abc")));
 
 // argument
-expectType<commander.Command>(program.argument('<value>'));
-expectType<commander.Command>(program.argument('<value>', 'description'));
-expectType<commander.Command>(program.argument('[value]', 'description', 'default'));
-expectType<commander.Command>(program.argument('[value]', 'description', parseFloat));
-expectType<commander.Command>(program.argument('[value]', 'description', parseFloat, 1.23));
+expectType<commander.Command>(program.argument("<value>"));
+expectType<commander.Command>(program.argument("<value>", "description"));
+expectType<commander.Command>(
+  program.argument("[value]", "description", "default")
+);
+expectType<commander.Command>(
+  program.argument("[value]", "description", parseFloat)
+);
+expectType<commander.Command>(
+  program.argument("[value]", "description", parseFloat, 1.23)
+);
 
 // arguments
-expectType<commander.Command>(program.arguments('<cmd> [env]'));
+expectType<commander.Command>(program.arguments("<cmd> [env]"));
 
 // addHelpCommand
 expectType<commander.Command>(program.addHelpCommand());
 expectType<commander.Command>(program.addHelpCommand(false));
 expectType<commander.Command>(program.addHelpCommand(true));
-expectType<commander.Command>(program.addHelpCommand('compress <file>'));
-expectType<commander.Command>(program.addHelpCommand('compress <file>', 'compress target file'));
+expectType<commander.Command>(program.addHelpCommand("compress <file>"));
+expectType<commander.Command>(
+  program.addHelpCommand("compress <file>", "compress target file")
+);
 
 // exitOverride
 expectType<commander.Command>(program.exitOverride());
-expectType<commander.Command>(program.exitOverride((err): never => {
-  return process.exit(err.exitCode);
-}));
-expectType<commander.Command>(program.exitOverride((err): void => {
-  if (err.code !== 'commander.executeSubCommandAsync') {
-    throw err;
-  } else {
-    // Async callback from spawn events, not useful to throw.
-  }
-}));
+expectType<commander.Command>(
+  program.exitOverride((err): never => {
+    return process.exit(err.exitCode);
+  })
+);
+expectType<commander.Command>(
+  program.exitOverride((err): void => {
+    if (err.code !== "commander.executeSubCommandAsync") {
+      throw err;
+    } else {
+      // Async callback from spawn events, not useful to throw.
+    }
+  })
+);
 
 // hook
-expectType<commander.Command>(program.hook('preAction', () => {}));
-expectType<commander.Command>(program.hook('postAction', () => {}));
-expectType<commander.Command>(program.hook('preAction', async() => {}));
-expectType<commander.Command>(program.hook('preAction', (thisCommand, actionCommand) => {
-  // implicit parameter types
-  expectType<commander.Command>(thisCommand);
-  expectType<commander.Command>(actionCommand);
-}));
+expectType<commander.Command>(program.hook("preAction", () => {}));
+expectType<commander.Command>(program.hook("postAction", () => {}));
+expectType<commander.Command>(program.hook("preAction", async () => {}));
+expectType<commander.Command>(
+  program.hook("preAction", (thisCommand, actionCommand) => {
+    // implicit parameter types
+    expectType<commander.Command>(thisCommand);
+    expectType<commander.Command>(actionCommand);
+  })
+);
 
 // action
 expectType<commander.Command>(program.action(() => {}));
-expectType<commander.Command>(program.action(async() => {}));
+expectType<commander.Command>(program.action(async () => {}));
 
 // option
-expectType<commander.Command>(program.option('-a,--alpha'));
-expectType<commander.Command>(program.option('-p, --peppers', 'Add peppers'));
-expectType<commander.Command>(program.option('-s, --string [value]', 'default string', 'value'));
-expectType<commander.Command>(program.option('-b, --boolean', 'default boolean', false));
-expectType<commander.Command>(program.option('--drink <size', 'drink size', /small|medium|large/)); // deprecated
+expectType<commander.Command>(program.option("-a,--alpha"));
+expectType<commander.Command>(program.option("-p, --peppers", "Add peppers"));
+expectType<commander.Command>(
+  program.option("-s, --string [value]", "default string", "value")
+);
+expectType<commander.Command>(
+  program.option("-b, --boolean", "default boolean", false)
+);
+expectType<commander.Command>(
+  program.option("--drink <size", "drink size", /small|medium|large/)
+); // deprecated
 
 // example coercion functions from README
 
@@ -110,56 +147,139 @@ function collect(value: string, previous: string[]): string[] {
 }
 
 function commaSeparatedList(value: string): string[] {
-  return value.split(',');
+  return value.split(",");
 }
 
-expectType<commander.Command>(program.option('-f, --float <number>', 'float argument', parseFloat));
-expectType<commander.Command>(program.option('-f, --float <number>', 'float argument', parseFloat, 3.2));
-expectType<commander.Command>(program.option('-i, --integer <number>', 'integer argument', myParseInt));
-expectType<commander.Command>(program.option('-i, --integer <number>', 'integer argument', myParseInt, 5));
-expectType<commander.Command>(program.option('-v, --verbose', 'verbosity that can be increased', increaseVerbosity, 0));
-expectType<commander.Command>(program.option('-c, --collect <value>', 'repeatable value', collect, []));
-expectType<commander.Command>(program.option('-l, --list <items>', 'comma separated list', commaSeparatedList));
+expectType<commander.Command>(
+  program.option("-f, --float <number>", "float argument", parseFloat)
+);
+expectType<commander.Command>(
+  program.option("-f, --float <number>", "float argument", parseFloat, 3.2)
+);
+expectType<commander.Command>(
+  program.option("-i, --integer <number>", "integer argument", myParseInt)
+);
+expectType<commander.Command>(
+  program.option("-i, --integer <number>", "integer argument", myParseInt, 5)
+);
+expectType<commander.Command>(
+  program.option(
+    "-v, --verbose",
+    "verbosity that can be increased",
+    increaseVerbosity,
+    0
+  )
+);
+expectType<commander.Command>(
+  program.option("-c, --collect <value>", "repeatable value", collect, [])
+);
+expectType<commander.Command>(
+  program.option(
+    "-l, --list <items>",
+    "comma separated list",
+    commaSeparatedList
+  )
+);
 
 // requiredOption, same tests as option
-expectType<commander.Command>(program.requiredOption('-a,--alpha'));
-expectType<commander.Command>(program.requiredOption('-p, --peppers', 'Add peppers'));
-expectType<commander.Command>(program.requiredOption('-s, --string [value]', 'default string', 'value'));
-expectType<commander.Command>(program.requiredOption('-b, --boolean', 'default boolean', false));
-expectType<commander.Command>(program.requiredOption('--drink <size', 'drink size', /small|medium|large/)); // deprecated
+expectType<commander.Command>(program.requiredOption("-a,--alpha"));
+expectType<commander.Command>(
+  program.requiredOption("-p, --peppers", "Add peppers")
+);
+expectType<commander.Command>(
+  program.requiredOption("-s, --string [value]", "default string", "value")
+);
+expectType<commander.Command>(
+  program.requiredOption("-b, --boolean", "default boolean", false)
+);
+expectType<commander.Command>(
+  program.requiredOption("--drink <size", "drink size", /small|medium|large/)
+); // deprecated
 
-expectType<commander.Command>(program.requiredOption('-f, --float <number>', 'float argument', parseFloat));
-expectType<commander.Command>(program.requiredOption('-f, --float <number>', 'float argument', parseFloat, 3.2));
-expectType<commander.Command>(program.requiredOption('-i, --integer <number>', 'integer argument', myParseInt));
-expectType<commander.Command>(program.requiredOption('-i, --integer <number>', 'integer argument', myParseInt, 5));
-expectType<commander.Command>(program.requiredOption('-v, --verbose', 'verbosity that can be increased', increaseVerbosity, 0));
-expectType<commander.Command>(program.requiredOption('-c, --collect <value>', 'repeatable value', collect, []));
-expectType<commander.Command>(program.requiredOption('-l, --list <items>', 'comma separated list', commaSeparatedList));
+expectType<commander.Command>(
+  program.requiredOption("-f, --float <number>", "float argument", parseFloat)
+);
+expectType<commander.Command>(
+  program.requiredOption(
+    "-f, --float <number>",
+    "float argument",
+    parseFloat,
+    3.2
+  )
+);
+expectType<commander.Command>(
+  program.requiredOption(
+    "-i, --integer <number>",
+    "integer argument",
+    myParseInt
+  )
+);
+expectType<commander.Command>(
+  program.requiredOption(
+    "-i, --integer <number>",
+    "integer argument",
+    myParseInt,
+    5
+  )
+);
+expectType<commander.Command>(
+  program.requiredOption(
+    "-v, --verbose",
+    "verbosity that can be increased",
+    increaseVerbosity,
+    0
+  )
+);
+expectType<commander.Command>(
+  program.requiredOption(
+    "-c, --collect <value>",
+    "repeatable value",
+    collect,
+    []
+  )
+);
+expectType<commander.Command>(
+  program.requiredOption(
+    "-l, --list <items>",
+    "comma separated list",
+    commaSeparatedList
+  )
+);
 
 // createOption
-expectType<commander.Option>(program.createOption('a, --alpha'));
-expectType<commander.Option>(program.createOption('a, --alpha', 'description'));
+expectType<commander.Option>(program.createOption("a, --alpha"));
+expectType<commander.Option>(program.createOption("a, --alpha", "description"));
 
 // addOption
-expectType<commander.Command>(program.addOption(new commander.Option('-s,--simple')));
+expectType<commander.Command>(
+  program.addOption(new commander.Option("-s,--simple"))
+);
 
 // storeOptionsAsProperties
-expectType<commander.Command & commander.OptionValues>(program.storeOptionsAsProperties());
-expectType<commander.Command & commander.OptionValues>(program.storeOptionsAsProperties(true));
+expectType<commander.Command & commander.OptionValues>(
+  program.storeOptionsAsProperties()
+);
+expectType<commander.Command & commander.OptionValues>(
+  program.storeOptionsAsProperties(true)
+);
 expectType<commander.Command>(program.storeOptionsAsProperties(false));
 
 // getOptionValue
-void program.getOptionValue('example');
+void program.getOptionValue("example");
 
 // setOptionValue
-expectType<commander.Command>(program.setOptionValue('example', 'value'));
-expectType<commander.Command>(program.setOptionValue('example', true));
+expectType<commander.Command>(program.setOptionValue("example", "value"));
+expectType<commander.Command>(program.setOptionValue("example", true));
 
 // setOptionValueWithSource
-expectType<commander.Command>(program.setOptionValueWithSource('example', [], 'cli'));
+expectType<commander.Command>(
+  program.setOptionValueWithSource("example", [], "cli")
+);
 
 // getOptionValueSource
-expectType<commander.OptionValueSource>(program.getOptionValueSource('example'));
+expectType<commander.OptionValueSource>(
+  program.getOptionValueSource("example")
+);
 
 // combineFlagAndOptionalValue
 expectType<commander.Command>(program.combineFlagAndOptionalValue());
@@ -184,25 +304,37 @@ expectType<commander.Command>(program.passThroughOptions(false));
 // parse
 expectType<commander.Command>(program.parse());
 expectType<commander.Command>(program.parse(process.argv));
-expectType<commander.Command>(program.parse(['node', 'script.js'], { from: 'node' }));
-expectType<commander.Command>(program.parse(['node', 'script.js'], { from: 'electron' }));
-expectType<commander.Command>(program.parse(['--option'], { from: 'user' }));
+expectType<commander.Command>(
+  program.parse(["node", "script.js"], { from: "node" })
+);
+expectType<commander.Command>(
+  program.parse(["node", "script.js"], { from: "electron" })
+);
+expectType<commander.Command>(program.parse(["--option"], { from: "user" }));
 
 // parseAsync, same tests as parse
 expectType<Promise<commander.Command>>(program.parseAsync());
 expectType<Promise<commander.Command>>(program.parseAsync(process.argv));
-expectType<Promise<commander.Command>>(program.parseAsync(['node', 'script.js'], { from: 'node' }));
-expectType<Promise<commander.Command>>(program.parseAsync(['node', 'script.js'], { from: 'electron' }));
-expectType<Promise<commander.Command>>(program.parseAsync(['--option'], { from: 'user' }));
+expectType<Promise<commander.Command>>(
+  program.parseAsync(["node", "script.js"], { from: "node" })
+);
+expectType<Promise<commander.Command>>(
+  program.parseAsync(["node", "script.js"], { from: "electron" })
+);
+expectType<Promise<commander.Command>>(
+  program.parseAsync(["--option"], { from: "user" })
+);
 
 // parseOptions (and ParseOptionsResult)
-expectType<{operands: string[]; unknown: string[]}>(program.parseOptions(['node', 'script.js', 'hello']));
+expectType<{ operands: string[]; unknown: string[] }>(
+  program.parseOptions(["node", "script.js", "hello"])
+);
 
 // opts
 const opts = program.opts();
 expectType<commander.OptionValues>(opts);
 expectType(opts.foo);
-expectType(opts['bar']);
+expectType(opts["bar"]);
 
 // opts with generics
 interface MyCheeseOption {
@@ -214,34 +346,46 @@ expectType<string>(myCheeseOption.cheese);
 expectType(myCheeseOption.foo);
 
 // description
-expectType<commander.Command>(program.description('my description'));
+expectType<commander.Command>(program.description("my description"));
 expectType<string>(program.description());
-expectType<commander.Command>(program.description('my description of command with arg foo', { foo: 'foo description'})); // deprecated
+expectType<commander.Command>(
+  program.description("my description of command with arg foo", {
+    foo: "foo description",
+  })
+); // deprecated
 
 // alias
-expectType<commander.Command>(program.alias('my alias'));
+expectType<commander.Command>(program.alias("my alias"));
 expectType<string>(program.alias());
 
 // aliases
-expectType<commander.Command>(program.aliases(['first-alias', 'second-alias']));
+expectType<commander.Command>(program.aliases(["first-alias", "second-alias"]));
 expectType<string[]>(program.aliases());
 
 // usage
-expectType<commander.Command>(program.usage('my usage'));
+expectType<commander.Command>(program.usage("my usage"));
 expectType<string>(program.usage());
 
 // name
-expectType<commander.Command>(program.name('my-name'));
+expectType<commander.Command>(program.name("my-name"));
 expectType<string>(program.name());
 
 // outputHelp
 expectType<void>(program.outputHelp());
-expectType<void>(program.outputHelp((str: string) => { return str; }));
+expectType<void>(
+  program.outputHelp((str: string) => {
+    return str;
+  })
+);
 expectType<void>(program.outputHelp({ error: true }));
 
 // help
 expectType<never>(program.help());
-expectType<never>(program.help((str: string) => { return str; }));
+expectType<never>(
+  program.help((str: string) => {
+    return str;
+  })
+);
 expectType<never>(program.help({ error: true }));
 
 // helpInformation
@@ -249,27 +393,33 @@ expectType<string>(program.helpInformation());
 expectType<string>(program.helpInformation({ error: true }));
 
 // helpOption
-expectType<commander.Command>(program.helpOption('-h,--help'));
-expectType<commander.Command>(program.helpOption('-h,--help', 'custom description'));
-expectType<commander.Command>(program.helpOption(undefined, 'custom description'));
+expectType<commander.Command>(program.helpOption("-h,--help"));
+expectType<commander.Command>(
+  program.helpOption("-h,--help", "custom description")
+);
+expectType<commander.Command>(
+  program.helpOption(undefined, "custom description")
+);
 expectType<commander.Command>(program.helpOption(false));
 
 // addHelpText
-expectType<commander.Command>(program.addHelpText('after', 'text'));
-expectType<commander.Command>(program.addHelpText('afterAll', 'text'));
-expectType<commander.Command>(program.addHelpText('before', () => 'before'));
-expectType<commander.Command>(program.addHelpText('beforeAll', (context) => {
-  expectType<boolean>(context.error);
-  expectType<commander.Command>(context.command);
-  return '';
-}));
+expectType<commander.Command>(program.addHelpText("after", "text"));
+expectType<commander.Command>(program.addHelpText("afterAll", "text"));
+expectType<commander.Command>(program.addHelpText("before", () => "before"));
+expectType<commander.Command>(
+  program.addHelpText("beforeAll", (context) => {
+    expectType<boolean>(context.error);
+    expectType<commander.Command>(context.command);
+    return "";
+  })
+);
 
 // on
-expectType<commander.Command>(program.on('command:foo', () => {}));
+expectType<commander.Command>(program.on("command:foo", () => {}));
 
 // createCommand
 expectType<commander.Command>(program.createCommand());
-expectType<commander.Command>(program.createCommand('name'));
+expectType<commander.Command>(program.createCommand("name"));
 
 class MyCommand extends commander.Command {
   createCommand(name?: string): MyCommand {
@@ -281,45 +431,57 @@ class MyCommand extends commander.Command {
   }
 }
 const myProgram = new MyCommand();
-expectType<MyCommand>(myProgram.command('sub'));
+expectType<MyCommand>(myProgram.command("sub"));
 
 // configureHelp
 expectType<commander.Help>(program.createHelp());
-expectType<commander.Command>(program.configureHelp({
-  sortSubcommands: true, // override property
-  visibleCommands: () => [] // override method
-}));
+expectType<commander.Command>(
+  program.configureHelp({
+    sortSubcommands: true, // override property
+    visibleCommands: () => [], // override method
+  })
+);
 expectType<commander.HelpConfiguration>(program.configureHelp());
 
 // copyInheritedSettings
-expectType<commander.Command>(program.copyInheritedSettings(new commander.Command()));
+expectType<commander.Command>(
+  program.copyInheritedSettings(new commander.Command())
+);
 
 // showHelpAfterError
 expectType<commander.Command>(program.showHelpAfterError());
 expectType<commander.Command>(program.showHelpAfterError(true));
-expectType<commander.Command>(program.showHelpAfterError('See --help'));
+expectType<commander.Command>(program.showHelpAfterError("See --help"));
 
 // showSuggestionAfterError
 expectType<commander.Command>(program.showSuggestionAfterError());
 expectType<commander.Command>(program.showSuggestionAfterError(false));
 
 // configureOutput
-expectType<commander.Command>(program.configureOutput({ }));
+expectType<commander.Command>(program.configureOutput({}));
 expectType<commander.OutputConfiguration>(program.configureOutput());
 
-expectType<commander.Command>(program.configureOutput({
-  writeOut: (str: string) => console.log(str),
-  writeErr: (str: string) => console.error(str),
-  getOutHelpWidth: () => 80,
-  getErrHelpWidth: () => 80,
-  outputError: (str: string, write: (str: string) => void) => { write(str); }
-}));
+expectType<commander.Command>(
+  program.configureOutput({
+    writeOut: (str: string) => console.log(str),
+    writeErr: (str: string) => console.error(str),
+    getOutHelpWidth: () => 80,
+    getErrHelpWidth: () => 80,
+    outputError: (str: string, write: (str: string) => void) => {
+      write(str);
+    },
+  })
+);
 
 // Help
+const config = {
+  flags: "-a, -all",
+};
 const helper = new commander.Help();
 const helperCommand = new commander.Command();
-const helperOption = new commander.Option('-a, --all');
-const helperArgument = new commander.Argument('<file>');
+const helperOptionString = new commander.Option("-a, --all");
+const helperOptionConfig = new commander.Option(config);
+const helperArgument = new commander.Argument("<file>");
 
 expectType<number | undefined>(helper.helpWidth);
 expectType<boolean>(helper.sortSubcommands);
@@ -329,8 +491,10 @@ expectType<string>(helper.subcommandTerm(helperCommand));
 expectType<string>(helper.commandUsage(helperCommand));
 expectType<string>(helper.commandDescription(helperCommand));
 expectType<string>(helper.subcommandDescription(helperCommand));
-expectType<string>(helper.optionTerm(helperOption));
-expectType<string>(helper.optionDescription(helperOption));
+expectType<string>(helper.optionTerm(helperOptionString));
+expectType<string>(helper.optionDescription(helperOptionString));
+expectType<string>(helper.optionTerm(helperOptionConfig));
+expectType<string>(helper.optionDescription(helperOptionConfig));
 expectType<string>(helper.argumentTerm(helperArgument));
 expectType<string>(helper.argumentDescription(helperArgument));
 
@@ -343,27 +507,33 @@ expectType<number>(helper.longestOptionTermLength(helperCommand, helper));
 expectType<number>(helper.longestArgumentTermLength(helperCommand, helper));
 expectType<number>(helper.padWidth(helperCommand, helper));
 
-expectType<string>(helper.wrap('a b c', 50, 3));
+expectType<string>(helper.wrap("a b c", 50, 3));
 
 expectType<string>(helper.formatHelp(helperCommand, helper));
 
 // Option methods
 
-const baseOption = new commander.Option('-f,--foo', 'foo description');
+const baseOption = new commander.Option("-f,--foo", "foo description");
 
 // default
 expectType<commander.Option>(baseOption.default(3));
-expectType<commander.Option>(baseOption.default(60, 'one minute'));
+expectType<commander.Option>(baseOption.default(60, "one minute"));
 
 // env
-expectType<commander.Option>(baseOption.env('PORT'));
+expectType<commander.Option>(baseOption.env("PORT"));
 
 // fullDescription
 expectType<string>(baseOption.fullDescription());
 
 // argParser
-expectType<commander.Option>(baseOption.argParser((value: string) => parseInt(value)));
-expectType<commander.Option>(baseOption.argParser((value: string, previous: string[]) => { return previous.concat(value); }));
+expectType<commander.Option>(
+  baseOption.argParser((value: string) => parseInt(value))
+);
+expectType<commander.Option>(
+  baseOption.argParser((value: string, previous: string[]) => {
+    return previous.concat(value);
+  })
+);
 
 // makeOptionMandatory
 expectType<commander.Option>(baseOption.makeOptionMandatory());
@@ -375,7 +545,7 @@ expectType<commander.Option>(baseOption.hideHelp(true));
 expectType<commander.Option>(baseOption.hideHelp(false));
 
 // choices
-expectType<commander.Option>(baseOption.choices(['a', 'b']));
+expectType<commander.Option>(baseOption.choices(["a", "b"]));
 
 // name
 expectType<string>(baseOption.name());
@@ -384,7 +554,7 @@ expectType<string>(baseOption.name());
 expectType<string>(baseOption.attributeName());
 
 // Argument properties
-const baseArgument = new commander.Argument('<foo');
+const baseArgument = new commander.Argument("<foo");
 expectType<string>(baseArgument.description);
 expectType<boolean>(baseArgument.required);
 expectType<boolean>(baseArgument.variadic);
@@ -396,14 +566,20 @@ expectType<string>(baseArgument.name());
 
 // default
 expectType<commander.Argument>(baseArgument.default(3));
-expectType<commander.Argument>(baseArgument.default(60, 'one minute'));
+expectType<commander.Argument>(baseArgument.default(60, "one minute"));
 
 // argParser
-expectType<commander.Argument>(baseArgument.argParser((value: string) => parseInt(value)));
-expectType<commander.Argument>(baseArgument.argParser((value: string, previous: string[]) => { return previous.concat(value); }));
+expectType<commander.Argument>(
+  baseArgument.argParser((value: string) => parseInt(value))
+);
+expectType<commander.Argument>(
+  baseArgument.argParser((value: string, previous: string[]) => {
+    return previous.concat(value);
+  })
+);
 
 // choices
-expectType<commander.Argument>(baseArgument.choices(['a', 'b']));
+expectType<commander.Argument>(baseArgument.choices(["a", "b"]));
 
 // argRequired
 expectType<commander.Argument>(baseArgument.argRequired());
@@ -412,5 +588,5 @@ expectType<commander.Argument>(baseArgument.argRequired());
 expectType<commander.Argument>(baseArgument.argOptional());
 
 // createArgument
-expectType<commander.Argument>(program.createArgument('<name>'));
-expectType<commander.Argument>(program.createArgument('<name>', 'description'));
+expectType<commander.Argument>(program.createArgument("<name>"));
+expectType<commander.Argument>(program.createArgument("<name>", "description"));


### PR DESCRIPTION
# Pull Request

<!--
The text in these markdown comments is instructions that will not appear in the displayed pull request,
and can be deleted.

Please submit pull requests against the develop branch.

Follow the existing code style. Check the tests succeed, including lint.
  npm run test
  npm run lint

Don't update the CHANGELOG or command version number. That gets done by maintainers when preparing the release.

Commander currently has zero production dependencies. That isn't a hard requirement, but is a simple story. Requests which 
add a dependency are much less likely to be accepted, and we are likely to ask if there alternative approaches to avoid the dependency.
-->

## Problem
Adding a new form of creating an option object. This is to simplify work when creating multiple options
<!--
What problem are you solving?
What Issues does this relate to?
Show the broken output if appropriate.
-->

## Solution
Use option object to specify the new option with its fields. Later on we can implement a function that can create multiple options from one config object array `[ config1, config2, config3] and save time when creating a new program option.

`index.d.ts`
```typescript
export class Option {
//...
    constructor(config: { flags: string; description?: string });
//...
}
```

`option.js`
```javascript
constructor(config) { // Config object that contains flags and description?
    this.flags = config['flags']; //Adding flags
    this.description = config['description'] || ''; //Adding description

    this.required = flags.includes('<'); // A value must be supplied when the option is specified.
    this.optional = flags.includes('['); // A value is optional when the option is specified.
    // variadic test ignores <value,...> et al which might be used to describe custom splitting of single argument
    this.variadic = /\w\.\.\.[>\]]$/.test(flags); // The option can take multiple values.
    this.mandatory = false; // The option must have a value after parsing, which usually means it must be specified on command line.
    const optionFlags = splitOptionFlags(flags);
    this.short = optionFlags.shortFlag;
    this.long = optionFlags.longFlag;
    this.negate = false;
    if (this.long) {
      this.negate = this.long.startsWith('--no-');
    }
    this.defaultValue = undefined;
    this.defaultValueDescription = undefined;
    this.envVar = undefined;
    this.parseArg = undefined;
    this.hidden = false;
    this.argChoices = undefined;
  }
```

<!--
How did you solve the problem? 
Show the fixed output if appropriate.

There are a lot of forms of documentation which could need updating for a change in functionality. It
is ok if you want to show us the code to discuss before doing the extra work, and
you should say so in your comments so we focus on the concept first before talking about all the other pieces:

- TypeScript typings
- JSDoc documentation in code
- tests
- README
- examples/
-->

## ChangeLog

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->
