### PR TITLE
Add implied to typedef and precedence

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -57,6 +57,15 @@ class Command extends EventEmitter {
     this._showHelpAfterError = false;
     this._showSuggestionAfterError = true;
 
+    // 'unknown' value is left out on purpose, should be treated as such
+    this._precedence = [
+      'default',
+      'implied', // implied by others configs
+      'config', // placeholder for configuration files
+      'env',
+      'cli'
+    ];
+
     // see .configureOutput() for docs
     this._outputConfiguration = {
       writeOut: (str) => process.stdout.write(str),
@@ -780,11 +789,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   setOptionValue(key, value) {
-    if (this._storeOptionsAsProperties) {
-      this[key] = value;
-    } else {
-      this._optionValues[key] = value;
-    }
+    this.setOptionValueWithSource(key, value);
     return this;
   }
 
@@ -797,8 +802,12 @@ Expecting one of '${allowedValues.join("', '")}'`);
     * @return {Command} `this` command for chaining
     */
 
-  setOptionValueWithSource(key, value, source) {
-    this.setOptionValue(key, value);
+  setOptionValueWithSource(key, value, source = 'unknown') {
+    if (this._storeOptionsAsProperties) {
+      this[key] = value;
+    } else {
+      this._optionValues[key] = value;
+    }
     this._optionValueSources[key] = source;
     return this;
   }
@@ -1584,7 +1593,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
       if (option.envVar && option.envVar in process.env) {
         const optionKey = option.attributeName();
         // Priority check. Do not overwrite cli or options from unknown source (client-code).
-        if (this.getOptionValue(optionKey) === undefined || ['default', 'config', 'env'].includes(this.getOptionValueSource(optionKey))) {
+        if (this.getOptionValue(optionKey) === undefined || this._isNewSourcePreferred('env', this.getOptionValueSource(optionKey))) {
           if (option.required || option.optional) { // option can take a value
             // keep very simple, optional always takes value
             this.emit(`optionEnv:${option.name()}`, process.env[option.envVar]);
@@ -1598,6 +1607,18 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   /**
+   * Check if newSource is preferred.
+   *
+   * @api private
+   */
+  _isNewSourcePreferred(newSource, existingSource) {
+    // unknown source should always take precedence. undefined existingSource means option not set.
+    if (newSource == null || !this._precedence.includes(newSource) || existingSource === undefined) return true;
+    if (existingSource === null || !this._precedence.includes(existingSource)) return false;
+    return this._precedence.indexOf(newSource) >= this._precedence.indexOf(existingSource);
+  }
+
+  /**
    * Apply any implied option values, if option is undefined or default value.
    *
    * @api private
@@ -1605,7 +1626,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
   _parseOptionsImplied() {
     const dualHelper = new DualOptions(this.options);
     const hasCustomOptionValue = (optionKey) => {
-      return this.getOptionValue(optionKey) !== undefined && !['default', 'implied'].includes(this.getOptionValueSource(optionKey));
+      return this.getOptionValue(optionKey) !== undefined && !this._isNewSourcePreferred('implied', this.getOptionValueSource(optionKey));
     };
     this.options
       .filter(option => (option.implied !== undefined) &&

--- a/lib/command.js
+++ b/lib/command.js
@@ -424,11 +424,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
     return this;
   }
 
-  strictPriority(priorities) {
+  strictPriority() {
     this._strictPriority = true;
-    if (priorities) {
-      this._priorities = priorities;
-    }
+    return this;
   }
 
   /**

--- a/lib/command.js
+++ b/lib/command.js
@@ -57,13 +57,14 @@ class Command extends EventEmitter {
     this._showHelpAfterError = false;
     this._showSuggestionAfterError = true;
 
-    // 'unknown' value is left out on purpose, should be treated as such
-    this._precedence = [
-      'default',
-      'implied', // implied by others configs
-      'config', // placeholder for configuration files
+    this._strictPriority = false;
+    this._priorities = [
+      'cli',
       'env',
-      'cli'
+      'config', // placeholder for configuration files
+      'implied', // implied by others configs
+      'default', // default option value
+      undefined // initial state, not touched yet
     ];
 
     // see .configureOutput() for docs
@@ -419,6 +420,13 @@ Expecting one of '${allowedValues.join("', '")}'`);
       this._lifeCycleHooks[event] = [listener];
     }
     return this;
+  }
+
+  strictPriority(priorities) {
+    this._strictPriority = true;
+    if (priorities) {
+      this._priorities = priorities;
+    }
   }
 
   /**
@@ -802,7 +810,8 @@ Expecting one of '${allowedValues.join("', '")}'`);
     * @return {Command} `this` command for chaining
     */
 
