### PR TITLE
Fix JSDoc comment for copyInheritedSettings

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -83,7 +83,7 @@ class Command extends EventEmitter {
    * (Used internally when adding a command using `.command()` so subcommands inherit parent settings.)
    *
    * @param {Command} sourceCommand
-   * @return {Command} returns `this` for executable command
+   * @return {Command} `this` command for chaining
    */
   copyInheritedSettings(sourceCommand) {
     this._outputConfiguration = sourceCommand._outputConfiguration;


### PR DESCRIPTION
Fix bogus comment, probably left over from copy-paste when adding method.