### PR TITLE
Add target-branch to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,7 @@
 version: 2
 updates:
 - package-ecosystem: "github-actions"
+  target-branch: "develop"
   directory: "/"
   schedule:
       interval: "weekly"


### PR DESCRIPTION
#1732 immediately triggered three action update PR! Noisy since we haven't been updating, but probably good.  Got some reading of release notes to do...

However, we prefer PR against `develop`. Add config.