### PR TITLE
Add develop branch to codeql scanning for earlier warnings

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,10 +2,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, develop ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ master, develop ]
   schedule:
     - cron: '27 5 * * 6'
 


### PR DESCRIPTION
I noticed the `branches` when looking at the version bumps, and we probably want warnings when things are targeting `develop` too for earlier warning about issues.