### PR TITLE
Rework option defaults and add preset

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -313,7 +313,7 @@ program
   .addOption(new Option('-t, --timeout <delay>', 'timeout in seconds').default(60, 'one minute'))
   .addOption(new Option('-d, --drink <size>', 'drink size').choices(['small', 'medium', 'large']))
   .addOption(new Option('-p, --port <number>', 'port number').env('PORT'))
-  .addOption(new Option('--donate [amount]').preset('20').argParser(parseFloat));
+  .addOption(new Option('--donate [amount]', 'optional donation in dollars').preset('20').argParser(parseFloat));
 ```
 
 ```bash

--- a/Readme.md
+++ b/Readme.md
@@ -330,8 +330,8 @@ Options:
 $ extra --drink huge
 error: option '-d, --drink <size>' argument 'huge' is invalid. Allowed choices are small, medium, large.
 
-$ PORT=80 extra 
-Options:  { timeout: 60, port: '80' }
+$ PORT=80 extra --donate
+Options:  { timeout: 60, donate: 20, port: '80' }
 ```
 
 ### Custom option processing

--- a/Readme.md
+++ b/Readme.md
@@ -146,7 +146,7 @@ pizza details:
 
 ### Default option value
 
-You can specify a default value for an option which takes a value.
+You can specify a default value for an option.
 
 Example file: [options-defaults.js](./examples/options-defaults.js)
 
@@ -172,7 +172,7 @@ You can define a boolean option long name with a leading `no-` to set the option
 Defined alone this also makes the option true by default.
 
 If you define `--foo` first, adding `--no-foo` does not change the default value from what it would
-otherwise be. You can specify a default boolean value for a boolean option and it can be overridden on command line.
+otherwise be.
 
 Example file: [options-negatable.js](./examples/options-negatable.js)
 
@@ -312,7 +312,8 @@ program
   .addOption(new Option('-s, --secret').hideHelp())
   .addOption(new Option('-t, --timeout <delay>', 'timeout in seconds').default(60, 'one minute'))
   .addOption(new Option('-d, --drink <size>', 'drink size').choices(['small', 'medium', 'large']))
-  .addOption(new Option('-p, --port <number>', 'port number').env('PORT'));
+  .addOption(new Option('-p, --port <number>', 'port number').env('PORT'))
+  .addOption(new Option('--donate [amount]').preset('20').argParser(parseFloat));
 ```
 
 ```bash
@@ -323,6 +324,7 @@ Options:
   -t, --timeout <delay>  timeout in seconds (default: one minute)
   -d, --drink <size>     drink cup size (choices: "small", "medium", "large")
   -p, --port <number>    port number (env: PORT)
+  --donate [amount]
   -h, --help             display help for command
 
 $ extra --drink huge

--- a/Readme.md
+++ b/Readme.md
@@ -324,7 +324,7 @@ Options:
   -t, --timeout <delay>  timeout in seconds (default: one minute)
   -d, --drink <size>     drink cup size (choices: "small", "medium", "large")
   -p, --port <number>    port number (env: PORT)
-  --donate [amount]
+  --donate [amount]      optional donation in dollars (preset: 20)
   -h, --help             display help for command
 
 $ extra --drink huge

--- a/examples/options-extra.js
+++ b/examples/options-extra.js
@@ -11,7 +11,8 @@ program
   .addOption(new Option('-s, --secret').hideHelp())
   .addOption(new Option('-t, --timeout <delay>', 'timeout in seconds').default(60, 'one minute'))
   .addOption(new Option('-d, --drink <size>', 'drink cup size').choices(['small', 'medium', 'large']))
-  .addOption(new Option('-p, --port <number>', 'port number').env('PORT'));
+  .addOption(new Option('-p, --port <number>', 'port number').env('PORT'))
+  .addOption(new Option('--donate [amount]').preset('20').argParser(parseFloat));
 
 program.parse();
 
@@ -21,3 +22,5 @@ console.log('Options: ', program.opts());
 //    node options-extra.js --help
 //    node options-extra.js --drink huge
 //    PORT=80 node options-extra.js
+//    node options-extra.js --donate
+//    node options-extra.js --donate 30.50

--- a/examples/options-extra.js
+++ b/examples/options-extra.js
@@ -12,7 +12,7 @@ program
   .addOption(new Option('-t, --timeout <delay>', 'timeout in seconds').default(60, 'one minute'))
   .addOption(new Option('-d, --drink <size>', 'drink cup size').choices(['small', 'medium', 'large']))
   .addOption(new Option('-p, --port <number>', 'port number').env('PORT'))
-  .addOption(new Option('--donate [amount]').preset('20').argParser(parseFloat));
+  .addOption(new Option('--donate [amount]', 'optional donation in dollars').preset('20').argParser(parseFloat));
 
 program.parse();
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -516,17 +516,19 @@ Expecting one of '${allowedValues.join("', '")}'`);
     const oname = option.name();
     const name = option.attributeName();
 
