### PR TITLE
Option-arguments after the double dash being ignored

### DIFF
--- a/tests/options.variadic.test.js
+++ b/tests/options.variadic.test.js
@@ -167,4 +167,15 @@ describe('variadic special cases', () => {
 
     expect(program.options[0].variadic).toBeFalsy();
   });
+
+  test('when option flags arguments includes -- then some literals the argument values includes all of them except --', () => {
+    // This might be used to describe coercion for comma separated values, and is not variadic.
+    const program = new commander.Command();
+    program
+      .option('-a, --arguments [values...]');
+
+    program.parse(['--arguments', '--', 'one', 'two', '-non-option', 'four'], { from: 'user' });
+
+    expect(program.opts().arguments).toEqual(['one', 'two', '-non-option', 'four']);
+  });
 });


### PR DESCRIPTION
# Pull Request

<!--
The text in these markdown comments is instructions that will not appear in the displayed pull request,
and can be deleted.

Please submit pull requests against the develop branch.

Follow the existing code style. Check the tests succeed, including lint.
  npm run test
  npm run lint

Don't update the CHANGELOG or command version number. That gets done by maintainers when preparing the release.

Commander currently has zero production dependencies. That isn't a hard requirement, but is a simple story. Requests which 
add a dependency are much less likely to be accepted, and we are likely to ask if there alternative approaches to avoid the dependency.
-->

### Overview

When we use a variadic option argument, it will not accept literal arguments starting with dash (`-`, e.g. `-abcdefg-`), that's expected because we consider those arguments to be option arguments. In order to pass a non-option argument (one starting with dash) we have to make use of double dash (`--`) before it (such as `... --variadic-option arg1 arg2 -- -non-option-argument arg4 ...`). See [Utility Syntax Guidelines, Guideline 10](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html).


## Problem

<!--
What problem are you solving?
What Issues does this relate to?
Show the broken output if appropriate.
-->

Option-arguments placed after the first double dash will not be read, but they should be.

So, given this example:

```sh
$ my-program my-command --my-variadic-option-argument "value1" "value number 2" -- "-my-non-option-argument" "one more argument"
```

The expected behavior is:

```ts
program.parse(<the given example argv>);
const myValues = program.opts().myVariadicOptionArgument;
// myValues = ['value1', 'value number 2', '-my-non-option-argument', 'one more argument']
```

But the current behavior is:

```ts
program.parse(<the given example argv>);
const myValues = program.opts().myVariadicOptionArgument;
// myValues = ['value1', 'value number 2']
```

## Solution

<!--
How did you solve the problem? 
Show the fixed output if appropriate.

There are a lot of forms of documentation which could need updating for a change in functionality. It
is ok if you want to show us the code to discuss before doing the extra work, and
you should say so in your comments so we focus on the concept first before talking about all the other pieces:

- TypeScript typings
- JSDoc documentation in code
- tests
- README
- examples/
-->

**TBD:** needs to be confirmed before proceeding.

## ChangeLog

- Adds a test case for the expected behavior of option-arguments that are placed after the first double dash in the argv.

**TODO**
- Make the parser to do not ignore option-arguments after the first double dash; only stop parsing options.

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->
