### PR TITLE
Add support for getting merged options including globals

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -174,8 +174,6 @@ const program = new Command();
 Options are defined with the `.option()` method, also serving as documentation for the options. Each option can have a short flag (single character) and a long name, separated by a comma or space or vertical bar ('|').
 
 The parsed options can be accessed by calling `.opts()` on a `Command` object, and are passed to the action handler.
-(You can also use `.getOptionValue()` and `.setOptionValue()` to work with a single option value,
-and `.getOptionValueSource()` and `.setOptionValueWithSource()` when it matters where the option value came from.)
 
 Multi-word options such as "--template-engine" are camel-cased, becoming `program.opts().templateEngine` etc.
 
@@ -185,6 +183,12 @@ For example `-a -b -p 80` may be written as `-ab -p80` or even `-abp80`.
 You can use `--` to indicate the end of the options, and any remaining arguments will be used without being interpreted.
 
 By default options on the command line are not positional, and can be specified before or after other arguments.
+
+There are additional related routines for when `.opts()` is not enough:
+
+- `.optsWithGlobals()` returns the command option values merged with the global options from the program (and intermediate commands)
+- `.getOptionValue()` and `.setOptionValue()` work with a single option value
+- `.getOptionValueSource()` and `.setOptionValueWithSource()` include where the option value came from
 
 ### Common option types, boolean and value
 

--- a/Readme.md
+++ b/Readme.md
@@ -186,7 +186,7 @@ By default options on the command line are not positional, and can be specified 
 
 There are additional related routines for when `.opts()` is not enough:
 
-- `.optsWithGlobals()` returns the command option values merged with the global options from the program (and intermediate commands)
+- `.optsWithGlobals()` returns merged local and global option values
 - `.getOptionValue()` and `.setOptionValue()` work with a single option value
 - `.getOptionValueSource()` and `.setOptionValueWithSource()` include where the option value came from
 

--- a/examples/optsWithGlobals.js
+++ b/examples/optsWithGlobals.js
@@ -1,0 +1,24 @@
+// const { Command } = require('commander'); // (normal include)
+const { Command } = require('../'); // include commander in git clone of commander repo
+
+// Show use of .optsWithGlobals(), and compare with .opts().
+
+const program = new Command();
+
+program
+  .option('-g, --global');
+
+program
+  .command('sub')
+  .option('-l, --local')
+  .action((options, cmd) => {
+    console.log({
+      opts: cmd.opts(),
+      optsWithGlobals: cmd.optsWithGlobals()
+    });
+  });
+
+program.parse();
+
+// Try the following:
+//    node optsWithGlobals.js --global sub --local

--- a/lib/command.js
+++ b/lib/command.js
@@ -1445,7 +1445,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    *
    * @return {Object}
    */