-    // Have three behaviours that overloaded: default value, starting value for custom parse, default optional value
-    let defaultValue = option.defaultValue;
-
-    // preassign default value for --no-*, [optional], <required>, or plain flag if boolean value
-    if (option.negate || option.optional || option.required || typeof defaultValue === 'boolean') {
-      // when --no-foo we make sure default is true, unless a --foo option is already defined
-      if (option.negate) {
-        const positiveLongFlag = option.long.replace(/^--no-/, '--');
-        defaultValue = this._findOption(positiveLongFlag) ? this.getOptionValue(name) : true;
+    const defaultValue = option.defaultValue;
+    if (option.isBoolean()) {
+      if (typeof defaultValue === 'boolean') {
+        this.setOptionValueWithSource(name, defaultValue, 'default');
       }
-      // preassign only if we have a default
+      // else magic, treated as implicit value ????
+    } else if (option.negate) {
+      // when --no-foo we make sure default is true, unless a --foo option is already defined
+      const positiveLongFlag = option.long.replace(/^--no-/, '--');
+      if (!this._findOption(positiveLongFlag)) {
+        this.setOptionValueWithSource(name, true, 'default');
+      }
+    } else if (option.optional || option.required) {
       if (defaultValue !== undefined) {
         this.setOptionValueWithSource(name, defaultValue, 'default');
       }

--- a/lib/command.js
+++ b/lib/command.js
@@ -561,7 +561,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
         } else if (option.isBoolean() || option.optional) {
           val = true;
         } else {
-          val = ''; // not normal, parse might have failed or be a mock function for testing
+          val = ''; // not normal, parseArg might have failed or be a mock function for testing
         }
       }
       this.setOptionValueWithSource(name, val, valueSource);

--- a/lib/command.js
+++ b/lib/command.js
@@ -518,10 +518,10 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
     // store default value
     if (option.negate) {
-      // --no-foo is special and defaults to true, unless a --foo option is already defined
+      // --no-foo is special and defaults foo to true, unless a --foo option is already defined
       const positiveLongFlag = option.long.replace(/^--no-/, '--');
       if (!this._findOption(positiveLongFlag)) {
-        this.setOptionValueWithSource(name, true, 'default');
+        this.setOptionValueWithSource(name, option.defaultValue === undefined ? true : option.defaultValue, 'default');
       }
     } else if (option.defaultValue !== undefined) {
       this.setOptionValueWithSource(name, option.defaultValue, 'default');

--- a/lib/command.js
+++ b/lib/command.js
@@ -516,6 +516,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     const oname = option.name();
     const name = option.attributeName();
 
+    // Have three behaviours that overloaded: default value, starting value for custom parse, default optional value
     let defaultValue = option.defaultValue;
 
     // preassign default value for --no-*, [optional], <required>, or plain flag if boolean value

--- a/lib/command.js
+++ b/lib/command.js
@@ -516,24 +516,15 @@ Expecting one of '${allowedValues.join("', '")}'`);
     const oname = option.name();
     const name = option.attributeName();
 
-    // store default value if appropriate
-    const defaultValue = option.defaultValue;
-    if (option.isBoolean()) {
-      // support boolean default to allow setting from environment (predates .env())
-      if (typeof defaultValue === 'boolean') {
-        this.setOptionValueWithSource(name, defaultValue, 'default');
-      }
-    } else if (option.negate) {
-      // when --no-foo we make sure default is true, unless a --foo option is already defined
+    // store default value
+    if (option.negate) {
+      // --no-foo is special and defaults to true, unless a --foo option is already defined
       const positiveLongFlag = option.long.replace(/^--no-/, '--');
       if (!this._findOption(positiveLongFlag)) {
         this.setOptionValueWithSource(name, true, 'default');
       }
-    } else {
-      // (option.optional || option.required)
-      if (defaultValue !== undefined) {
-        this.setOptionValueWithSource(name, defaultValue, 'default');
-      }
+    } else if (option.defaultValue !== undefined) {
+      this.setOptionValueWithSource(name, option.defaultValue, 'default');
     }
 
     // register the option
@@ -541,13 +532,17 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
     // handler for cli and env supplied values
     const handleOptionValue = (val, invalidValueMessage, valueSource) => {
-      // Note: using closure to access lots of lexical scoped variables.
-      const oldValue = this.getOptionValue(name);
+      // val is null for optional option used without an optional-argument.
+      // val is undefined for boolean and negated option.
+      if (val == null && option.presetArg !== undefined) {
+        val = option.presetArg;
+      }
 
       // custom processing
+      const oldValue = this.getOptionValue(name);
       if (val !== null && option.parseArg) {
         try {
-          val = option.parseArg(val, oldValue === undefined ? defaultValue : oldValue);
+          val = option.parseArg(val, oldValue);
         } catch (err) {
           if (err.code === 'commander.invalidArgument') {
             const message = `${invalidValueMessage} ${err.message}`;
@@ -559,18 +554,17 @@ Expecting one of '${allowedValues.join("', '")}'`);
         val = option._concatValue(val, oldValue);
       }
 
