### PR TITLE
Throw error for Option to option() or requiredOption()

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -581,9 +581,8 @@ Expecting one of '${allowedValues.join("', '")}'`);
    * @api private
    */
   _optionEx(config, flags, description, fn, defaultValue) {
-    if (typeof flags !== 'string') {
-      // Have specific error for usage error, like passing Option, to speed up fixing.
-      throw new Error('First argument to option() and requiredOption() must be a string');
+    if (typeof flags === 'object' && flags instanceof Option) {
+      throw new Error('To add an Option object use addOption() instead of option() or requiredOption()');
     }
     const option = this.createOption(flags, description);
     option.makeOptionMandatory(!!config.mandatory);

--- a/lib/command.js
+++ b/lib/command.js
@@ -581,6 +581,10 @@ Expecting one of '${allowedValues.join("', '")}'`);
    * @api private
    */
   _optionEx(config, flags, description, fn, defaultValue) {
+    if (typeof flags !== 'string') {
+      // Have specific error for usage error, like passing Option, to speed up fixing.
+      throw new Error('First argument to option() and requiredOption() must be a string');
+    }
     const option = this.createOption(flags, description);
     option.makeOptionMandatory(!!config.mandatory);
     if (typeof fn === 'function') {


### PR DESCRIPTION
# Pull Request

Small possible improvement from personal experience. (Fairly specific, might be too special case?)

## Problem

I have made the mistake a couple of times of switching to an Option to use extra features, but forgetting to change to `.addOption()`. It also _looks_ like something which might work.

e.g. start with

```js
program
    .option('-s, --secret`, 'secret option for developers')
```

change to

```js
program
    .option(new Option('-s, --secret', 'secret option for developers').hideHelp());
```

and get error

```
    this.required = flags.includes('<'); // A value must be supplied when the option is specified.
                          ^

TypeError: flags.includes is not a function
```

## Solution

Throw a specific error to help programmer work out the mistake quickly.

```
      throw new Error('To add an Option object use addOption() instead of option() or requiredOption()');
      ^

Error: To add an Option object use addOption() instead of option() or requiredOption()
```
