### PR TITLE
Add EventEmitter style use of this for action handler to README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -535,6 +535,20 @@ program
   });
 ```
 
+If you prefer, you can work with the command directly and skip declaring the parameters for the action handler. The `this` keyword is set to the running command and can be used from a function expression (but not from an arrow function).
+
+Example file: [action-this.js](./examples/action-this.js)
+
+```js
+program
+  .command('serve')
+  .argument('<script>')
+  .option('-p, --port <number>', 'port number', 80)
+  .action(function() {
+    console.error('Run script %s on port %s', this.args[0], this.opts().port);
+  });
+```
+
 You may supply an `async` action handler, in which case you call `.parseAsync` rather than `.parse`.
 
 ```js

--- a/examples/action-this.js
+++ b/examples/action-this.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+// This example is used as an example in the README for the action handler.
+
+// const { Command } = require('commander'); // (normal include)
+const { Command } = require('../'); // include commander in git clone of commander repo
+const program = new Command();
+
+program
+  .command('serve')
+  .argument('<script>')
+  .option('-p, --port <number>', 'port number', 80)
+  .action(function() {
+    console.error('Run script %s on port %s', this.args[0], this.opts().port);
+  });
+
+program.parse();
+
+// Try the following:
+//    node action-this.js serve --port 8080 index.js

--- a/tests/command.action.test.js
+++ b/tests/command.action.test.js
@@ -12,6 +12,16 @@ test('when .action called then command passed to action', () => {
   expect(actionMock).toHaveBeenCalledWith(cmd.opts(), cmd);
 });
 
+test('when .action called then this is set to command', () => {
+  const program = new commander.Command();
+  let actionThis;
+  const cmd = program
+    .command('info')
+    .action(function() { actionThis = this; });
+  program.parse(['node', 'test', 'info']);
+  expect(actionThis).toBe(cmd);
+});
+
 test('when .action called then program.args only contains args', () => {
   // At one time program.args was being modified to contain the same args as the call to .action
   // and so included the command as an extra and unexpected complex item in array.


### PR DESCRIPTION
# Pull Request

## Problem

1) Some use cases make declaring the various command-arguments for the action handler inconvenient or unnecessary. We have an alternative approach available since we were originally using EventEmitter and event listener. (Which I keep forgetting as being available! Use arrow functions so much.)

2) The code pattern for a simple program without an action handler feels quite different to putting the same code in an action handler. Change from working with `program.opts()` and `program.args` to naming command-arguments and passed options.

Related: #1277 #1639

## Solution

Document using `this` in a action handler.