### PR TITLE
Fail on missing required option-arg when option is not last argument (resolves #1684)

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -1404,7 +1404,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
         if (option) {
           if (option.required) {
             const value = args.shift();
-            if (value === undefined) this.optionMissingArgument(option);
+            if (value === undefined || this._findOption(value)) this.optionMissingArgument(option);
             this.emit(`option:${option.name()}`, value);
           } else if (option.optional) {
             let value = null;

--- a/lib/command.js
+++ b/lib/command.js
@@ -1404,7 +1404,10 @@ Expecting one of '${allowedValues.join("', '")}'`);
         if (option) {
           if (option.required) {
             const value = args.shift();
-            if (value === undefined || this._findOption(value)) this.optionMissingArgument(option);
+            if (value === undefined || (this._findOption(value.split('=')[0])) ||
+              (maybeOption(value) && this._findOption(value.slice(0, 2)))) {
+              this.optionMissingArgument(option);
+            }
             this.emit(`option:${option.name()}`, value);
           } else if (option.optional) {
             let value = null;

--- a/tests/options.required.test.js
+++ b/tests/options.required.test.js
@@ -37,6 +37,66 @@ describe('option with required value, no default', () => {
     // Assert
     expect(mockOptionMissingArgument).toHaveBeenCalled();
   });
+
+  test('when option value not specified and other options follow then error', () => {
+    // Arrange. Mock error routine to allow interception.
+    const mockOptionMissingArgument = jest.fn(() => {
+      throw new Error('optionMissingArgument');
+    });
+    const program = new commander.Command();
+    program.optionMissingArgument = mockOptionMissingArgument;
+    program
+      .option('--cheese <type>', 'cheese type')
+      .option('--sauce <type>', 'sauce type');
+
+    // Act. The throw is due to the above mock, and not default behaviour.
+    expect(() => {
+      program.parse(['node', 'test', '--cheese', '--sauce', 'red']);
+    }).toThrow();
+
+    // Assert
+    expect(mockOptionMissingArgument).toHaveBeenCalled();
+  });
+
+  test('when option value not specified and other options follow using alternate long option syntax then error', () => {
+    // Arrange. Mock error routine to allow interception.
+    const mockOptionMissingArgument = jest.fn(() => {
+      throw new Error('optionMissingArgument');
+    });
+    const program = new commander.Command();
+    program.optionMissingArgument = mockOptionMissingArgument;
+    program
+      .option('--cheese <type>', 'cheese type')
+      .option('--sauce <type>', 'sauce type');
+
+    // Act. The throw is due to the above mock, and not default behaviour.
+    expect(() => {
+      program.parse(['node', 'test', '--cheese', '--sauce=red']);
+    }).toThrow();
+
+    // Assert
+    expect(mockOptionMissingArgument).toHaveBeenCalled();
+  });
+
+  test('when option value not specified and other options follow using alternate short option syntax then error', () => {
+    // Arrange. Mock error routine to allow interception.
+    const mockOptionMissingArgument = jest.fn(() => {
+      throw new Error('optionMissingArgument');
+    });
+    const program = new commander.Command();
+    program.optionMissingArgument = mockOptionMissingArgument;
+    program
+      .option('--cheese <type>', 'cheese type')
+      .option('-s --sauce <type>', 'sauce type');
+
+    // Act. The throw is due to the above mock, and not default behaviour.
+    expect(() => {
+      program.parse(['node', 'test', '--cheese', '-sred']);
+    }).toThrow();
+
+    // Assert
+    expect(mockOptionMissingArgument).toHaveBeenCalled();
+  });
 });
 
 // option with required value, with default
@@ -74,26 +134,6 @@ describe('option with required value, with default', () => {
     // Act. The throw is due to the above mock, and not default behaviour.
     expect(() => {
       program.parse(['node', 'test', '--cheese']);
-    }).toThrow();
-
-    // Assert
-    expect(mockOptionMissingArgument).toHaveBeenCalled();
-  });
-
-  test('when option value not specified and other options follow then error', () => {
-    // Arrange. Mock error routine to allow interception.
-    const mockOptionMissingArgument = jest.fn(() => {
-      throw new Error('optionMissingArgument');
-    });
-    const program = new commander.Command();
-    program.optionMissingArgument = mockOptionMissingArgument;
-    program
-      .option('--cheese <type>', 'cheese type')
-      .option('--sauce <type>', 'sauce type');
-
-    // Act. The throw is due to the above mock, and not default behaviour.
-    expect(() => {
-      program.parse(['node', 'test', '--cheese', '--sauce', 'red']);
     }).toThrow();
 
     // Assert

--- a/tests/options.required.test.js
+++ b/tests/options.required.test.js
@@ -79,4 +79,24 @@ describe('option with required value, with default', () => {
     // Assert
     expect(mockOptionMissingArgument).toHaveBeenCalled();
   });
+
+  test('when option value not specified and other options follow then error', () => {
+    // Arrange. Mock error routine to allow interception.
+    const mockOptionMissingArgument = jest.fn(() => {
+      throw new Error('optionMissingArgument');
+    });
+    const program = new commander.Command();
+    program.optionMissingArgument = mockOptionMissingArgument;
+    program
+      .option('--cheese <type>', 'cheese type')
+      .option('--sauce <type>', 'sauce type');
+
+    // Act. The throw is due to the above mock, and not default behaviour.
+    expect(() => {
+      program.parse(['node', 'test', '--cheese', '--sauce', 'red']);
+    }).toThrow();
+
+    // Assert
+    expect(mockOptionMissingArgument).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Problem
Existing logic to catch missing required option-arguments works only in the case that the option is the last argument.
Example command:

```
program
  .option('--no-sauce', 'Remove sauce')
  .option('--cheese <flavour>', 'cheese flavour', 'mozzarella')
  .option('--no-cheese', 'plain with no cheese')
  .parse();
```
Calling this command with `--cheese` as the last/only argument (missing its required option-argument `<flavour>`) will produce the error: `error: option '--cheese <flavour>' argument missing`.

However, calling the same command with arguments `--cheese --no-sauce` (still missing the required `<flavour>` option-argument) will produce no error and the command will run with a value of `--no-sauce` assigned to the option `--cheese`. This issue was reported in #1684.

## Solution
When parsing options, check that required option-argument values do not match existing option names.

## ChangeLog
Check for missing required option-args when option is not last one passed.

