### PR TITLE
Remove low-value argument test

### DIFF
--- a/lib/option.js
+++ b/lib/option.js
@@ -80,10 +80,6 @@ class Option {
    */
 
   conflicts(names) {
-    if (!Array.isArray(names) && typeof names !== 'string') {
-      throw new Error('conflicts() argument must be a string or an array of strings');
-    }
-
     this.conflictsWith = this.conflictsWith.concat(names);
     return this;
   }


### PR DESCRIPTION
Long story for small deletion.

I suggested this test as part of adding single string support.
- https://github.com/tj/commander.js/pull/1678#issuecomment-1047218753

I noticed it today because it is not covered by a unit test. Rather than adding a unit test, I think perhaps just delete the check. I don't think it is providing much value, and I suggest deleting it and if anyone reports problems using the API then add tests when we know what mistakes people make.

The previous situation was the routine expected an array and would silently do the wrong thing if a single string was passed. And two of us made that very mistake!

```
// early API required array like:
option.conflicts(['one']);
// early API silently did weird things if passed single string
option.conflicts('one');
```

New API supports both forms:
```
option.conflicts(['one']);
option.conflicts('one');
```
 
What I think the most likely user mistake now might be, and not too likely:
```
option.conflicts('one', 'two');
```

And the current test won't detect that! So suggesting keep it simple, delete for now.