### PR TITLE
global options example: pass arguments to sub-subcommands too

### DIFF
--- a/examples/global-options.js
+++ b/examples/global-options.js
@@ -9,28 +9,38 @@
 // (A different pattern for a "global" option is to add it to the root command, rather
 // than to the subcommand. That is not shown here.)
 
-// const { Command } = require('commander'); // (normal include)
-const { Command } = require('../'); // include commander in git clone of commander repo
+// const { Command, createOption } = require('commander'); // (normal include)
+const { Command, createOption } = require('../'); // include commander in git clone of commander repo
 
 // Common options can be added when subcommands are created by using a custom subclass.
 // If the options are unsorted in the help, these will appear first.
 class MyRootCommand extends Command {
   createCommand(name) {
-    const cmd = new Command(name);
+    // use MyRootCommand to add --verbose to any sub-subcommands like "print pdf"
+    const cmd = new MyRootCommand(name);
     cmd.option('-v, --verbose', 'use verbose logging');
     return cmd;
   }
 }
 
-const program = new MyRootCommand();
+// enablePositionalOptions makes --verbose and --a4 available to "print pdf"
+const program = new MyRootCommand().enablePositionalOptions();
 
-program.command('print')
-  .option('--a4', 'Use A4 sized paper')
+const commonPrintOptions = createOption('--a4', 'Use A4 sized paper');
+
+const print = program.command('print')
+  .addOption(commonPrintOptions)
   .action((options) => {
     console.log('print options: %O', options);
   });
 
-program.command('serve')
+print.command('pdf')
+  .addOption(commonPrintOptions)
+  .action((options) => {
+    console.log('print pdf options: %O', options);
+  });
+
+  program.command('serve')
   .option('-p, --port <number>', 'port number for server')
   .action((options) => {
     console.log('serve options: %O', options);
@@ -38,14 +48,21 @@ program.command('serve')
 
 // Common options can be added manually after setting up program and subcommands.
 // If the options are unsorted in the help, these will appear last.
-program.commands.forEach((cmd) => {
+program.commands.forEach(addDebug);
+
+function addDebug(cmd) {
   cmd.option('-d, --debug');
-});
+  // recurse to add --debug to any sub-subcommands like "print pdf"
+  cmd.commands.forEach(addDebug);
+}
 
 program.parse();
 
 // Try the following:
-//    node common-options.js --help
-//    node common-options.js print --help
-//    node common-options.js serve --help
-//    node common-options.js serve --debug --verbose
+//    node global-options.js --help
+//    node global-options.js print --help
+//    node global-options.js print pdf --help
+//    node global-options.js serve --help
+//    node global-options.js serve --debug --verbose
+//    node global-options.js print -d -v --a4
+//    node global-options.js print pdf -d -v --a4


### PR DESCRIPTION
## Problem
Was hard to understand why sub-subcommand did not get option, even though `--help` shows the option. I read the example, others will probably too. Expand it to also add options to sub-subcommands.

See issue #1753.

## Solution
Added sub-subcommand to global-options example.