-      // unassigned or boolean value
-      if (typeof oldValue === 'boolean' || typeof oldValue === 'undefined') {
-        // if no value, negate false, and we have a default, then use it!
-        if (val == null) {
-          this.setOptionValueWithSource(name, option.negate ? false : defaultValue || true, valueSource);
+      // Fill-in appropriate missing values. Long winded but easy to follow.
+      if (val == null) {
+        if (option.negate) {
+          val = false;
+        } else if (option.isBoolean() || option.optional) {
+          val = true;
         } else {
-          this.setOptionValueWithSource(name, val, valueSource);
+          val = ''; // not normal, parse might have failed or be a mock function for testing
         }
-      } else if (val !== null) {
-        // reassign
-        this.setOptionValueWithSource(name, option.negate ? false : val, valueSource);
       }
+      this.setOptionValueWithSource(name, val, valueSource);
     };
 
     this.on('option:' + oname, (val) => {

--- a/lib/command.js
+++ b/lib/command.js
@@ -516,19 +516,21 @@ Expecting one of '${allowedValues.join("', '")}'`);
     const oname = option.name();
     const name = option.attributeName();
 
+    // store default value if appropriate
     const defaultValue = option.defaultValue;
     if (option.isBoolean()) {
+      // support boolean default to allow setting from environment (predates .env())
       if (typeof defaultValue === 'boolean') {
         this.setOptionValueWithSource(name, defaultValue, 'default');
       }
-      // else magic, treated as implicit value ????
     } else if (option.negate) {
       // when --no-foo we make sure default is true, unless a --foo option is already defined
       const positiveLongFlag = option.long.replace(/^--no-/, '--');
       if (!this._findOption(positiveLongFlag)) {
         this.setOptionValueWithSource(name, true, 'default');
       }
-    } else if (option.optional || option.required) {
+    } else {
+      // (option.optional || option.required)
       if (defaultValue !== undefined) {
         this.setOptionValueWithSource(name, defaultValue, 'default');
       }

--- a/lib/help.js
+++ b/lib/help.js
@@ -246,7 +246,7 @@ class Help {
       extraInfo.push(`default: ${option.defaultValueDescription || JSON.stringify(option.defaultValue)}`);
     }
     if (option.presetArg !== undefined) {
-      extraInfo.push(`preset: ${option.presetArg}`);
+      extraInfo.push(`preset: ${JSON.stringify(option.presetArg)}`);
     }
     if (option.envVar !== undefined) {
       extraInfo.push(`env: ${option.envVar}`);

--- a/lib/help.js
+++ b/lib/help.js
@@ -235,17 +235,23 @@ class Help {
 
   optionDescription(option) {
     const extraInfo = [];
-    // Some of these do not make sense for negated boolean and suppress for backwards compatibility.
 
-    if (option.argChoices && !option.negate) {
+    if (option.argChoices) {
       extraInfo.push(
         // use stringify to match the display of the default value
         `choices: ${option.argChoices.map((choice) => JSON.stringify(choice)).join(', ')}`);
     }
-    if (option.defaultValue !== undefined && !option.negate) {
-      extraInfo.push(`default: ${option.defaultValueDescription || JSON.stringify(option.defaultValue)}`);
+    if (option.defaultValue !== undefined) {
+      // default for boolean and negated more for programmer than end user,
+      // but show true/false for boolean option as may be for hand-rolled env or config processing.
+      const showDefault = option.required || option.optional ||
+        (option.isBoolean() && typeof option.defaultValue === 'boolean');
+      if (showDefault) {
+        extraInfo.push(`default: ${option.defaultValueDescription || JSON.stringify(option.defaultValue)}`);
+      }
     }
-    if (option.presetArg !== undefined) {
+    // preset for boolean and negated are more for programmer than end user
+    if (option.presetArg !== undefined && option.optional) {
       extraInfo.push(`preset: ${JSON.stringify(option.presetArg)}`);
     }
     if (option.envVar !== undefined) {

--- a/lib/help.js
+++ b/lib/help.js
@@ -245,6 +245,9 @@ class Help {
     if (option.defaultValue !== undefined && !option.negate) {
       extraInfo.push(`default: ${option.defaultValueDescription || JSON.stringify(option.defaultValue)}`);
     }
+    if (option.presetArg !== undefined) {
+      extraInfo.push(`preset: ${option.presetArg}`);
+    }
     if (option.envVar !== undefined) {
       extraInfo.push(`env: ${option.envVar}`);
     }

--- a/lib/option.js
+++ b/lib/option.js
@@ -70,7 +70,7 @@ class Option {
    * new Option('--color').default('GREYSCALE').preset('RGB');
    * new Option('--donate [amount]').preset('20').argParser(parseFloat);
    *
-   * @param {value}
+   * @param {any} arg
    * @return {Option}
    */
 
@@ -190,12 +190,11 @@ class Option {
    *
    * Options are one of boolean, negated, required argument, or optional argument.
    *
-   * @param {string} arg
    * @return {boolean}
    * @api private
    */
 
-  isBoolean(arg) {
+  isBoolean() {
     return !this.required && !this.optional && !this.negate;
   };
 }

--- a/lib/option.js
+++ b/lib/option.js
@@ -186,6 +186,21 @@ class Option {
   is(arg) {
     return this.short === arg || this.long === arg;
   };
+
+  /**
+   * Return whether a boolean option.
+   *
+   * Process of elimination. Boolean if does not have a required argument,
+   * does not have an optional argument, and not a negated option.
+   *
+   * @param {string} arg
+   * @return {boolean}
+   * @api private
+   */
+
+  isBoolean(arg) {
+    return !this.required && !this.optional && !this.negate;
+  };
 }
 
 /**

--- a/lib/option.js
+++ b/lib/option.js
@@ -28,7 +28,7 @@ class Option {
     }
     this.defaultValue = undefined;
     this.defaultValueDescription = undefined;
-    this.defaultOptionalValue = undefined;
+    this.presetArg = undefined;
     this.envVar = undefined;
     this.parseArg = undefined;
     this.hidden = false;
@@ -63,21 +63,19 @@ class Option {
   };
 
   /**
-   * Value to use when an optional option is used without option-argument on command line.
+   * Preset to use instead of `true` for boolean option, or optional without an option argument.
+   * The custom processing (parseArg) is called.
    *
-   * @param {optionalValue} name
+   * @example
+   * new Option('--color').default('GREYSCALE').preset('RGB');
+   * new Option('--donate [amount]').preset('20').argParser(parseFloat);
+   *
+   * @param {value}
    * @return {Option}
    */
 
-  defaultOptional(optionalValue) {
-    if (optionalValue === undefined) {
-      if (this.defaultOptionalValue !== undefined) {
-        return this.defaultOptionalValue;
-      }
-      return this.defaultValue; // Legacy behaviour
-    }
-
-    this.defaultOptionaValue = optionalValue;
+  preset(arg) {
+    this.presetArg = arg;
     return this;
   };
 
@@ -190,8 +188,7 @@ class Option {
   /**
    * Return whether a boolean option.
    *
-   * Process of elimination. Boolean if does not have a required argument,
-   * does not have an optional argument, and not a negated option.
+   * Options are one of boolean, negated, required argument, or optional argument.
    *
    * @param {string} arg
    * @return {boolean}

--- a/lib/option.js
+++ b/lib/option.js
@@ -28,6 +28,7 @@ class Option {
     }
     this.defaultValue = undefined;
     this.defaultValueDescription = undefined;
+    this.defaultOptionalValue = undefined;
     this.envVar = undefined;
     this.parseArg = undefined;
     this.hidden = false;
@@ -58,6 +59,25 @@ class Option {
 
   env(name) {
     this.envVar = name;
+    return this;
+  };
+
+  /**
+   * Value to use when an optional option is used without option-argument on command line.
+   *
+   * @param {optionalValue} name
+   * @return {Option}
+   */
+
+  defaultOptional(optionalValue) {
+    if (optionalValue === undefined) {
+      if (this.defaultOptionalValue !== undefined) {
+        return this.defaultOptionalValue;
+      }
+      return this.defaultValue; // Legacy behaviour
+    }
+
+    this.defaultOptionaValue = optionalValue;
     return this;
   };
 

--- a/lib/option.js
+++ b/lib/option.js
@@ -50,19 +50,6 @@ class Option {
   };
 
   /**
-   * Set environment variable to check for option value.
-   * Priority order of option values is default < env < cli
-   *
-   * @param {string} name
-   * @return {Option}
-   */
-
-  env(name) {
-    this.envVar = name;
-    return this;
-  };
-
-  /**
    * Preset to use instead of `true` for boolean option, or optional without an option argument.
    * The custom processing (parseArg) is called.
    *
@@ -76,6 +63,19 @@ class Option {
 
   preset(arg) {
     this.presetArg = arg;
+    return this;
+  };
+
+  /**
+   * Set environment variable to check for option value.
+   * Priority order of option values is default < env < cli
+   *
+   * @param {string} name
+   * @return {Option}
+   */
+
+  env(name) {
+    this.envVar = name;
     return this;
   };
 

--- a/lib/option.js
+++ b/lib/option.js
@@ -50,7 +50,7 @@ class Option {
   };
 
   /**
-   * Preset to use instead of `true` for boolean option, or optional without an option argument.
+   * Preset to use when option used without option-argument, especially optional but also boolean and negated.
    * The custom processing (parseArg) is called.
    *
    * @example

--- a/tests/help.optionDescription.test.js
+++ b/tests/help.optionDescription.test.js
@@ -24,6 +24,13 @@ describe('optionDescription', () => {
     expect(helper.optionDescription(option)).toEqual('description (default: "default")');
   });
 
+  test('when option has preset value then return description and default value', () => {
+    const description = 'description';
+    const option = new commander.Option('-a', description).preset('abc');
+    const helper = new commander.Help();
+    expect(helper.optionDescription(option)).toEqual('description (preset: "abc")');
+  });
+
   test('when option has env then return description and env name', () => {
     const description = 'description';
     const option = new commander.Option('-a', description).env('ENV');

--- a/tests/help.optionDescription.test.js
+++ b/tests/help.optionDescription.test.js
@@ -17,20 +17,33 @@ describe('optionDescription', () => {
     expect(helper.optionDescription(option)).toEqual(description);
   });
 
-  test('when option has default value then return description and default value', () => {
+  test('when boolean option has default value true then return description and default value', () => {
     const description = 'description';
-    const option = new commander.Option('-a', description).default('default');
+    const option = new commander.Option('-a', description).default(true);
     const helper = new commander.Help();
-    expect(helper.optionDescription(option)).toEqual('description (default: "default")');
+    expect(helper.optionDescription(option)).toEqual('description (default: true)');
   });
 
-  test('when option has preset value then return description and default value', () => {
+  test('when boolean option has default value string then return description without default', () => {
     const description = 'description';
-    const option = new commander.Option('-a', description).preset('abc');
+    const option = new commander.Option('-a', description).default('foo');
+    const helper = new commander.Help();
+    expect(helper.optionDescription(option)).toEqual('description');
+  });
+
+  test('when optional option has preset value then return description and default value', () => {
+    const description = 'description';
+    const option = new commander.Option('--aa [value]', description).preset('abc');
     const helper = new commander.Help();
     expect(helper.optionDescription(option)).toEqual('description (preset: "abc")');
   });
 
+  test('when boolean option has preset value then return description without default', () => {
+    const description = 'description';
+    const option = new commander.Option('--bb', description).preset('abc');
+    const helper = new commander.Help();
+    expect(helper.optionDescription(option)).toEqual('description');
+  });
   test('when option has env then return description and env name', () => {
     const description = 'description';
     const option = new commander.Option('-a', description).env('ENV');
@@ -41,7 +54,7 @@ describe('optionDescription', () => {
   test('when option has default value description then return description and custom default description', () => {
     const description = 'description';
     const defaultValueDescription = 'custom';
-    const option = new commander.Option('-a', description).default('default value', defaultValueDescription);
+    const option = new commander.Option('-a <value>', description).default('default value', defaultValueDescription);
     const helper = new commander.Help();
     expect(helper.optionDescription(option)).toEqual(`description (default: ${defaultValueDescription})`);
   });
@@ -49,7 +62,7 @@ describe('optionDescription', () => {
   test('when option has choices then return description and choices', () => {
     const description = 'description';
     const choices = ['one', 'two'];
-    const option = new commander.Option('-a', description).choices(choices);
+    const option = new commander.Option('-a <value>', description).choices(choices);
     const helper = new commander.Help();
     expect(helper.optionDescription(option)).toEqual('description (choices: "one", "two")');
   });

--- a/tests/options.bool.combo.test.js
+++ b/tests/options.bool.combo.test.js
@@ -96,28 +96,51 @@ describe('boolean option combo, default false, short flags', () => {
   });
 });
 
-// This is a somewhat undocumented special behaviour which appears in some examples.
-// When a flag has a non-boolean default, it is used as the value (only) when the flag is specified.
-//
-// boolean option combo with non-boolean default
+// boolean option combo with non-boolean default.
+// Changed behaviour to normal default in Commander 9.
 describe('boolean option combo with non-boolean default', () => {
-  test('when boolean combo not specified then value is undefined', () => {
-    const flagValue = 'red';
-    const program = createPepperProgramWithDefault(flagValue);
+  test('when boolean combo not specified then value is default', () => {
+    const program = createPepperProgramWithDefault('default');
     program.parse(['node', 'test']);
-    expect(program.opts().pepper).toBeUndefined();
+    expect(program.opts().pepper).toBe('default');
   });
 
-  test('when boolean combo positive then value is "default" value', () => {
-    const flagValue = 'red';
-    const program = createPepperProgramWithDefault(flagValue);
+  test('when boolean combo positive then value is true', () => {
+    const program = createPepperProgramWithDefault('default');
     program.parse(['node', 'test', '--pepper']);
-    expect(program.opts().pepper).toBe(flagValue);
+    expect(program.opts().pepper).toBe(true);
   });
 
   test('when boolean combo negative then value is false', () => {
-    const flagValue = 'red';
-    const program = createPepperProgramWithDefault(flagValue);
+    const program = createPepperProgramWithDefault('default');
+    program.parse(['node', 'test', '--no-pepper']);
+    expect(program.opts().pepper).toBe(false);
+  });
+});
+
+describe('boolean option combo with non-boolean default and preset', () => {
+  function createPepperProgramWithDefaultAndPreset() {
+    const program = new commander.Command();
+    program
+      .addOption(new commander.Option('-p, --pepper').default('default').preset('preset'))
+      .option('-P, --no-pepper', 'remove pepper');
+    return program;
+  }
+
+  test('when boolean combo not specified then value is default', () => {
+    const program = createPepperProgramWithDefaultAndPreset();
+    program.parse(['node', 'test']);
+    expect(program.opts().pepper).toBe('default');
+  });
+
+  test('when boolean combo positive then value is preset', () => {
+    const program = createPepperProgramWithDefaultAndPreset();
+    program.parse(['node', 'test', '--pepper']);
+    expect(program.opts().pepper).toBe('preset');
+  });
+
+  test('when boolean combo negative then value is false', () => {
+    const program = createPepperProgramWithDefaultAndPreset();
     program.parse(['node', 'test', '--no-pepper']);
     expect(program.opts().pepper).toBe(false);
   });

--- a/tests/options.bool.test.js
+++ b/tests/options.bool.test.js
@@ -85,13 +85,14 @@ describe('boolean flag on command', () => {
 });
 
 // boolean flag with non-boolean default
-// NB: behaviour changed in Commander v9 to have default be default
+// NB: behaviour changed in Commander v9 to have default be default.
+// These tests no longer match likely uses, but retained and updated to match current behaviour.
 describe('boolean flag with non-boolean default', () => {
   test('when flag not specified then value is "default"', () => {
     const flagValue = 'black';
     const program = new commander.Command();
     program
-      .option('--olives', 'Add olives? Sorry we only have black.', flagValue);
+      .option('--olives', 'Add green olives?', flagValue);
     program.parse(['node', 'test']);
     expect(program.opts().olives).toBe(flagValue);
   });
@@ -100,16 +101,16 @@ describe('boolean flag with non-boolean default', () => {
     const flagValue = 'black';
     const program = new commander.Command();
     program
-      .option('-v, --olives', 'Add olives? Sorry we only have black.', flagValue);
+      .option('-v, --olives', 'Add green olives?', flagValue);
     program.parse(['node', 'test', '--olives']);
     expect(program.opts().olives).toBe(true);
   });
 
-  test('when flag implied and negated then value is false', () => {
+  test('when combo flag and negated then value is false', () => {
     const flagValue = 'black';
     const program = new commander.Command();
     program
-      .option('-v, --olives', 'Add olives? Sorry we only have black.', flagValue)
+      .option('-v, --olives', 'Add green olives?', flagValue)
       .option('--no-olives');
     program.parse(['node', 'test', '--olives', '--no-olives']);
     expect(program.opts().olives).toBe(false);

--- a/tests/options.bool.test.js
+++ b/tests/options.bool.test.js
@@ -84,27 +84,25 @@ describe('boolean flag on command', () => {
   });
 });
 
-// This is a somewhat undocumented special behaviour which appears in some examples.
-// When a flag has a non-boolean default, it is used as the value (only) when the flag is specified.
-//
 // boolean flag with non-boolean default
+// NB: behaviour changed in Commander v9 to have default be default
 describe('boolean flag with non-boolean default', () => {
-  test('when flag not specified then value is undefined', () => {
+  test('when flag not specified then value is "default"', () => {
     const flagValue = 'black';
     const program = new commander.Command();
     program
       .option('--olives', 'Add olives? Sorry we only have black.', flagValue);
     program.parse(['node', 'test']);
-    expect(program.opts().olives).toBeUndefined();
+    expect(program.opts().olives).toBe(flagValue);
   });
 
-  test('when flag specified then value is "default" value', () => {
+  test('when flag specified then value is true', () => {
     const flagValue = 'black';
     const program = new commander.Command();
     program
       .option('-v, --olives', 'Add olives? Sorry we only have black.', flagValue);
     program.parse(['node', 'test', '--olives']);
-    expect(program.opts().olives).toBe(flagValue);
+    expect(program.opts().olives).toBe(true);
   });
 
   test('when flag implied and negated then value is false', () => {

--- a/tests/options.default.test.js
+++ b/tests/options.default.test.js
@@ -117,3 +117,77 @@ describe('Option with default and option not specified in parse', () => {
     expect(program.opts().colour).toBe('RGB');
   });
 });
+
+// Fairly obvious this needs to happen, but was broken for optional in past!
+describe('default overwritten by specified option', () => {
+  test('when boolean option with boolean default then value is true', () => {
+    const program = new Command();
+    program.option('-d, --debug', 'description', false);
+    program.parse(['-d'], { from: 'user' });
+    expect(program.opts().debug).toBe(true);
+  });
+
+  test('when boolean option with number zero default then value is true', () => {
+    const program = new Command();
+    program.option('-d, --debug', 'description', 0);
+    program.parse(['-d'], { from: 'user' });
+    expect(program.opts().debug).toBe(true);
+  });
+
+  test('when boolean option with string default then value is true', () => {
+    const program = new Command();
+    program.option('-d, --debug', 'description', 'default');
+    program.parse(['-d'], { from: 'user' });
+    expect(program.opts().debug).toBe(true);
+  });
+
+  test('when required option-argument and default number then value is from args', () => {
+    const program = new Command();
+    program.option('-p, --port <port-number>', 'description', 80);
+    program.parse(['-p', '1234'], { from: 'user' });
+    expect(program.opts().port).toBe('1234');
+  });
+
+  test('when required option-argument and default string then value is from args', () => {
+    const program = new Command();
+    program.option('-p, --port <port-number>', 'description', 'foo');
+    program.parse(['-p', '1234'], { from: 'user' });
+    expect(program.opts().port).toBe('1234');
+  });
+
+  test('when optional option-argument and default number and option-argument specified then value is from args', () => {
+    const program = new Command();
+    program.option('-p, --port [port-number]', 'description', 80);
+    program.parse(['-p', '1234'], { from: 'user' });
+    expect(program.opts().port).toBe('1234');
+  });
+
+  test('when optional option-argument and default string and option-argument specified then value is from args', () => {
+    const program = new Command();
+    program.option('-p, --port [port-number]', 'description', 'foo');
+    program.parse(['-p', '1234'], { from: 'user' });
+    expect(program.opts().port).toBe('1234');
+  });
+
+  test('when optional option-argument and default number and option-argument not specified then value is true', () => {
+    const program = new Command();
+    program.option('-p, --port [port-number]', 'description', 80);
+    program.parse(['-p'], { from: 'user' });
+    expect(program.opts().port).toBe(true);
+  });
+
+  test('when optional option-argument and default string and option-argument not specified then value is true', () => {
+    const program = new Command();
+    program.option('-p, --port [port-number]', 'description', 'foo');
+    program.parse(['-p'], { from: 'user' });
+    expect(program.opts().port).toBe(true);
+  });
+
+  test('when negated and default string then value is false', () => {
+    // Bit tricky thinking about what default means for a negated option, but treat as with other options.
+    const program = new Command();
+    program.option('--no-colour', 'description', 'RGB');
+    program.parse(['--no-colour'], { from: 'user' });
+    expect(program.opts().colour).toBe(false);
+  });
+});

--- a/tests/options.default.test.js
+++ b/tests/options.default.test.js
@@ -1,0 +1,119 @@
+const { Command, Option } = require('../');
+
+describe('.option() with default and option not specified in parse', () => {
+  test('when boolean option with boolean default then value is default', () => {
+    const program = new Command();
+    program.option('-d, --debug', 'description', false);
+    program.parse([], { from: 'user' });
+    expect(program.opts().debug).toBe(false);
+  });
+
+  test('when boolean option with number zero default then value is zero', () => {
+    const program = new Command();
+    program.option('-d, --debug', 'description', 0);
+    program.parse([], { from: 'user' });
+    expect(program.opts().debug).toBe(0);
+  });
+
+  test('when boolean option with string default then value is default', () => {
+    const program = new Command();
+    program.option('-d, --debug', 'description', 'default');
+    program.parse([], { from: 'user' });
+    expect(program.opts().debug).toBe('default');
+  });
+
+  test('when required option-argument and default number then value is default', () => {
+    const program = new Command();
+    program.option('-p, --port <port-number>', 'description', 80);
+    program.parse([], { from: 'user' });
+    expect(program.opts().port).toBe(80);
+  });
+
+  test('when required option-argument and default string then value is default', () => {
+    const program = new Command();
+    program.option('-p, --port <port-number>', 'description', 'foo');
+    program.parse([], { from: 'user' });
+    expect(program.opts().port).toBe('foo');
+  });
+
+  test('when optional option-argument and default number then value is default', () => {
+    const program = new Command();
+    program.option('-p, --port [port-number]', 'description', 80);
+    program.parse([], { from: 'user' });
+    expect(program.opts().port).toBe(80);
+  });
+
+  test('when optional option-argument and default string then value is default', () => {
+    const program = new Command();
+    program.option('-p, --port [port-number]', 'description', 'foo');
+    program.parse([], { from: 'user' });
+    expect(program.opts().port).toBe('foo');
+  });
+
+  test('when negated and default string then value is default', () => {
+    // Bit tricky thinking about what default means for a negated option, but treat as with other options.
+    const program = new Command();
+    program.option('--no-colour', 'description', 'RGB');
+    program.parse([], { from: 'user' });
+    expect(program.opts().colour).toBe('RGB');
+  });
+});
+
+describe('Option with default and option not specified in parse', () => {
+  test('when boolean option with boolean default then value is default', () => {
+    const program = new Command();
+    program.addOption(new Option('-d, --debug').default(false));
+    program.parse([], { from: 'user' });
+    expect(program.opts().debug).toBe(false);
+  });
+
+  test('when boolean option with number zero default then value is zero', () => {
+    const program = new Command();
+    program.addOption(new Option('-d, --debug').default(0));
+    program.parse([], { from: 'user' });
+    expect(program.opts().debug).toBe(0);
+  });
+
+  test('when boolean option with string default then value is default', () => {
+    const program = new Command();
+    program.addOption(new Option('-d, --debug').default('default'));
+    program.parse([], { from: 'user' });
+    expect(program.opts().debug).toBe('default');
+  });
+
+  test('when required option-argument and default number then value is default', () => {
+    const program = new Command();
+    program.addOption(new Option('-p, --port <port-number>').default(80));
+    program.parse([], { from: 'user' });
+    expect(program.opts().port).toBe(80);
+  });
+
+  test('when required option-argument and default string then value is default', () => {
+    const program = new Command();
+    program.addOption(new Option('-p, --port <port-number>').default('foo'));
+    program.parse([], { from: 'user' });
+    expect(program.opts().port).toBe('foo');
+  });
+
+  test('when optional option-argument and default number then value is default', () => {
+    const program = new Command();
+    program.addOption(new Option('-p, --port [port-number]').default(80));
+    program.parse([], { from: 'user' });
+    expect(program.opts().port).toBe(80);
+  });
+
+  test('when optional option-argument and default string then value is default', () => {
+    const program = new Command();
+    program.addOption(new Option('-p, --port [port-number]').default('foo'));
+    program.parse([], { from: 'user' });
+    expect(program.opts().port).toBe('foo');
+  });
+
+  test('when negated and default string then value is default', () => {
+    // Bit tricky thinking about what default means for a negated option, but treat as with other options.
+    const program = new Command();
+    program.addOption(new Option('--no-colour').default('RGB'));
+    program.parse([], { from: 'user' });
+    expect(program.opts().colour).toBe('RGB');
+  });
+});

--- a/tests/options.optional.test.js
+++ b/tests/options.optional.test.js
@@ -59,12 +59,20 @@ describe('option with optional value, with default', () => {
     expect(program.opts().cheese).toBe(cheeseType);
   });
 
-  test('when option specified without value then value is default', () => {
+  test('when option specified without value then value is true', () => {
     const defaultValue = 'default';
     const program = new commander.Command();
     program
       .option('--cheese [type]', 'cheese type', defaultValue);
     program.parse(['node', 'test', '--cheese']);
-    expect(program.opts().cheese).toBe(defaultValue);
+    expect(program.opts().cheese).toBe(true);
+  });
+
+  test('when option specified without value and preset then value is preset', () => {
+    const program = new commander.Command();
+    program
+      .addOption(new commander.Option('--cheese [type]').preset('preset'));
+    program.parse(['node', 'test', '--cheese']);
+    expect(program.opts().cheese).toBe('preset');
   });
 });

--- a/tests/options.preset.test.js
+++ b/tests/options.preset.test.js
@@ -1,0 +1,50 @@
+const { Command, Option } = require('../');
+
+test('when boolean option with string preset used then value is preset', () => {
+  const program = new Command();
+  program.addOption(new Option('-d, --debug').preset('foo'));
+  program.parse(['-d'], { from: 'user' });
+  expect(program.opts().debug).toBe('foo');
+});
+
+test('when boolean option with number preset used then value is preset', () => {
+  const program = new Command();
+  program.addOption(new Option('-d, --debug').preset(80));
+  program.parse(['-d'], { from: 'user' });
+  expect(program.opts().debug).toBe(80);
+});
+
+test('when optional with string preset used then value is preset', () => {
+  const program = new Command();
+  program.addOption(new Option('-p, --port [port]').preset('foo'));
+  program.parse(['-p'], { from: 'user' });
+  expect(program.opts().port).toBe('foo');
+});
+
+test('when optional with number preset used then value is preset', () => {
+  const program = new Command();
+  program.addOption(new Option('-p, --port [port]').preset(80));
+  program.parse(['-p'], { from: 'user' });
+  expect(program.opts().port).toBe(80);
+});
+
+test('when optional with string preset used with option-argument then value is as specified', () => {
+  const program = new Command();
+  program.addOption(new Option('-p, --port [port]').preset('foo'));
+  program.parse(['-p', '1234'], { from: 'user' });
+  expect(program.opts().port).toBe('1234');
+});
+
+test('when optional with preset and coerce used then preset is coerced', () => {
+  const program = new Command();
+  program.addOption(new Option('-p, --port [port]').preset('4').argParser(parseFloat));
+  program.parse(['-p'], { from: 'user' });
+  expect(program.opts().port).toBe(4);
+});
+
+test('when optional with preset and variadic used then preset is concatenated', () => {
+  const program = new Command();
+  program.addOption(new Option('-n, --name [name...]').preset('two'));
+  program.parse(['-n', 'one', '-n', '-n', 'three'], { from: 'user' });
+  expect(program.opts().name).toEqual(['one', 'two', 'three']);
+});

--- a/tests/options.preset.test.js
+++ b/tests/options.preset.test.js
@@ -48,3 +48,10 @@ test('when optional with preset and variadic used then preset is concatenated', 
   program.parse(['-n', 'one', '-n', '-n', 'three'], { from: 'user' });
   expect(program.opts().name).toEqual(['one', 'two', 'three']);
 });
+
+test('when negated with string preset used then value is preset', () => {
+  const program = new Command();
+  program.addOption(new Option('--no-colour').preset('foo'));
+  program.parse(['--no-colour'], { from: 'user' });
+  expect(program.opts().colour).toBe('foo');
+});

--- a/tests/options.twice.test.js
+++ b/tests/options.twice.test.js
@@ -1,0 +1,46 @@
+const { Command, Option } = require('../');
+
+// Test that when option specified twice, second use wins.
+// Seems pretty obvious for boolean options, but there was a bug before Commander v9.
+
+test('when boolean option used twice then value is true', () => {
+  const program = new Command();
+  program.option('-d, --debug');
+  program.parse(['-d', '-d'], { from: 'user' });
+  expect(program.opts().debug).toBe(true);
+});
+
+test('when boolean option with default used twice then value is true', () => {
+  const program = new Command();
+  program.option('-d, --debug', 'description', 'foo');
+  program.parse(['-d', '-d'], { from: 'user' });
+  expect(program.opts().debug).toBe(true);
+});
+
+test('when boolean option with preset used twice then value is preset', () => {
+  const program = new Command();
+  program.addOption(new Option('-d, --debug').preset('foo'));
+  program.parse(['-d', '-d'], { from: 'user' });
+  expect(program.opts().debug).toBe('foo');
+});
+
+test('when option with required argument used twice then value is from second use', () => {
+  const program = new Command();
+  program.option('-p, --port <port-number>');
+  program.parse(['-p', '1', '-p', '2'], { from: 'user' });
+  expect(program.opts().port).toBe('2');
+});
+
+test('when option with optional argument used second time without value then value is true', () => {
+  const program = new Command();
+  program.option('--donate [amount]');
+  program.parse(['--donate', '123', '--donate'], { from: 'user' });
+  expect(program.opts().donate).toBe(true);
+});
+
+test('when option with optional argument used second time with value then value is from second use', () => {
+  const program = new Command();
+  program.option('--donate [amount]');
+  program.parse(['--donate', '--donate', '123'], { from: 'user' });
+  expect(program.opts().donate).toBe('123');
+});

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -100,6 +100,18 @@ export class Option {
   default(value: unknown, description?: string): this;
 
   /**
+   * Preset to use instead of `true` for boolean option, or optional without an option argument.
+   * The custom processing (parseArg) is called.
+   *
+   * @example
+   * ```ts
+   * new Option('--color').default('GREYSCALE').preset('RGB');
+   * new Option('--donate [amount]').preset('20').argParser(parseFloat);
+   * ```
+   */
+   preset(arg: unknown): this;
+
+  /**
    * Set environment variable to check for option value.
    * Priority order of option values is default < env < cli
    */
@@ -140,6 +152,14 @@ export class Option {
    * as a object attribute key.
    */
   attributeName(): string;
+
+  /**
+   * Return whether a boolean option.
+   *
+   * Options are one of boolean, negated, required argument, or optional argument.
+   */
+   isBoolean(): boolean;
+
 }
 
 export class Help {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -100,7 +100,7 @@ export class Option {
   default(value: unknown, description?: string): this;
 
   /**
-   * Preset to use instead of `true` for boolean option, or optional without an option argument.
+   * Preset to use when option used without option-argument, especially optional but also boolean and negated.
    * The custom processing (parseArg) is called.
    *
    * @example

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -355,6 +355,10 @@ const baseOption = new commander.Option('-f,--foo', 'foo description');
 expectType<commander.Option>(baseOption.default(3));
 expectType<commander.Option>(baseOption.default(60, 'one minute'));
 
+// preset
+expectType<commander.Option>(baseOption.preset(123));
+expectType<commander.Option>(baseOption.preset('abc'));
+
 // env
 expectType<commander.Option>(baseOption.env('PORT'));
 
@@ -382,6 +386,9 @@ expectType<string>(baseOption.name());
 
 // attributeName
 expectType<string>(baseOption.attributeName());
+
+// isBoolean
+expectType<boolean>(baseOption.isBoolean());
 
 // Argument properties
 const baseArgument = new commander.Argument('<foo');


### PR DESCRIPTION
# Pull Request

## Problem

1) Using "default" value with boolean options and optional options is a bit fragile and buggy.
- non-boolean default used with boolean option is intended to replace "true" when option used, but different behaviour than normal default, never documented in README, and bugs when option repeated
- default used with optional does set the default, but breaks the use of optional without an option argument which is just ignored
- behaviour varies depending on previous value

2) No way to  set value for optional used without argument .

3) Optional used without argument does not trigger custom processing, complicating some uses.

4) This area of code is a problem for adding features to the code with some difficult to understand behaviours and intentions.

Matching issue: #1648

Related: #116 #440 #928 #984 #1135 #1201 #1328 #1394

## Solution

1) Make default consistently set just the default (initial) value for boolean, required, and optional options. Fix use of optional with a default value.

2) Add `Option.preset()` for explicitly setting the preset value to use instead of `true` with a boolean option, or optional without an option argument. 

3) Using preset does trigger custom processing.

## ChangeLog

- fixed: option with optional argument not supplied on command line now works when option already has a value, whether from default value or from previous arguments
- changed: default value specified for boolean option now always used as default value (see `.preset()` to match some previous behaviours)
- changed: default value for boolean option only shown in help if true/false
- added: `Option.preset()` allows specifying value/arg for option when used without option-argument (especially optional, but also boolean option)

