### PR TITLE
Add example for "global" options

### DIFF
--- a/examples/common-options.js
+++ b/examples/common-options.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+// This example shows a couple of ways of adding a common option to all the subcommands.
+// We are using one level of subcommands. (Adding options to just the leaf subcommands
+// with deeper nesting would be a little more work.)
+
+// const { Command } = require('commander'); // (normal include)
+const { Command } = require('../'); // include commander in git clone of commander repo
+
+// Common options can be added when subcommands are created by using a custom subclass.
+// If the options are unsorted in the help, these will appear first.
+class MyRootCommand extends Command {
+  createCommand(name) {
+    const cmd = new Command(name);
+    cmd.option('-v, --verbose', 'use verbose logging');
+    return cmd;
+  }
+}
+
+const program = new MyRootCommand();
+
+program.command('print')
+  .option('--a4', 'Use A4 sized paper')
+  .action((options) => {
+    console.log('print options: %O', options);
+  });
+
+program.command('serve')
+  .option('-p, --port <number>', 'port number for server')
+  .action((options) => {
+    console.log('serve options: %O', options);
+  });
+
+// Common options can be added manually after setting up program and subcommands.
+// If the options are unsorted in the help, these will appear last.
+program.commands.forEach((cmd) => {
+  cmd.option('-d, --debug');
+});
+
+program.parse();
+
+// Try the following:
+//    node common-options.js print --help
+//    node common-options.js serve --help
+//    node common-options.js serve --debug --verbose

--- a/examples/global-options.js
+++ b/examples/global-options.js
@@ -1,8 +1,13 @@
 #!/usr/bin/env node
 
-// This example shows a couple of ways of adding a common option to all the subcommands.
-// We are using one level of subcommands. (Adding options to just the leaf subcommands
-// with deeper nesting would be a little more work.)
+// This example shows a couple of ways to add a "global" option to all of the subcommands.
+// The first approach is to use a subclass and add the option as the subcommand is created.
+// The second approach is to loop over the subcommands after they have been created.
+//
+// The code in this example assumes there is just one level of subcommands.
+//
+// (A different pattern for a "global" option is to add it to the root command, rather
+// than to the subcommand. That is not shown here.)
 
 // const { Command } = require('commander'); // (normal include)
 const { Command } = require('../'); // include commander in git clone of commander repo
@@ -40,6 +45,7 @@ program.commands.forEach((cmd) => {
 program.parse();
 
 // Try the following:
+//    node common-options.js --help
 //    node common-options.js print --help
 //    node common-options.js serve --help
 //    node common-options.js serve --debug --verbose


### PR DESCRIPTION
# Pull Request

## Problem

Sometimes people would like to be able to add common (global) options to all the subcommands, rather than to the program. This was the most popular enhancement in poll https://github.com/tj/commander.js/issues/1551#issuecomment-869093337

Related:
- #243 _so they're all already populated with the common options_
- #476  _add global options to a program that is applied to all commands_
- https://github.com/tj/commander.js/issues/1229#issuecomment-623613637  _a set of common options for all my subcommands_
- #1426 _an option that I add to all the commands of my application_
- #1631 _add global options to each of the commands_

I tried adding an explicit routine in #1670 but it turned out less effective than leaving it up to the user.

## Solution

Add an example file showing two ways to add global options to subcommands.
