### PR TITLE
addCommonOption for options common to subcommands

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -24,6 +24,8 @@ class Command extends EventEmitter {
     this.commands = [];
     /** @type {Option[]} */
     this.options = [];
+    /** @type {Option[]} */
+    this.commonOptions = []; // for subcommands
     this.parent = null;
     this._allowUnknownOption = false;
     this._allowExcessArguments = true;
@@ -108,6 +110,21 @@ class Command extends EventEmitter {
   }
 
   /**
+   * Copy common options from sourceCommand
+   *
+   * (Used internally when adding a command using `.command()`.)
+   *
+   * @param {Command} sourceCommand
+   * @return {Command} `this` command for chaining
+   */
+  copyCommonOptions(sourceCommand) {
+    sourceCommand.commonOptions.forEach((commonOption) => {
+      this.addOption(commonOption);
+    });
+    return this;
+  }
+
+  /**
    * Define a command.
    *
    * There are two styles of command: pay attention to where to put the description.
@@ -154,6 +171,7 @@ class Command extends EventEmitter {
     this.commands.push(cmd);
     cmd.parent = this;
     cmd.copyInheritedSettings(this);
+    cmd.copyCommonOptions(this);
 
     if (desc) return this;
     return cmd;
@@ -571,6 +589,19 @@ Expecting one of '${allowedValues.join("', '")}'`);
       });
     }
 
+    return this;
+  }
+
+  /**
+   * Add a common option for subcommands created using .command().
+   *
+   * (See also .copyCommonOptions() for manual copying.)
+   *
+   * @param {Option} option
+   * @return {Command} `this` command for chaining
+   */
+  addCommonOption(option) {
+    this.commonOptions.push(option);
     return this;
   }
 

--- a/tests/command.chain.test.js
+++ b/tests/command.chain.test.js
@@ -58,6 +58,12 @@ describe('Command methods that should return this for chaining', () => {
     expect(result).toBe(program);
   });
 
+  test('when call .addCommonOption() then returns this', () => {
+    const program = new Command();
+    const result = program.addCommonOption(new Option('-e'));
+    expect(result).toBe(program);
+  });
+
   test('when call .option() then returns this', () => {
     const program = new Command();
     const result = program.option('-e');
@@ -200,6 +206,13 @@ describe('Command methods that should return this for chaining', () => {
     const program = new Command();
     const cmd = new Command();
     const result = cmd.copyInheritedSettings(program);
+    expect(result).toBe(cmd);
+  });
+
+  test('when call .copyCommonOptions() then returns this', () => {
+    const program = new Command();
+    const cmd = new Command();
+    const result = cmd.copyCommonOptions(program);
     expect(result).toBe(cmd);
   });
 


### PR DESCRIPTION
# Pull Request

## Problem

Sometimes people would like to be able to add common (global) options to all the subcommands, rather than to the program. This was the most popular enhancement in poll https://github.com/tj/commander.js/issues/1551#issuecomment-869093337

Related:
- #243 _so they're all already populated with the common options_
- #476  _add global options to a program that is applied to all commands_
- https://github.com/tj/commander.js/issues/1229#issuecomment-623613637  _a set of common options for all my subcommands_
- #1426 _an option that I add to all the commands of my application_
- #1631 _add global options to each of the commands_

## Solution

- add `.addCommonOption()`
- implemented using `.copyCommonOptions()`
- following same pattern as `.copyInheritedSettings()`, and common settings are automatic for `.command()` but manual for `.addCommand()`

This is implemented for one level deep. The common options are added to direct subcommands and not sub sub commands, as don't have a good way of identifying leaf vs non-leaf commands at the time they are added.

Why not `.commonOption()` matching `.option()`? Because would need more variations to cover `.requiredOption()` and `.addOption()`.

## Example Usage

```js
const { program, Option } = require('commander');

program
  .addCommonOption(new Option('-d, --debug'))
  .addCommonOption(new Option('--quiet'));

program
  .command('sub')
  .option('-l, --local')
  .action(() => {
    console.log('Thanks for calling sub');
  });

program.parse();
```

```
$ node index.js help sub
Usage: index sub [options]

Options:
  -d, --debug
  --quiet
  -l, --local
  -h, --help   display help for command
```

## ChangeLog

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->
