### PR TITLE
Add `"types"` to `"exports"`

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
   "main": "./index.js",
   "exports": {
     ".": {
+      "types": "./typings/index.d.ts",
       "require": "./index.js",
-      "import": "./esm.mjs",
-      "types": "./typings/index.d.ts"
+      "import": "./esm.mjs"
     },
     "./esm.mjs": "./esm.mjs"
   },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
   "exports": {
     ".": {
       "require": "./index.js",
-      "import": "./esm.mjs"
+      "import": "./esm.mjs",
+      "types": "./typings/index.d.ts"
     },
     "./esm.mjs": "./esm.mjs"
   },


### PR DESCRIPTION
# Pull Request

<!--
The text in these markdown comments is instructions that will not appear in the displayed pull request,
and can be deleted.

Please submit pull requests against the develop branch.

Follow the existing code style. Check the tests succeed, including lint.
  npm run test
  npm run lint

Don't update the CHANGELOG or command version number. That gets done by maintainers when preparing the release.

Commander currently has zero production dependencies. That isn't a hard requirement, but is a simple story. Requests which 
add a dependency are much less likely to be accepted, and we are likely to ask if there alternative approaches to avoid the dependency.
-->

## Problem
Fixes #1703 
<!--
What problem are you solving?
What Issues does this relate to?
Show the broken output if appropriate.
-->

## Solution
Add `"types"` to `"exports"`
<!--
How did you solve the problem? 
Show the fixed output if appropriate.

There are a lot of forms of documentation which could need updating for a change in functionality. It
is ok if you want to show us the code to discuss before doing the extra work, and
you should say so in your comments so we focus on the concept first before talking about all the other pieces:

- TypeScript typings
- JSDoc documentation in code
- tests
- README
- examples/
-->

## ChangeLog

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->
