### PR TITLE
Fix errata in example for error

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1012,8 +1012,8 @@ As well as the error message, you can optionally specify the `exitCode` (used wi
 and `code` (used with `CommanderError`).
 
 ```js
-program.exit('Password must be longer than four characters');
-program.exit('Custom processing has failed', { exitCode: 2, code: 'my.custom.error' });
+program.error('Password must be longer than four characters');
+program.error('Custom processing has failed', { exitCode: 2, code: 'my.custom.error' });
 ```
 
 ### Override exit and output handling


### PR DESCRIPTION
Oops, all this talk of error and exit, used the wrong one in the example (which I did not run...).

https://github.com/tj/commander.js/pull/1675#discussion_r785171583
