### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/help.js
+++ b/lib/help.js
@@ -387,8 +387,8 @@ class Help {
     const columnWidth = width - indent;
     if (columnWidth < minColumnWidth) return str;
 
-    const leadingStr = str.substr(0, indent);
-    const columnText = str.substr(indent);
+    const leadingStr = str.slice(0, indent);
+    const columnText = str.slice(indent);
 
     const indentString = ' '.repeat(indent);
     const regex = new RegExp('.{1,' + (columnWidth - 1) + '}([\\s\u200B]|$)|[^\\s\u200B]+?([\\s\u200B]|$)', 'g');


### PR DESCRIPTION
## Problem

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.
