### PR TITLE
Make showSuggestionAfterError true by default

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -53,7 +53,7 @@ class Command extends EventEmitter {
     this._lifeCycleHooks = {}; // a hash of arrays
     /** @type {boolean | string} */
     this._showHelpAfterError = false;
-    this._showSuggestionAfterError = false;
+    this._showSuggestionAfterError = true;
 
     // see .configureOutput() for docs
     this._outputConfiguration = {


### PR DESCRIPTION
# Pull Request

In https://github.com/tj/commander.js/pull/1590#issue-981808526 I said:

> Make the suggestions off by default to minimise breakage in Commander 8, and probably switch to on by default in Commander 9.

I am still happy with the suggestions. I think this adds value for most users.

If accepted, this PR turns it on by default.

## ChangeLog

- changed: showSuggestionAfterError is now on by default
