### PR TITLE
Improve Command typings

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -266,13 +266,13 @@ export class Help {
   /** Get the command summary to show in the list of subcommands. */
   subcommandDescription(cmd: Command): string;
   /** Get the option term to show in the list of options. */
-  optionTerm(option: Option<any>): string;
+  optionTerm(option: Option<any, any, any, any>): string;
   /** Get the option description to show in the list of options. */
-  optionDescription(option: Option<any>): string;
+  optionDescription(option: Option<any, any, any, any>): string;
   /** Get the argument term to show in the list of arguments. */
-  argumentTerm(argument: Argument<any>): string;
+  argumentTerm(argument: Argument<any, any, any>): string;
   /** Get the argument description to show in the list of arguments. */
-  argumentDescription(argument: Argument<any>): string;
+  argumentDescription(argument: Argument<any, any, any>): string;
 
   /** Get the command usage to be displayed at the top of the built-in help. */
   commandUsage(cmd: Command): string;
@@ -282,9 +282,9 @@ export class Help {
   /** Get an array of the visible subcommands. Includes a placeholder for the implicit help command, if there is one. */
   visibleCommands(cmd: Command): Command[];
   /** Get an array of the visible options. Includes a placeholder for the implicit help option, if there is one. */
-  visibleOptions(cmd: Command): Array<Option<any>>;
+  visibleOptions(cmd: Command): Array<Option<any, any, any, any>>;
   /** Get an array of the arguments which have descriptions. */
-  visibleArguments(cmd: Command): Array<Argument<any>>;
+  visibleArguments(cmd: Command): Array<Argument<any, any, any>>;
 
   /** Get the longest command term length. */
   longestSubcommandTermLength(cmd: Command, helper: Help): number;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -29,7 +29,7 @@ type StringImpliedType<S extends string, /* fallback to boolean */ F extends boo
 
 type StringTypedArguments<S extends string, T, /* default type */ D extends T | undefined> =
   S extends `${infer A} ${infer Rest}`
-    ? [StringTypedArguments<A, T, D>, ...StringTypedArguments<Rest, T, D>]
+    ? [...StringTypedArguments<A, T, D>, ...StringTypedArguments<Rest, T, D>]
     : [D extends undefined
         ? S extends `[${infer N}]`
           ? T | undefined
@@ -38,7 +38,7 @@ type StringTypedArguments<S extends string, T, /* default type */ D extends T | 
 
 type StringUntypedArguments<S extends string, /* default type */ D> =
   S extends `${infer A} ${infer Rest}`
-    ? [StringUntypedArguments<A, D>, ...StringUntypedArguments<Rest, D>]
+    ? [...StringUntypedArguments<A, D>, ...StringUntypedArguments<Rest, D>]
     : [StringImpliedType<S>];
 
 type StringTypedOption<S extends string, T, /* default type */ D extends T | undefined> =

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -59,6 +59,8 @@ type StringTypedOption<S extends string, T, /* default type */ D> =
 type StringUntypedOption<S extends string, /* default type */ D> =
   StringTypedOption<S, StringImpliedType<S, true>, D>;
 
+type MergeOptions<A, B> = (A & B) extends infer O ? {[K in keyof O]: O[K]} : never;
+
 export class CommanderError extends Error {
   code: string;
   exitCode: number;
@@ -591,10 +593,10 @@ export class Command<Args extends unknown[] = [], Options extends { [K: string]:
    *
    * @returns `this` command for chaining
    */
-  option<Flags extends string>(flags: Flags, description?: string): Command<Args, Options & StringUntypedOption<Flags, undefined>>;
-  option<Flags extends string, D extends StringImpliedType<Flags, true> | undefined>(flags: Flags, description: string, defaultValue: D): Command<Args, Options & StringUntypedOption<Flags, D>>;
-  option<Flags extends string, T>(flags: Flags, description: string, fn: (value: string, previous: T) => T): Command<Args, Options & StringTypedOption<Flags, T, undefined>>;
-  option<Flags extends string, T, D extends T | undefined>(flags: Flags, description: string, fn: (value: string, previous: T) => T, defaultValue: D): Command<Args, Options & StringTypedOption<Flags, T, D>>;
+  option<Flags extends string>(flags: Flags, description?: string): Command<Args, MergeOptions<Options, StringUntypedOption<Flags, undefined>>>;
+  option<Flags extends string, D extends StringImpliedType<Flags, true> | undefined>(flags: Flags, description: string, defaultValue: D): Command<Args, MergeOptions<Options, StringUntypedOption<Flags, D>>>;
+  option<Flags extends string, T>(flags: Flags, description: string, fn: (value: string, previous: T) => T): Command<Args, MergeOptions<Options, StringTypedOption<Flags, T, undefined>>>;
+  option<Flags extends string, T, D extends T | undefined>(flags: Flags, description: string, fn: (value: string, previous: T) => T, defaultValue: D): Command<Args, MergeOptions<Options, StringTypedOption<Flags, T, D>>>;
   /** @deprecated since v7, instead use choices or a custom function */
   option(flags: string, description: string, regexp: RegExp, defaultValue?: string | boolean | string[]): this;
 
@@ -604,10 +606,10 @@ export class Command<Args extends unknown[] = [], Options extends { [K: string]:
    *
    * The `flags` string contains the short and/or long flags, separated by comma, a pipe or space.
    */
-  requiredOption<Flags extends string>(flags: Flags, description?: string): Command<Args, Options & Required<StringUntypedOption<Flags, undefined>>>;
-  requiredOption<Flags extends string, D extends StringImpliedType<Flags, true> | undefined>(flags: Flags, description: string, defaultValue: D): Command<Args, Options & Required<StringUntypedOption<Flags, D>>>;
-  requiredOption<Flags extends string, T>(flags: Flags, description: string, fn: (value: string, previous: T) => T): Command<Args, Options & Required<StringTypedOption<Flags, T, undefined>>>;
-  requiredOption<Flags extends string, T, D extends T | undefined>(flags: Flags, description: string, fn: (value: string, previous: T) => T, defaultValue: D): Command<Args, Options & Required<StringTypedOption<Flags, T, D>>>;
+  requiredOption<Flags extends string>(flags: Flags, description?: string): Command<Args, MergeOptions<Options, Required<StringUntypedOption<Flags, undefined>>>>;
+  requiredOption<Flags extends string, D extends StringImpliedType<Flags, true> | undefined>(flags: Flags, description: string, defaultValue: D): Command<Args, MergeOptions<Options, Required<StringUntypedOption<Flags, D>>>>;
+  requiredOption<Flags extends string, T>(flags: Flags, description: string, fn: (value: string, previous: T) => T): Command<Args, MergeOptions<Options, Required<StringTypedOption<Flags, T, undefined>>>>;
+  requiredOption<Flags extends string, T, D extends T | undefined>(flags: Flags, description: string, fn: (value: string, previous: T) => T, defaultValue: D): Command<Args, MergeOptions<Options, Required<StringTypedOption<Flags, T, D>>>>;
   /** @deprecated since v7, instead use choices or a custom function */
   requiredOption(flags: string, description: string, regexp: RegExp, defaultValue?: string | boolean | string[]): this;
 
@@ -625,7 +627,7 @@ export class Command<Args extends unknown[] = [], Options extends { [K: string]:
    *
    * See .option() and .requiredOption() for creating and attaching an option in a single call.
    */
-  addOption<Flags extends string, T, D, M>(option: Option<Flags, T, D, M>): Command<Args, Options & M extends true ? Required<StringTypedOption<Flags, T, D>> : StringTypedOption<Flags, T, D>>;
+  addOption<Flags extends string, T, D, M>(option: Option<Flags, T, D, M>): Command<Args, MergeOptions<Options, M extends true ? Required<StringTypedOption<Flags, T, D>> : StringTypedOption<Flags, T, D>>>;
 
   /**
    * Whether to store option values as properties on command object,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -4,22 +4,21 @@
 // Using method rather than property for method-signature-style, to document method overloads separately. Allow either.
 /* eslint-disable @typescript-eslint/method-signature-style */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/no-unused-vars */
 
 type CamelCase<S extends string> = S extends `${infer W}-${infer Rest}`
   ? CamelCase<`${W}${Capitalize<Rest>}`>
   : S;
 
 type StringImpliedType<S extends string, /* fallback to boolean */ F extends boolean = false> =
-  S extends `${infer B}<${infer N}...>`
+  S extends `${string}<${string}...>`
     ? [string, ...string[]]
-    : S extends `${infer B}[${infer N}...]`
+    : S extends `${string}[${string}...]`
       ? F extends true
         ? string[] | boolean
         : string[]
-      : S extends `${infer B}<${infer N}>`
+      : S extends `${string}<${string}>`
         ? string
-        : S extends `${infer B}[${infer N}]`
+        : S extends `${string}[${string}]`
           ? F extends true
             ? string | boolean
             : string | undefined
@@ -29,7 +28,7 @@ type StringImpliedType<S extends string, /* fallback to boolean */ F extends boo
 
 type StringTypedArgument<S extends string, T, /* default type */ D> =
   undefined extends D
-    ? S extends `[${infer N}]`
+    ? S extends `[${string}]`
       ? T | undefined
       : T
     : T;
@@ -45,9 +44,9 @@ type StringArguments<S extends string> =
     : [StringUntypedArgument<S, undefined>];
 
 type StringTypedOption<S extends string, T, /* default type */ D> =
-  S extends `${infer Flags} <${infer N}>` | `${infer Flags} [${infer N}]` // Trim the ending ` <xxx>` or ` [xxx]`
+  S extends `${infer Flags} <${string}>` | `${infer Flags} [${string}]` // Trim the ending ` <xxx>` or ` [xxx]`
     ? StringTypedOption<Flags, T, D>
-    : S extends `-${infer Arg}, ${infer Rest}` // Trim the leading `-xxx, `
+    : S extends `-${string}, ${infer Rest}` // Trim the leading `-xxx, `
       ? StringTypedOption<Rest, T, D>
       : S extends `-${infer Arg}` // Trim the leading `-`.
         ? StringTypedOption<Arg, T, D>

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -44,12 +44,12 @@ type StringArguments<S extends string> =
     : [StringUntypedArgument<S, undefined>];
 
 type StringTypedOption<S extends string, T, /* default type */ D> =
-  S extends `${infer Flags} <${string}>` | `${infer Flags} [${string}]` // Trim the ending ` <xxx>` or ` [xxx]`
+  S extends `${infer Flags} <${string}>` | `${infer Flags} [${string}]` | `${infer Flags} ` // Trim the ending ` <xxx>` or ` [xxx]` or ` `
     ? StringTypedOption<Flags, T, D>
-    : S extends `-${string}, ${infer Rest}` // Trim the leading `-xxx, `
+    : S extends `-${string},${infer Rest}` // Trim the leading `-xxx,`
       ? StringTypedOption<Rest, T, D>
-      : S extends `-${infer Arg}` // Trim the leading `-`.
-        ? StringTypedOption<Arg, T, D>
+      : S extends `-${infer Rest}` | ` ${infer Rest}` // Trim the leading `-` or ' '.
+        ? StringTypedOption<Rest, T, D>
         : S extends `no-${infer Rest}` // Check the leading `no-`
           ? { [K in CamelCase<Rest>]: T }
           : undefined extends D

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -44,7 +44,7 @@ type StringArguments<S extends string, /* default type */ D> =
     ? [StringUntypedArgument<A, D>, ...StringArguments<Rest, D>]
     : [StringUntypedArgument<S, D>];
 
-type StringTypedOption<S extends string, T, /* default type */ D extends T | undefined> =
+type StringTypedOption<S extends string, T, /* default type */ D> =
   S extends `${infer Flags} <${infer N}>` | `${infer Flags} [${infer N}]` // Trim the ending ` <xxx>` or ` [xxx]`
     ? StringTypedOption<Flags, T, D>
     : S extends `-${infer Arg}, ${infer Rest}` // Trim the leading `-xxx, `
@@ -57,7 +57,7 @@ type StringTypedOption<S extends string, T, /* default type */ D extends T | und
             ? { [K in CamelCase<S>]?: T }
             : { [K in CamelCase<S>]: T };
 
-type StringUntypedOption<S extends string, /* default type */ D extends StringImpliedType<S, true> | undefined> =
+type StringUntypedOption<S extends string, /* default type */ D> =
   StringTypedOption<S, StringImpliedType<S, true>, D>;
 
 export class CommanderError extends Error {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -28,14 +28,14 @@ type StringImpliedType<S extends string, /* fallback to boolean */ F extends boo
             : never;
 
 type StringTypedArgument<S extends string, T, /* default type */ D> =
-  D extends undefined
+  undefined extends D
     ? S extends `[${infer N}]`
       ? T | undefined
       : T
     : T;
 
 type StringUntypedArgument<S extends string, /* default type */ D> =
-  D extends undefined
+  undefined extends D
     ? StringImpliedType<S>
     : NonNullable<StringImpliedType<S>>;
 
@@ -53,7 +53,7 @@ type StringTypedOption<S extends string, T, /* default type */ D> =
         ? StringTypedOption<Arg, T, D>
         : S extends `no-${infer Rest}` // Check the leading `no-`
           ? { [K in CamelCase<Rest>]: T }
-          : D extends undefined
+          : undefined extends D
             ? { [K in CamelCase<S>]?: T }
             : { [K in CamelCase<S>]: T };
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -24,7 +24,7 @@ type StringImpliedType<S extends string, /* fallback to boolean */ F extends boo
             : string | undefined
           : F extends true
             ? boolean
-            : never;
+            : string;
 
 type StringTypedArgument<S extends string, T, /* default type */ D> =
   undefined extends D

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -39,10 +39,10 @@ type StringUntypedArgument<S extends string, /* default type */ D> =
     ? StringImpliedType<S>
     : NonNullable<StringImpliedType<S>>;
 
-type StringArguments<S extends string, /* default type */ D> =
+type StringArguments<S extends string> =
   S extends `${infer A} ${infer Rest}`
-    ? [StringUntypedArgument<A, D>, ...StringArguments<Rest, D>]
-    : [StringUntypedArgument<S, D>];
+    ? [StringUntypedArgument<A, undefined>, ...StringArguments<Rest>]
+    : [StringUntypedArgument<S, undefined>];
 
 type StringTypedOption<S extends string, T, /* default type */ D> =
   S extends `${infer Flags} <${infer N}>` | `${infer Flags} [${infer N}]` // Trim the ending ` <xxx>` or ` [xxx]`
@@ -449,7 +449,7 @@ export class Command<Args extends unknown[] = [], Options extends { [K: string]:
    *
    * @returns `this` command for chaining
    */
-  arguments<Names extends string>(names: Names): Command<[...Args, ...StringArguments<Names, undefined>], Options>;
+  arguments<Names extends string>(names: Names): Command<[...Args, ...StringArguments<Names>], Options>;
 
   /**
    * Override default decision whether to add implicit help command.

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -43,6 +43,11 @@ type StringArguments<S extends string> =
     ? [StringUntypedArgument<A, undefined>, ...StringArguments<Rest>]
     : [StringUntypedArgument<S, undefined>];
 
+type StringCommand<S extends string> =
+  S extends `${string} ${infer Rest}`
+    ? StringArguments<Rest>
+    : never;
+
 type StringTypedOption<S extends string, T, /* default type */ D> =
   S extends `${infer Flags} <${string}>` | `${infer Flags} [${string}]` | `${infer Flags} ` // Trim the ending ` <xxx>` or ` [xxx]` or ` `
     ? StringTypedOption<Flags, T, D>
@@ -366,7 +371,7 @@ export class Command<Args extends unknown[] = [], Options extends { [K: string]:
    * @param opts - configuration options
    * @returns new command
    */
-  command(nameAndArgs: string, opts?: CommandOptions): ReturnType<this['createCommand']>;
+  command<T extends string>(nameAndArgs: T, opts?: CommandOptions): Command<StringCommand<T>>;
   /**
    * Define a command, implemented in a separate executable file.
    *
@@ -385,7 +390,7 @@ export class Command<Args extends unknown[] = [], Options extends { [K: string]:
    * @param opts - configuration options
    * @returns `this` command for chaining
    */
-  command(nameAndArgs: string, description: string, opts?: ExecutableCommandOptions): this;
+  command<T extends string>(nameAndArgs: T, description: string, opts?: ExecutableCommandOptions): Command<StringCommand<T>>;
 
   /**
    * Factory routine to create a new unattached command.

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -760,6 +760,7 @@ export class Command<Args extends unknown[] = [], Options extends { [K: string]:
    * Return an object containing local option values as key-value pairs
    */
   opts<T extends OptionValues>(): T & Options;
+  opts(): Options;
 
   /**
    * Return an object containing merged local and global option values as key-value pairs.

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -443,7 +443,7 @@ export class Command<Args extends unknown[] = [], Options extends { [K: string]:
    *
    * @returns `this` command for chaining
    */
-  arguments(names: string): this;
+  arguments<Names extends string>(names: Names): Command<[...Args, ...StringUntypedArguments<Names, undefined>], Options>;
 
   /**
    * Override default decision whether to add implicit help command.

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -547,7 +547,8 @@ export class Command<Args extends unknown[] = [], Options extends { [K: string]:
    *
    * @returns `this` command for chaining
    */
-  action(fn: (this: this, ...args: [...Args, Options, this]) => (void | Promise<void>)): this;
+  action(fn: (this: this, ...args: [...Args, Options, this]) => void | Promise<void>): this;
+  action<A extends unknown[], O extends OptionValues>(fn: (this: this, ...args: [...A, ...Args, O & Options, this]) => void | Promise<void>): this;
 
   /**
    * Define option with `flags`, `description` and optional

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -135,14 +135,14 @@ export class Argument<Arg extends string, T = StringImpliedType<Arg>, D = undefi
   argOptional(): this;
 }
 
-export class Option<Flags extends string, T = StringImpliedType<Flags, true>, D = undefined> {
+export class Option<Flags extends string, T = StringImpliedType<Flags, true>, D = undefined, M = false> {
   flags: Flags;
   description: string;
 
-  required: boolean; // A value must be supplied when the option is specified.
-  optional: boolean; // A value is optional when the option is specified.
-  variadic: boolean;
-  mandatory: boolean; // The option must have a value after parsing, which usually means it must be specified on command line.
+  required: Flags extends `${string}<${string}>${string}` ? true : false; // A value must be supplied when the option is specified.
+  optional: Flags extends `${string}<${string}>${string}` ? false : true; // A value is optional when the option is specified.
+  variadic: Flags extends `${string}[${string}...]${string}` | `${string}<${string}...>${string}` ? true : false;
+  mandatory: M; // The option must have a value after parsing, which usually means it must be specified on command line.
   optionFlags: string;
   short: string | undefined;
   long: string | undefined;
@@ -158,7 +158,7 @@ export class Option<Flags extends string, T = StringImpliedType<Flags, true>, D 
   /**
    * Set the default value, and optionally supply the description to be displayed in the help.
    */
-  default<D2>(value: D2, description?: string): Option<Flags, T, D2>;
+  default<D2>(value: D2, description?: string): Option<Flags, T, D2, M>;
 
   /**
    * Preset to use when option used without option-argument, especially optional but also boolean and negated.
@@ -210,12 +210,12 @@ export class Option<Flags extends string, T = StringImpliedType<Flags, true>, D 
   /**
    * Set the custom handler for processing CLI option arguments into option values.
    */
-  argParser<T2>(fn: (value: string, previous: T2) => T2): Option<Flags, T2, D>;
+  argParser<T2>(fn: (value: string, previous: T2) => T2): Option<Flags, T2, D, M>;
 
   /**
    * Whether the option is mandatory and must have a value after parsing.
    */
-  makeOptionMandatory(mandatory?: boolean): this;
+  makeOptionMandatory<M2 extends boolean = true>(mandatory?: M2): Option<Flags, T, D, M2>;
 
   /**
    * Hide option in help.
@@ -625,7 +625,7 @@ export class Command<Args extends unknown[] = [], Options extends { [K: string]:
    *
    * See .option() and .requiredOption() for creating and attaching an option in a single call.
    */
-  addOption<Flags extends string, T, D>(option: Option<Flags, T, D>): Command<Args, Options & StringTypedOption<Flags, T, D>>;
+  addOption<Flags extends string, T, D, M>(option: Option<Flags, T, D, M>): Command<Args, Options & M extends true ? Required<StringTypedOption<Flags, T, D>> : StringTypedOption<Flags, T, D>>;
 
   /**
    * Whether to store option values as properties on command object,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -54,6 +54,9 @@ type StringTypedOption<S extends string, T, /* default type */ D extends T | und
             ? { [K in CamelCase<S>]?: T }
             : { [K in CamelCase<S>]: T };
 
+type StringUntypedOption<S extends string, /* default type */ D extends StringImpliedType<S, true> | undefined> =
+  StringTypedOption<S, StringImpliedType<S, true>, D>;
+
 export class CommanderError extends Error {
   code: string;
   exitCode: number;
@@ -586,8 +589,8 @@ export class Command<Args extends unknown[] = [], Options extends { [K: string]:
    *
    * @returns `this` command for chaining
    */
-  option<Flags extends string>(flags: Flags, description?: string): Command<Args, Options & StringTypedOption<Flags, StringImpliedType<Flags, true>, undefined>>;
-  option<Flags extends string, D extends StringImpliedType<Flags, true> | undefined>(flags: Flags, description: string, defaultValue: D): Command<Args, Options & StringTypedOption<Flags, StringImpliedType<Flags, true>, D>>;
+  option<Flags extends string>(flags: Flags, description?: string): Command<Args, Options & StringUntypedOption<Flags, undefined>>;
+  option<Flags extends string, D extends StringImpliedType<Flags, true> | undefined>(flags: Flags, description: string, defaultValue: D): Command<Args, Options & StringUntypedOption<Flags, D>>;
   option<Flags extends string, T>(flags: Flags, description: string, fn: (value: string, previous: T) => T): Command<Args, Options & StringTypedOption<Flags, T, undefined>>;
   option<Flags extends string, T, D extends T | undefined>(flags: Flags, description: string, fn: (value: string, previous: T) => T, defaultValue: D): Command<Args, Options & StringTypedOption<Flags, T, D>>;
   /** @deprecated since v7, instead use choices or a custom function */
@@ -599,8 +602,8 @@ export class Command<Args extends unknown[] = [], Options extends { [K: string]:
    *
    * The `flags` string contains the short and/or long flags, separated by comma, a pipe or space.
    */
-  requiredOption<Flags extends string>(flags: Flags, description?: string): Command<Args, Options & Required<StringTypedOption<Flags, StringImpliedType<Flags, true>, undefined>>>;
-  requiredOption<Flags extends string, D extends StringImpliedType<Flags, true> | undefined>(flags: Flags, description: string, defaultValue: D): Command<Args, Options & Required<StringTypedOption<Flags, StringImpliedType<Flags, true>, D>>>;
+  requiredOption<Flags extends string>(flags: Flags, description?: string): Command<Args, Options & Required<StringUntypedOption<Flags, undefined>>>;
+  requiredOption<Flags extends string, D extends StringImpliedType<Flags, true> | undefined>(flags: Flags, description: string, defaultValue: D): Command<Args, Options & Required<StringUntypedOption<Flags, D>>>;
   requiredOption<Flags extends string, T>(flags: Flags, description: string, fn: (value: string, previous: T) => T): Command<Args, Options & Required<StringTypedOption<Flags, T, undefined>>>;
   requiredOption<Flags extends string, T, D extends T | undefined>(flags: Flags, description: string, fn: (value: string, previous: T) => T, defaultValue: D): Command<Args, Options & Required<StringTypedOption<Flags, T, D>>>;
   /** @deprecated since v7, instead use choices or a custom function */

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -46,7 +46,7 @@ type StringArguments<S extends string> =
 type StringCommand<S extends string> =
   S extends `${string} ${infer Rest}`
     ? StringArguments<Rest>
-    : never;
+    : [];
 
 type StringTypedOption<S extends string, T, /* default type */ D> =
   S extends `${infer Flags} <${string}>` | `${infer Flags} [${string}]` | `${infer Flags} ` // Trim the ending ` <xxx>` or ` [xxx]` or ` `

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -371,7 +371,7 @@ export class Command<Args extends unknown[] = [], Options extends { [K: string]:
    * @param opts - configuration options
    * @returns new command
    */
-  command<T extends string>(nameAndArgs: T, opts?: CommandOptions): Command<StringCommand<T>>;
+  command<T extends string>(nameAndArgs: T, opts?: CommandOptions): (<T>() => T extends this['createCommand'] ? 1 : 2) extends (<T>() => T extends Command['createCommand'] ? 1 : 2) ? Command<StringCommand<T>> : ReturnType<this['createCommand']>;
   /**
    * Define a command, implemented in a separate executable file.
    *

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -16,13 +16,13 @@ expectType<commander.Command>(commander.program);
 // Check export classes and functions exist
 expectType<commander.Command>(new commander.Command());
 expectType<commander.Command>(new commander.Command('name'));
-expectType<commander.Option>(new commander.Option('-f'));
+expectType<commander.Option<'-f'>>(new commander.Option('-f'));
 expectType<commander.CommanderError>(new commander.CommanderError(1, 'code', 'message'));
 expectType<commander.InvalidArgumentError>(new commander.InvalidArgumentError('message'));
 expectType<commander.InvalidArgumentError>(new commander.InvalidOptionArgumentError('message'));
 expectType<commander.Command>(commander.createCommand());
-expectType<commander.Option>(commander.createOption('--demo'));
-expectType<commander.Argument>(commander.createArgument('<foo>'));
+expectType<commander.Option<'--demo'>>(commander.createOption('--demo'));
+expectType<commander.Argument<'<foo>'>>(commander.createArgument('<foo>'));
 
 // Command properties
 expectType<string[]>(program.args);
@@ -46,14 +46,14 @@ expectType<commander.Command>(program.command('exec', 'exec description', { isDe
 expectType<commander.Command>(program.addCommand(new commander.Command('abc')));
 
 // argument
-expectType<commander.Command>(program.argument('<value>'));
-expectType<commander.Command>(program.argument('<value>', 'description'));
-expectType<commander.Command>(program.argument('[value]', 'description', 'default'));
-expectType<commander.Command>(program.argument('[value]', 'description', parseFloat));
-expectType<commander.Command>(program.argument('[value]', 'description', parseFloat, 1.23));
+expectType<commander.Command<[string]>>(program.argument('<value>'));
+expectType<commander.Command<[string]>>(program.argument('<value>', 'description'));
+expectType<commander.Command<[string]>>(program.argument('[value]', 'description', 'default'));
+expectType<commander.Command<[number|undefined]>>(program.argument('[value]', 'description', parseFloat));
+expectType<commander.Command<[number]>>(program.argument('[value]', 'description', parseFloat, 1.23));
 
 // arguments
-expectType<commander.Command>(program.arguments('<cmd> [env]'));
+expectType<commander.Command<[string, string|undefined]>>(program.arguments('<cmd> [env]'));
 
 // addHelpCommand
 expectType<commander.Command>(program.addHelpCommand());
@@ -96,10 +96,10 @@ expectType<commander.Command>(program.action(() => {}));
 expectType<commander.Command>(program.action(async() => {}));
 
 // option
-expectType<commander.Command>(program.option('-a,--alpha'));
-expectType<commander.Command>(program.option('-p, --peppers', 'Add peppers'));
-expectType<commander.Command>(program.option('-s, --string [value]', 'default string', 'value'));
-expectType<commander.Command>(program.option('-b, --boolean', 'default boolean', false));
+expectType<commander.Command<[], {alpha?: boolean}>>(program.option('-a,--alpha'));
+expectType<commander.Command<[], {peppers?: boolean}>>(program.option('-p, --peppers', 'Add peppers'));
+expectType<commander.Command<[], {string: string|boolean}>>(program.option('-s, --string [value]', 'default string', 'value'));
+expectType<commander.Command<[], {boolean: boolean}>>(program.option('-b, --boolean', 'default boolean', false));
 expectType<commander.Command>(program.option('--drink <size', 'drink size', /small|medium|large/)); // deprecated
 
 // example coercion functions from README
@@ -120,35 +120,35 @@ function commaSeparatedList(value: string): string[] {
   return value.split(',');
 }
 
-expectType<commander.Command>(program.option('-f, --float <number>', 'float argument', parseFloat));
-expectType<commander.Command>(program.option('-f, --float <number>', 'float argument', parseFloat, 3.2));
-expectType<commander.Command>(program.option('-i, --integer <number>', 'integer argument', myParseInt));
-expectType<commander.Command>(program.option('-i, --integer <number>', 'integer argument', myParseInt, 5));
-expectType<commander.Command>(program.option('-v, --verbose', 'verbosity that can be increased', increaseVerbosity, 0));
-expectType<commander.Command>(program.option('-c, --collect <value>', 'repeatable value', collect, []));
-expectType<commander.Command>(program.option('-l, --list <items>', 'comma separated list', commaSeparatedList));
+expectType<commander.Command<[], {float?: number}>>(program.option('-f, --float <number>', 'float argument', parseFloat));
+expectType<commander.Command<[], {float: number}>>(program.option('-f, --float <number>', 'float argument', parseFloat, 3.2));
+expectType<commander.Command<[], {integer?: number}>>(program.option('-i, --integer <number>', 'integer argument', myParseInt));
+expectType<commander.Command<[], {integer: number}>>(program.option('-i, --integer <number>', 'integer argument', myParseInt, 5));
+expectType<commander.Command<[], {verbose: number}>>(program.option('-v, --verbose', 'verbosity that can be increased', increaseVerbosity, 0));
+expectType<commander.Command<[], {collect: string[]}>>(program.option('-c, --collect <value>', 'repeatable value', collect, []));
+expectType<commander.Command<[], {list?: string[]}>>(program.option('-l, --list <items>', 'comma separated list', commaSeparatedList));
 
 // requiredOption, same tests as option
-expectType<commander.Command>(program.requiredOption('-a,--alpha'));
-expectType<commander.Command>(program.requiredOption('-p, --peppers', 'Add peppers'));
-expectType<commander.Command>(program.requiredOption('-s, --string [value]', 'default string', 'value'));
-expectType<commander.Command>(program.requiredOption('-b, --boolean', 'default boolean', false));
+expectType<commander.Command<[], {alpha: boolean}>>(program.requiredOption('-a,--alpha'));
+expectType<commander.Command<[], {peppers: boolean}>>(program.requiredOption('-p, --peppers', 'Add peppers'));
+expectType<commander.Command<[], {string: string|boolean}>>(program.requiredOption('-s, --string [value]', 'default string', 'value'));
+expectType<commander.Command<[], {boolean: boolean}>>(program.requiredOption('-b, --boolean', 'default boolean', false));
 expectType<commander.Command>(program.requiredOption('--drink <size', 'drink size', /small|medium|large/)); // deprecated
 
-expectType<commander.Command>(program.requiredOption('-f, --float <number>', 'float argument', parseFloat));
-expectType<commander.Command>(program.requiredOption('-f, --float <number>', 'float argument', parseFloat, 3.2));
-expectType<commander.Command>(program.requiredOption('-i, --integer <number>', 'integer argument', myParseInt));
-expectType<commander.Command>(program.requiredOption('-i, --integer <number>', 'integer argument', myParseInt, 5));
-expectType<commander.Command>(program.requiredOption('-v, --verbose', 'verbosity that can be increased', increaseVerbosity, 0));
-expectType<commander.Command>(program.requiredOption('-c, --collect <value>', 'repeatable value', collect, []));
-expectType<commander.Command>(program.requiredOption('-l, --list <items>', 'comma separated list', commaSeparatedList));
+expectType<commander.Command<[], {float: number}>>(program.requiredOption('-f, --float <number>', 'float argument', parseFloat));
+expectType<commander.Command<[], {float: number}>>(program.requiredOption('-f, --float <number>', 'float argument', parseFloat, 3.2));
+expectType<commander.Command<[], {integer: number}>>(program.requiredOption('-i, --integer <number>', 'integer argument', myParseInt));
+expectType<commander.Command<[], {integer: number}>>(program.requiredOption('-i, --integer <number>', 'integer argument', myParseInt, 5));
+expectType<commander.Command<[], {verbose: number}>>(program.requiredOption('-v, --verbose', 'verbosity that can be increased', increaseVerbosity, 0));
+expectType<commander.Command<[], {collect: string[]}>>(program.requiredOption('-c, --collect <value>', 'repeatable value', collect, []));
+expectType<commander.Command<[], {list: string[]}>>(program.requiredOption('-l, --list <items>', 'comma separated list', commaSeparatedList));
 
 // createOption
-expectType<commander.Option>(program.createOption('a, --alpha'));
-expectType<commander.Option>(program.createOption('a, --alpha', 'description'));
+expectType<commander.Option<'a, --alpha'>>(program.createOption('a, --alpha'));
+expectType<commander.Option<'a, --alpha'>>(program.createOption('a, --alpha', 'description'));
 
 // addOption
-expectType<commander.Command>(program.addOption(new commander.Option('-s,--simple')));
+expectType<commander.Command<[], {simple?: boolean}>>(program.addOption(new commander.Option('-s,--simple')));
 
 // storeOptionsAsProperties
 expectType<commander.Command & commander.OptionValues>(program.storeOptionsAsProperties());
@@ -354,7 +354,7 @@ expectType<commander.Command>(program.configureOutput({
 // Help
 const helper = new commander.Help();
 const helperCommand = new commander.Command();
-const helperOption = new commander.Option('-a, --all');
+const helperOption = new commander.Option('-a, --all <arg>');
 const helperArgument = new commander.Argument('<file>');
 
 expectType<number | undefined>(helper.helpWidth);
@@ -371,8 +371,8 @@ expectType<string>(helper.argumentTerm(helperArgument));
 expectType<string>(helper.argumentDescription(helperArgument));
 
 expectType<commander.Command[]>(helper.visibleCommands(helperCommand));
-expectType<commander.Option[]>(helper.visibleOptions(helperCommand));
-expectType<commander.Argument[]>(helper.visibleArguments(helperCommand));
+expectType<Array<commander.Option<any, any, any, any>>>(helper.visibleOptions(helperCommand));
+expectType<Array<commander.Argument<any, any, any>>>(helper.visibleArguments(helperCommand));
 
 expectType<number>(helper.longestSubcommandTermLength(helperCommand, helper));
 expectType<number>(helper.longestOptionTermLength(helperCommand, helper));
@@ -388,42 +388,42 @@ expectType<string>(helper.formatHelp(helperCommand, helper));
 const baseOption = new commander.Option('-f,--foo', 'foo description');
 
 // default
-expectType<commander.Option>(baseOption.default(3));
-expectType<commander.Option>(baseOption.default(60, 'one minute'));
+expectType<commander.Option<'-f,--foo', boolean, number>>(baseOption.default(3));
+expectType<commander.Option<'-f,--foo', boolean, number>>(baseOption.default(60, 'one minute'));
 
 // preset
-expectType<commander.Option>(baseOption.preset(123));
-expectType<commander.Option>(baseOption.preset('abc'));
+expectType<commander.Option<'-f,--foo'>>(baseOption.preset(123));
+expectType<commander.Option<'-f,--foo'>>(baseOption.preset('abc'));
 
 // env
-expectType<commander.Option>(baseOption.env('PORT'));
+expectType<commander.Option<'-f,--foo'>>(baseOption.env('PORT'));
 
 // fullDescription
 expectType<string>(baseOption.fullDescription());
 
 // argParser
-expectType<commander.Option>(baseOption.argParser((value: string) => parseInt(value)));
-expectType<commander.Option>(baseOption.argParser((value: string, previous: string[]) => { return previous.concat(value); }));
+expectType<commander.Option<'-f,--foo', number>>(baseOption.argParser((value: string) => parseInt(value)));
+expectType<commander.Option<'-f,--foo', string[]>>(baseOption.argParser((value: string, previous: string[]) => { return previous.concat(value); }));
 
 // makeOptionMandatory
-expectType<commander.Option>(baseOption.makeOptionMandatory());
-expectType<commander.Option>(baseOption.makeOptionMandatory(true));
+expectType<commander.Option<'-f,--foo', boolean, undefined, true>>(baseOption.makeOptionMandatory());
+expectType<commander.Option<'-f,--foo', boolean, undefined, true>>(baseOption.makeOptionMandatory(true));
 
 // hideHelp
-expectType<commander.Option>(baseOption.hideHelp());
-expectType<commander.Option>(baseOption.hideHelp(true));
-expectType<commander.Option>(baseOption.hideHelp(false));
+expectType<commander.Option<'-f,--foo'>>(baseOption.hideHelp());
+expectType<commander.Option<'-f,--foo'>>(baseOption.hideHelp(true));
+expectType<commander.Option<'-f,--foo'>>(baseOption.hideHelp(false));
 
 // choices
-expectType<commander.Option>(baseOption.choices(['a', 'b']));
-expectType<commander.Option>(baseOption.choices(['a', 'b'] as const));
+expectType<commander.Option<'-f,--foo'>>(baseOption.choices(['a', 'b']));
+expectType<commander.Option<'-f,--foo'>>(baseOption.choices(['a', 'b'] as const));
 
 // conflicts
-expectType<commander.Option>(baseOption.conflicts('a'));
-expectType<commander.Option>(baseOption.conflicts(['a', 'b']));
+expectType<commander.Option<'-f,--foo'>>(baseOption.conflicts('a'));
+expectType<commander.Option<'-f,--foo'>>(baseOption.conflicts(['a', 'b']));
 
 // implies
-expectType<commander.Option>(baseOption.implies({ option: 'VALUE', colour: false }));
+expectType<commander.Option<'-f,--foo'>>(baseOption.implies({ option: 'VALUE', colour: false }));
 
 // name
 expectType<string>(baseOption.name());
@@ -446,23 +446,23 @@ expectType<boolean>(baseArgument.variadic);
 expectType<string>(baseArgument.name());
 
 // default
-expectType<commander.Argument>(baseArgument.default(3));
-expectType<commander.Argument>(baseArgument.default(60, 'one minute'));
+expectType<commander.Argument<any, any, number>>(baseArgument.default(3));
+expectType<commander.Argument<any, any, number>>(baseArgument.default(60, 'one minute'));
 
 // argParser
-expectType<commander.Argument>(baseArgument.argParser((value: string) => parseInt(value)));
-expectType<commander.Argument>(baseArgument.argParser((value: string, previous: string[]) => { return previous.concat(value); }));
+expectType<commander.Argument<any, number>>(baseArgument.argParser((value: string) => parseInt(value)));
+expectType<commander.Argument<any, string[]>>(baseArgument.argParser((value: string, previous: string[]) => { return previous.concat(value); }));
 
 // choices
-expectType<commander.Argument>(baseArgument.choices(['a', 'b']));
-expectType<commander.Argument>(baseArgument.choices(['a', 'b'] as const));
+expectType<commander.Argument<any>>(baseArgument.choices(['a', 'b']));
+expectType<commander.Argument<any>>(baseArgument.choices(['a', 'b'] as const));
 
 // argRequired
-expectType<commander.Argument>(baseArgument.argRequired());
+expectType<commander.Argument<any>>(baseArgument.argRequired());
 
 // argOptional
-expectType<commander.Argument>(baseArgument.argOptional());
+expectType<commander.Argument<any>>(baseArgument.argOptional());
 
 // createArgument
-expectType<commander.Argument>(program.createArgument('<name>'));
-expectType<commander.Argument>(program.createArgument('<name>', 'description'));
+expectType<commander.Argument<any>>(program.createArgument('<name>'));
+expectType<commander.Argument<any>>(program.createArgument('<name>', 'description'));


### PR DESCRIPTION
# Pull Request

<!--
The text in these markdown comments is instructions that will not appear in the displayed pull request,
and can be deleted.

Please submit pull requests against the develop branch.

Follow the existing code style. Check the tests succeed, including lint.
  npm run test
  npm run lint

Don't update the CHANGELOG or command version number. That gets done by maintainers when preparing the release.

Commander currently has zero production dependencies. That isn't a hard requirement, but is a simple story. Requests which 
add a dependency are much less likely to be accepted, and we are likely to ask if there alternative approaches to avoid the dependency.
-->

## Problem

<!--
What problem are you solving?
What Issues does this relate to?
Show the broken output if appropriate.
-->
This is related to #1245, #1585, similar to #1356 that tries to improve the TypeScript writing experiences. Commander and TypeScript have changed a lot, and improving the typings of commander today, to provide more specific type information of given options, has become more feasible.

## Solution

<!--
How did you solve the problem? 
Show the fixed output if appropriate.

There are a lot of forms of documentation which could need updating for a change in functionality. It
is ok if you want to show us the code to discuss before doing the extra work, and
you should say so in your comments so we focus on the concept first before talking about all the other pieces:

- TypeScript typings
- JSDoc documentation in code
- tests
- README
- examples/
-->
This PR creates a generic class for each `Argument`, `Option`, and `Command`, and solves the camelCase, `.action`, `.addArgument`, `.addOption`, and `.opts` problems that blocked #1356. You can try this [TS Playground link](https://www.typescriptlang.org/play?exactOptionalPropertyTypes=true&lib=lib.es2015.d.ts#code/PTAEAEBsEsCMC5QFMDOAmADARgKwCgAXATwAclQBhAQwFslJqUkAeAZWQA8CkA7AExSgUBAE7QeAcwB8oALyh2SLrwGgABgBIA3uIBmSEaADqAXwC02vQdAAlVARNq8oUAH5Kteoxaatp7dQk0ARUMABeLHbCUo5SzqCIrADceISk5Kyi4hIAkjQkMEh8ACrpbJzc-ILCYpIANKDAAFSguqGQsFQAxgDWoAQA9qCwAwOQSFQ8oE1gAGIVKoIjYxNT8m2QTDKy8YrKVeraNdkmzEdZkiYAdDdSTi4u7gDax-WgN1evEk8Auj-xLkSCwOvi+Jie51qEmuNx+9wej1A8yUlVUogArkgAQi3EILt8fqAAD7DUbjSbYhGIL6-SkJBTA1Sg-GnSEnO50xFfTn0vaowTMqHgtmXOE8xHI-ZokSY8UPdxfYmklYUnFq+mKkno-hIXTiIpyxCS-n9GVY9U49zLck8OWA0A8JAANwMKTSZAU+NKZD4AEERBJ0XQeARyijFnioQ1ig1mqA+LqqOjIAR+ulpmAACLbeLahN6x18RmCTPY9x8iNqCFaMFitXuYpKvO6-V8OmIYrYjtu4gezJQgCqIfSfoDQd4oYrBy+sZa+aTKbTHpmoGzclzOoLRWLq7LnqheQK0CK3pYrDiVNAADkBjwr8nIFRYOM2PjD4USmVz1Ie+n+9l-UDYMCBQMMpWqfEcxcKcmUsHh9EMX0TFAOCENsexHD3J5-0kIdeyKQDxxDZhfQaZstz4KQGg+HCJEI4DQKiAgpH+S9sPxPCR3oic2DIzdWxY38+y9EcAHkSAIaBbzAk0Z1AGNGjnRNk1TfCM1XKCGXDEFUOsWZHwkFBkLOGsWTuJVfCsQx9KoQzkOrWs1EaMBijEGh+gAC3IFRsnUUBmA4QLzIGQwnKeQKODreV92yU8+HEyTpJswzowabMuy08D1AsUyhQaXTDCYxxnPktzPPIck+F8tQzAihp4QRcsRJ9BKpJ4ZgmNSjT20yk0aoK0BAOKkBSugdyCC80BKuqsw1CuHkmqhOLWukwCuvSi0gW0pkeAGHKrPQ4RhrACgvN6cqpomKrJHUXbZrldwtFAJ4AGlQHEDw6AYKgmA6+wWI7UATENUByNbHdSwtRrQCe173qmagvu8NgWNcQHgahh5EFht6PsRrwfrPAH5KBoSMg44cWoktqZIjOS43nFSl3IFc1x2aDmqKFb2tYBpaPfY9PzIXjTUxKiNLJ0AAFkDAkJBudA0jQAAIW2UAAApfVAAAyFWAEodwO0TcS0OGPp6JAiAGXRQFEn5EFE16fmQxBHRdEQ3QTLpHxEchvZ+wRuOIwCdzkxt5H5-IP1PEiA3FzM5FB-jCxkLR4i6W8anRLpBhEdWqADRA1vjVAujEanbzRyNsj1lIXEZlNmEzNApHVp1QkxRBm4aBMUDL6AK54Kuvj1oux2A2OJHWlu69AAuJAABQLpgRGYYoW-V3QeEQNuO6Qal8QaEhfadKT0RQDs0AN2QZHX0fBvHnji-XtKfzwYG8C9n2-cfFBBG55gyVBDbQglGEmEc3xR0FjHIBDQMRIHjonMGhYGhS0ThsLYMN4i+wAI7omgL7PgRoDLAKyoKE4JkwRSBFNCJy7h4H0gwUgJIJUtbt0gJiUANBz6plgOQFA6ISBHm3AAdy8lMCa5ABiD3etUMgXRoB6iKPNFw0jEo8FCMQ2ypC+o0NZLldkei6GtFCEwek8CWEjTYXvWRoA1FtVCKAMRvALr2NvLYlA8jFGCxUaAduYgqBVS6FowyO5yGXAciyD4PwjEWT0ZQqJtxYn0LNIw0xzD06ZwxDnEKm8SEhJQD3Uu5d1HD3xLXeIDdQzN1buwzuq40BFL7iUtqZSoT3wAbA+SaVGnSzfi4eeS8RArzXhvLeO86n72rm8Y+zoz4X3klfOQt8r4O0HoAkh0ZemZlQf0rhVALbcylpMPgVBc5EGYFLNAO5rSrETvA1uNATlnJCkQKuVyOnrK6QpHZ0sZ7v1SF-AuP8A6UAGDQJ5-BJ46IjNqHou0RE8F+InX4DQFY7hxgfKE9sk7woGIioGictAmFTvEQJo4gJPwDKHQ+3SNL50Lg-SlwcAzrSkPfCg4LIV8GYE8D4gFCkxUkHFIOoZn6vx+GiweKA9nks6SQmlYCfm7PVm47etsvmbLpb8qW7LECcohSc6FqDZby2lcwBWqCdwMPcHYPBBCiiviWmJTV2i2UyESJzeKrqUraqkP62e88iKhiAYq7I0ZW66HyUiLVvd+6DyxeG1o6rd4cKmXJWZp8Bjnw7NfW+HKuVGr5TcAVfMvWio2W6ulyCigsSleomVgbH7EVDSA6ZU9tU7kbFqZOta8naIKU0+N6jE1vHGRrSZo6O2Zvmbm5ZdKqkADU95dwLYaqFxarilqFRIEVzaQ1ap+XWjVDbZX7uYFeTwYbJCtw0XQRAl66BDpaZXKda7uW8v5QGQVtFOI+grY+pAfF8wCUlSetqjayXnsA9ejtCc22R2EULFggGZA9pAyndWd6pmAefQPEd7ailtBUsutNq79WFo3V+31v7KYEWg54CV9aINnuZSBC9ngYXTkglhzjD7OPvqLdRwVNF8SitAoBmVYGFaypzm1TeKaJrQAWUpkTNx54LM3duy1nllM-DzROgY0AiwkgXiIcFymWBOiM5RPW99VOzzVZW0JbaviRujV0uNL6h5voo+unl26ZYBjNQ2i10qy2Djo969RznBU1sogG+ITnW1ZTkvBrKiHo5lC6Q8psvbKL9sMoOkuzT8NtSnURhcBBSP1MzIJqFgXTUKzCw2iL2Q-1cx9YK7MiXVFddgxGwrCzPPFLK7eCryaJkrsI6AGd2aFnFAM4tvzH7GvBeazp2iy0utdXi-6vZyWFWudpT8rteWMN9qjQOmNVavNjfVXJcdqb6kZpPrO+SS3Kskem3VlbRq1tyw2+Fnd22YvfNfr10AuD8GEPldo2D7nrsjdK4PNpNc-sNe-Sa9b5qdN2ph462j+Fos0y6Xt-bs9ocOpJ0lI7qXaXpZNJl6B2WtW5fQy2TDV2is3d9XdhNM2l0-fqwFrH0smu4+B-j6nTr2tRbh76nrkOqew-68dpViOefI+HeVmbT3J0zbmzmj787ltgv88a8XOPQt46QPawhsvhUurB4e4DnPa0U+wXbgnNP2opdkidtKZ2OcUU18N2No2BePZTQb17cz5tzpvgu5SKYatTN++b1bYuguA8l619C9vCdeoV4Ko9nu+sgXVp8htKQP4Zx4MIWb5mJAiFoInR0IjM8nKr-EK4QbgLqwAOTMHnh8KQg+9a97VUPswgqzCz9EP5NzE+p+DxnzwBo8+eBBn8tvmgfCRDj4aIPwfDR7z74MJPlwVxp+D7MLATf9+yQr+v7fswXRH9dE8JAd-hMzDcGEBf3eDfyoEfzukmAGEkRECfzGCAKuBV063URnxEEf1wSX0ggnzdGPgGBb1oD7zk1vHVgZV9TURQAM2JQqXr0b1IMTmwNwJoBvwkhQCrzdCoNTDoNbxoGuXkA7y734B72v37wnCHxHzjjgKEJDCHyeDUTMH8TMFH1hDgLfznwX0MGYGXyv2ALXzvw31AC3x32YD3wPyP1ABPzPyDAP00MYKQLvwfz0JgMgCUO0Pf0-2-1-yYH-3sCcJsPkLAL2ggKgIcLgIQN92QNQLt3QKhHHwqTwA4NoDQHwKQOIIaDUW3VIPIJMEoKyTsSYO4KbxwM4ISNIJYNSDYPyPoIAGZ28kBO8DVuUBCtCfCVCah5CRA1Cvgx9vD5MdCwCDCjCDATCzDrwLDL9V8fCP97CWiQoHDnoIofgujCC79QDJjRBWjoDpjrRZjApolgjvdqduYwj7C0D1CMCYi4iaAKjEj5MsMBhAIEoyD50KCUgyjSCqj5BzjLjiiYiyiJDUweCaimVg0RD54zBdBzMaB39f4UBOisiG9Uw1VqjO8Di78BhH81VQTwTISA5xCAwhkV51Zz9LDe8nlDlB5jl+AXkRAiASi8AyjziAAWREvgvgBovvPgClIE34qwuVNfNVM45vTg+kq4wg5InIkCDI2E6gpgxk94gU2gIUr4lIIAA), scroll to the bottom, hover the variables, make some changes and see if there're some syntax I failed to support.

![`opts` hover result](https://user-images.githubusercontent.com/22674396/175013150-b9874011-993d-4e6f-af7a-a12c4b9fddf3.png)


However, there're still some other problems like `storeOptionsAsProperties`, which is likely able to be solved by intersecting the generics returned with `this`, but I experienced a huge performance impact when I add that `& this` to each `.argument` and `.option` overload.

Also, the result of chaining off of commander needs to be assigned to a new variable. This can be improved if one day TS supports [Non‑void returning assertion functions](https://github.com/microsoft/TypeScript/issues/40562).

Any comment on this?

## ChangeLog

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->
