### PR TITLE
Expose Command.options property

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -277,7 +277,7 @@ export class Command {
   processedArgs: any[];
   commands: Command[];
   parent: Command | null;
-  readonly options: ReadonlyArray<Readonly<Option>>;
+  readonly options: Option[];
 
   constructor(name?: string);
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -277,6 +277,7 @@ export class Command {
   processedArgs: any[];
   commands: Command[];
   parent: Command | null;
+  readonly options: ReadonlyArray<Readonly<Option>>;
 
   constructor(name?: string);
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -276,8 +276,8 @@ export class Command {
   args: string[];
   processedArgs: any[];
   commands: Command[];
+  options: Option[];
   parent: Command | null;
-  readonly options: Option[];
 
   constructor(name?: string);
 

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -29,8 +29,8 @@ expectType<string[]>(program.args);
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 expectType<any[]>(program.processedArgs);
 expectType<commander.Command[]>(program.commands);
-expectType<commander.Command | null>(program.parent);
 expectType<commander.Option[]>(program.options);
+expectType<commander.Command | null>(program.parent);
 
 // version
 expectType<commander.Command>(program.version('1.2.3'));

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -30,7 +30,7 @@ expectType<string[]>(program.args);
 expectType<any[]>(program.processedArgs);
 expectType<commander.Command[]>(program.commands);
 expectType<commander.Command | null>(program.parent);
-expectType<ReadonlyArray<Readonly<commander.Option>>>(program.options);
+expectType<commander.Option[]>(program.options);
 
 // version
 expectType<commander.Command>(program.version('1.2.3'));

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -30,6 +30,7 @@ expectType<string[]>(program.args);
 expectType<any[]>(program.processedArgs);
 expectType<commander.Command[]>(program.commands);
 expectType<commander.Command | null>(program.parent);
+expectType<ReadonlyArray<Readonly<commander.Option>>>(program.options);
 
 // version
 expectType<commander.Command>(program.version('1.2.3'));


### PR DESCRIPTION
# Pull Request


<!--
The text in these markdown comments is instructions that will not appear in the displayed pull request,
and can be deleted.

Please submit pull requests against the develop branch.

Follow the existing code style. Check the tests succeed, including lint.
  npm run test
  npm run lint

Don't update the CHANGELOG or command version number. That gets done by maintainers when preparing the release.

Commander currently has zero production dependencies. That isn't a hard requirement, but is a simple story. Requests which 
add a dependency are much less likely to be accepted, and we are likely to ask if there alternative approaches to avoid the dependency.
-->

## Problem

I could not find a reason for options not to be exposes as this PR proposes.
Currently there is no way to introspect a command, `options` property is not exposed. That can be useful to build manuals, readme, and so one. I am targeting to build a GitHub Action definition https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions.
Options handlers, events and maybe others are parsed/settled at `addOption`. Once added, changing it can have unexpected results.
<!--
What problem are you solving?
What Issues does this relate to?
Show the broken output if appropriate.
-->

## Solution

Add a readonly field with readonly type.
<!--
How did you solve the problem? 
Show the fixed output if appropriate.

There are a lot of forms of documentation which could need updating for a change in functionality. It
is ok if you want to show us the code to discuss before doing the extra work, and
you should say so in your comments so we focus on the concept first before talking about all the other pieces:

- TypeScript typings
- JSDoc documentation in code
- tests
- README
- examples/
-->

## ChangeLog

Add options to Command type.
<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->
