### PR TITLE
Follow best practice and require process rather than use global

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -2,6 +2,7 @@ const EventEmitter = require('events').EventEmitter;
 const childProcess = require('child_process');
 const path = require('path');
 const fs = require('fs');
+const process = require('process');
 
 const { Argument, humanReadableArgName } = require('./argument.js');
 const { CommanderError } = require('./error.js');


### PR DESCRIPTION
# Pull Request

Making a minor change that I saw in another project and looked up the related documentation.

> The `process` object provides information about, and control over, the current Node.js process. While it is available as a global, it is recommended to explicitly access it via require or import:

https://nodejs.org/dist/latest-v16.x/docs/api/process.html#process