### PR TITLE
Export InvalidOptionArgumentError in esm

### DIFF
--- a/esm.mjs
+++ b/esm.mjs
@@ -8,7 +8,7 @@ export const {
   createOption,
   CommanderError,
   InvalidArgumentError,
-  InvalidArgumentError: InvalidOptionArgumentError,
+InvalidOptionArgumentError, // deprecated old name
   Command,
   Argument,
   Option,

--- a/esm.mjs
+++ b/esm.mjs
@@ -8,7 +8,7 @@ export const {
   createOption,
   CommanderError,
   InvalidArgumentError,
-InvalidOptionArgumentError, // deprecated old name
+  InvalidOptionArgumentError, // deprecated old name
   Command,
   Argument,
   Option,

--- a/esm.mjs
+++ b/esm.mjs
@@ -8,6 +8,7 @@ export const {
   createOption,
   CommanderError,
   InvalidArgumentError,
+  InvalidArgumentError: InvalidOptionArgumentError,
   Command,
   Argument,
   Option,

--- a/tests/esm-imports-test.mjs
+++ b/tests/esm-imports-test.mjs
@@ -1,4 +1,4 @@
-import { program, Command, Option, Argument, CommanderError, InvalidArgumentError, Help, createCommand, createArgument, createOption } from '../esm.mjs';
+import { program, Command, Option, Argument, CommanderError, InvalidArgumentError, InvalidOptionArgumentError, Help, createCommand, createArgument, createOption } from '../esm.mjs';
 
 // Do some simple checks that expected imports are available at runtime.
 // Run using `npm run test-esm`.
@@ -25,6 +25,7 @@ checkClass(new Command(), 'Command');
 checkClass(new Option('-e, --example'), 'Option');
 checkClass(new CommanderError(1, 'code', 'failed'), 'CommanderError');
 checkClass(new InvalidArgumentError('failed'), 'InvalidArgumentError');
+checkClass(new InvalidOptionArgumentError('failed'), 'InvalidArgumentError');
 checkClass(new Help(), 'Help');
 checkClass(new Argument('<file>'), 'Argument');
 


### PR DESCRIPTION
After upgrading a typescript project to native es modules  imports for
`InvalidOptionArgumentError` were undefined at runtime but 
defined in typescript as an alias to InvalidArgumentError.

```
# test.ts
import { InvalidOptionArgumentError } from 'commander'
//       ^ No type error here, typescript thinks InvalidOptionArgumentError should exist

assert(InvalidOptionArgumentError != null); // Yet will throw an error
```

A quick test showed that there was a difference between the commonjs and
ecmascript module. The issue wasn't limited to typescript.

```
# test.cjs
const { InvalidOptionArgumentError } = require('commander')
assert(InvalidOptionArgumentError != null);
```

```
# test.mjs
import { InvalidOptionArgumentError } from 'commander'
assert(InvalidOptionArgumentError != null); // This will throw an error
```

This commit fixes the issue by exporting InvalidOptionArgumentError from
the esm entry point. Alternatively we could remove
InvalidOptionArgumentError from typings, I'm happy as long as build and
runtime match.