-  opts(mergeOptions) {
+  opts() {
     if (this._storeOptionsAsProperties) {
       // Preserve original behaviour so backwards compatible when still using properties
       const result = {};
@@ -1466,7 +1466,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    *
    * @return {Object}
    */
-  optsWithGlobals(mergeOptions) {
+  optsWithGlobals() {
     // globals overwrite locals
     return getCommandAndParents(this).reduce(
       (combinedOptions, cmd) => Object.assign(combinedOptions, cmd.opts()),

--- a/lib/command.js
+++ b/lib/command.js
@@ -1441,11 +1441,25 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   /**
-   * Return an object containing options as key-value pairs
+   * Return an object containing options as key-value pairs.
    *
+   * @example
+   * const options = cmd.opts();
+   * const mergedOptions = cmd.opts({ includeGlobals: true });
+   *
+   * @param {Object} [mergeOptions]
+   * @param {boolean} mergeOptions.includeGlobals
    * @return {Object}
    */
-  opts() {
+  opts(mergeOptions) {
+    if (mergeOptions && mergeOptions.includeGlobals) {
+      // globals overwrite locals
+      return getCommandAndParents(this).reduce(
+        (combinedOptions, cmd) => Object.assign(combinedOptions, cmd.opts()),
+        {}
+      );
+    }
+
     if (this._storeOptionsAsProperties) {
       // Preserve original behaviour so backwards compatible when still using properties
       const result = {};

--- a/lib/command.js
+++ b/lib/command.js
@@ -1441,7 +1441,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   /**
-   * Return an object containing options as key-value pairs.
+   * Return an object containing local option values as key-value pairs.
    *
    * @return {Object}
    */
@@ -1462,8 +1462,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   /**
-   * Return an object containing options as key-value pairs, merging the local options with
-   * the global options from the program (and intermediate commands).
+   * Return an object containing merged local and global option values as key-value pairs.
    *
    * @return {Object}
    */

--- a/lib/command.js
+++ b/lib/command.js
@@ -1443,23 +1443,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
   /**
    * Return an object containing options as key-value pairs.
    *
-   * @example
-   * const options = cmd.opts();
-   * const mergedOptions = cmd.opts({ includeGlobals: true });
-   *
-   * @param {Object} [mergeOptions]
-   * @param {boolean} mergeOptions.includeGlobals
    * @return {Object}
    */
   opts(mergeOptions) {
-    if (mergeOptions && mergeOptions.includeGlobals) {
-      // globals overwrite locals
-      return getCommandAndParents(this).reduce(
-        (combinedOptions, cmd) => Object.assign(combinedOptions, cmd.opts()),
-        {}
-      );
-    }
-
     if (this._storeOptionsAsProperties) {
       // Preserve original behaviour so backwards compatible when still using properties
       const result = {};
@@ -1473,6 +1459,19 @@ Expecting one of '${allowedValues.join("', '")}'`);
     }
 
     return this._optionValues;
+  }
+
+  /**
+   * Return an object containing options as key-value pairs.
+   *
+   * @return {Object}
+   */
+  optsWithGlobals(mergeOptions) {
+    // globals overwrite locals
+    return getCommandAndParents(this).reduce(
+      (combinedOptions, cmd) => Object.assign(combinedOptions, cmd.opts()),
+      {}
+    );
   }
 
   /**

--- a/lib/command.js
+++ b/lib/command.js
@@ -1462,7 +1462,8 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   /**
-   * Return an object containing options as key-value pairs.
+   * Return an object containing options as key-value pairs, merging the local options with
+   * the global options from the program (and intermediate commands).
    *
    * @return {Object}
    */

--- a/tests/options.optsWithGlobals.test.js
+++ b/tests/options.optsWithGlobals.test.js
@@ -1,0 +1,63 @@
+const commander = require('../');
+
+test('when variety of options used with program then opts is same as optsWithGlobals', () => {
+  const program = new commander.Command();
+  program
+    .option('-b, --boolean')
+    .option('-r, --require-value <value)')
+    .option('-f, --float <value>', 'description', parseFloat)
+    .option('-d, --default-value <value)', 'description', 'default value')
+    .option('-n, --no-something');
+
+  program.parse(['-b', '-r', 'req', '-f', '1e2'], { from: 'user' });
+  expect(program.opts()).toEqual(program.optsWithGlobals());
+});
+
+test('when options in sub and program then optsWithGlobals includes both', () => {
+  const program = new commander.Command();
+  let mergedOptions;
+  program
+    .option('-g, --global <value>');
+  program
+    .command('sub')
+    .option('-l, --local <value)')
+    .action((options, cmd) => {
+      mergedOptions = cmd.optsWithGlobals();
+    });
+
+  program.parse(['-g', 'GGG', 'sub', '-l', 'LLL'], { from: 'user' });
+  expect(mergedOptions).toEqual({ global: 'GGG', local: 'LLL' });
+});
+
+test('when options in sub and subsub then optsWithGlobals includes both', () => {
+  const program = new commander.Command();
+  let mergedOptions;
+  program
+    .command('sub')
+    .option('-g, --global <value)')
+    .command('subsub')
+    .option('-l, --local <value)')
+    .action((options, cmd) => {
+      mergedOptions = cmd.optsWithGlobals();
+    });
+
+  program.parse(['sub', '-g', 'GGG', 'subsub', '-l', 'LLL'], { from: 'user' });
+  expect(mergedOptions).toEqual({ global: 'GGG', local: 'LLL' });
+});
+
+test('when same named option in sub and program then optsWithGlobals includes global', () => {
+  const program = new commander.Command();
+  let mergedOptions;
+  program
+    .option('-c, --common <value>')
+    .enablePositionalOptions();
+  program
+    .command('sub')
+    .option('-c, --common <value)')
+    .action((options, cmd) => {
+      mergedOptions = cmd.optsWithGlobals();
+    });
+
+  program.parse(['-c', 'GGG', 'sub', '-c', 'LLL'], { from: 'user' });
+  expect(mergedOptions).toEqual({ common: 'GGG' });
+});

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -664,6 +664,12 @@ export class Command {
   opts<T extends OptionValues>(): T;
 
   /**
+   * Return an object containing options as key-value pairs, merging the local options with
+   * the global options from the program (and intermediate commands).
+   */
+  optsWithGlobals<T extends OptionValues>(): T;
+
+  /**
    * Set the description.
    *
    * @returns `this` command for chaining

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -659,13 +659,12 @@ export class Command {
   parseOptions(argv: string[]): ParseOptionsResult;
 
   /**
-   * Return an object containing options as key-value pairs
+   * Return an object containing local option values as key-value pairs
    */
   opts<T extends OptionValues>(): T;
 
   /**
-   * Return an object containing options as key-value pairs, merging the local options with
-   * the global options from the program (and intermediate commands).
+   * Return an object containing merged local and global option values as key-value pairs.
    */
   optsWithGlobals<T extends OptionValues>(): T;
 

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -216,6 +216,18 @@ expectType<string>(myCheeseOption.cheese);
 // @ts-expect-error Check that options strongly typed and does not allow arbitrary properties
 expectType(myCheeseOption.foo);
 
+// optsWithGlobals
+const optsWithGlobals = program.optsWithGlobals();
+expectType<commander.OptionValues>(optsWithGlobals);
+expectType(optsWithGlobals.foo);
+expectType(optsWithGlobals.bar);
+
+// optsWithGlobals with generics
+const myCheeseOptionWithGlobals = program.optsWithGlobals<MyCheeseOption>();
+expectType<string>(myCheeseOptionWithGlobals.cheese);
+// @ts-expect-error Check that options strongly typed and does not allow arbitrary properties
+expectType(myCheeseOptionWithGlobals.foo);
+
 // description
 expectType<commander.Command>(program.description('my description'));
 expectType<string>(program.description());


### PR DESCRIPTION
# Pull Request

## Problem

Currently no direct support for getting merged options including globals. The work-around is to access the global options on the program or command parent. 

This was the second most popular enhancement in poll https://github.com/tj/commander.js/issues/1551#issuecomment-869093146

Related issues: #243 https://github.com/tj/commander.js/issues/476#issuecomment-941042505 #1024 #1229

Previous consideration by me: https://github.com/tj/commander.js/issues/1229#issuecomment-743944952 #1155 #1478

## Solution

<del>
Add mergeOptions parameter to `.opts()`.

```js
const options = cmd.opts();
const mergedOptions = cmd.opts({ includeGlobals: true });
```
</del>

Add `command.optsWithGlobals()`.

## Example Usage

```js
const { program } = require('commander');

program
  .option('-g, --global');

program
  .command('sub')
  .option('-l, --local')
  .action((options, cmd) => {
    console.log({
      opts: cmd.opts(),
      optsWithGlobals: cmd.optsWithGlobals())
    });
  });

program.parse();
```

```
$ node index.js sub --global --local
{
  opts: { local: true },
  optsWithGlobals: { local: true, global: true }
}
```

## ChangeLog

- add `.optsWithGlobals()` to return merged local and global options