-  setOptionValueWithSource(key, value, source = 'unknown') {
+  setOptionValueWithSource(key, value, source = null) {
+    if (this._strictPriority && !this._isNewSourcePreferred(source, this.getOptionValueSource(key))) return;
     if (this._storeOptionsAsProperties) {
       this[key] = value;
     } else {
@@ -1612,10 +1621,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    * @api private
    */
   _isNewSourcePreferred(newSource, existingSource) {
-    // unknown source should always take precedence. undefined existingSource means option not set.
-    if (newSource == null || !this._precedence.includes(newSource) || existingSource === undefined) return true;
-    if (existingSource === null || !this._precedence.includes(existingSource)) return false;
-    return this._precedence.indexOf(newSource) >= this._precedence.indexOf(existingSource);
+    return this._priorities.indexOf(newSource) <= this._priorities.indexOf(existingSource);
   }
 
   /**

--- a/lib/command.js
+++ b/lib/command.js
@@ -115,6 +115,8 @@ class Command extends EventEmitter {
     this._enablePositionalOptions = sourceCommand._enablePositionalOptions;
     this._showHelpAfterError = sourceCommand._showHelpAfterError;
     this._showSuggestionAfterError = sourceCommand._showSuggestionAfterError;
+    this._strictPriority = sourceCommand._strictPriority;
+    this._priorities = sourceCommand._priorities;
 
     return this;
   }

--- a/lib/command.js
+++ b/lib/command.js
@@ -811,7 +811,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     */
 
   setOptionValueWithSource(key, value, source = null) {
-    if (this._strictPriority && !this._isNewSourcePreferred(source, this.getOptionValueSource(key))) return;
+    if (this._strictPriority && !this._isNewSourcePreferred(source, this.getOptionValueSource(key))) return this;
     if (this._storeOptionsAsProperties) {
       this[key] = value;
     } else {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -266,7 +266,7 @@ export interface OutputConfiguration {
 
 export type AddHelpTextPosition = 'beforeAll' | 'before' | 'after' | 'afterAll';
 export type HookEvent = 'preSubcommand' | 'preAction' | 'postAction';
-export type OptionValueSource = 'default' | 'env' | 'config' | 'cli';
+export type OptionValueSource = 'default' | 'implied' | 'config' | 'env' | 'cli' | 'unknown';
 
 export interface OptionValues {
   [key: string]: any;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -266,7 +266,7 @@ export interface OutputConfiguration {
 
 export type AddHelpTextPosition = 'beforeAll' | 'before' | 'after' | 'afterAll';
 export type HookEvent = 'preSubcommand' | 'preAction' | 'postAction';
-export type OptionValueSource = 'default' | 'implied' | 'config' | 'env' | 'cli' | 'unknown';
+export type OptionValueSource = 'default' | 'implied' | 'config' | 'env' | 'cli' | null;
 
 export interface OptionValues {
   [key: string]: any;
@@ -595,7 +595,7 @@ export class Command {
   /**
    * Retrieve option value source.
    */
-  getOptionValueSource(key: string): OptionValueSource;
+  getOptionValueSource(key: string): OptionValueSource | undefined;
 
   /**
    * Alter parsing of short flags with optional values.

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -172,7 +172,7 @@ expectType<commander.Command>(program.setOptionValue('example', true));
 expectType<commander.Command>(program.setOptionValueWithSource('example', [], 'cli'));
 
 // getOptionValueSource
-expectType<commander.OptionValueSource>(program.getOptionValueSource('example'));
+expectType<commander.OptionValueSource | undefined>(program.getOptionValueSource('example'));
 
 // combineFlagAndOptionalValue
 expectType<commander.Command>(program.combineFlagAndOptionalValue());


### PR DESCRIPTION
# Pull Request

<!--
The text in these markdown comments is instructions that will not appear in the displayed pull request,
and can be deleted.

Please submit pull requests against the develop branch.

Follow the existing code style. Check the tests succeed, including lint.
  npm run test
  npm run lint

Don't update the CHANGELOG or command version number. That gets done by maintainers when preparing the release.

Commander currently has zero production dependencies. That isn't a hard requirement, but is a simple story. Requests which 
add a dependency are much less likely to be accepted, and we are likely to ask if there alternative approaches to avoid the dependency.
-->

## Problem

I was trying to understand source. I had difficulties, so did some changes to try to make easier to understand.
Following https://github.com/tj/commander.js/pull/1788#issuecomment-1233405495.
- add implied to definition
- implement _isNewSourcePreferred instead of hardcoded includes
- set 'unknown' source when using `setOptionValue()`, instead of not changing the source.
<!--
What problem are you solving?
What Issues does this relate to?
Show the broken output if appropriate.
-->

## Solution

<!--
How did you solve the problem? 
Show the fixed output if appropriate.

There are a lot of forms of documentation which could need updating for a change in functionality. It
is ok if you want to show us the code to discuss before doing the extra work, and
you should say so in your comments so we focus on the concept first before talking about all the other pieces:

- TypeScript typings
- JSDoc documentation in code
- tests
- README
- examples/
-->

## ChangeLog

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->
