### PR TITLE
fix(types): update `defaultValue` types

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -535,10 +535,10 @@ export class Command {
    *
    * @returns `this` command for chaining
    */
-  option(flags: string, description?: string, defaultValue?: string | boolean | string[]): this;
+  option(flags: string, description?: string, defaultValue?: number | string | boolean | string[]): this;
   option<T>(flags: string, description: string, fn: (value: string, previous: T) => T, defaultValue?: T): this;
   /** @deprecated since v7, instead use choices or a custom function */
-  option(flags: string, description: string, regexp: RegExp, defaultValue?: string | boolean | string[]): this;
+  option(flags: string, description: string, regexp: RegExp, defaultValue?: number | string | boolean | string[]): this;
 
   /**
    * Define a required option, which must have a value after parsing. This usually means
@@ -546,10 +546,10 @@ export class Command {
    *
    * The `flags` string contains the short and/or long flags, separated by comma, a pipe or space.
    */
-  requiredOption(flags: string, description?: string, defaultValue?: string | boolean | string[]): this;
+  requiredOption(flags: string, description?: string, defaultValue?: number | string | boolean | string[]): this;
   requiredOption<T>(flags: string, description: string, fn: (value: string, previous: T) => T, defaultValue?: T): this;
   /** @deprecated since v7, instead use choices or a custom function */
-  requiredOption(flags: string, description: string, regexp: RegExp, defaultValue?: string | boolean | string[]): this;
+  requiredOption(flags: string, description: string, regexp: RegExp, defaultValue?: number | string | boolean | string[]): this;
 
   /**
    * Factory routine to create a new unattached option.

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -104,6 +104,7 @@ expectType<commander.Command>(program.action(async() => {}));
 // option
 expectType<commander.Command>(program.option('-a,--alpha'));
 expectType<commander.Command>(program.option('-p, --peppers', 'Add peppers'));
+expectType<commander.Command>(program.option('-p, --port <number>', 'port number', 80));
 expectType<commander.Command>(program.option('-s, --string [value]', 'default string', 'value'));
 expectType<commander.Command>(program.option('-b, --boolean', 'default boolean', false));
 expectType<commander.Command>(program.option('--drink <size', 'drink size', /small|medium|large/)); // deprecated
@@ -137,6 +138,7 @@ expectType<commander.Command>(program.option('-l, --list <items>', 'comma separa
 // requiredOption, same tests as option
 expectType<commander.Command>(program.requiredOption('-a,--alpha'));
 expectType<commander.Command>(program.requiredOption('-p, --peppers', 'Add peppers'));
+expectType<commander.Command>(program.requiredOption('-n, --number <number>', 'default number', 80));
 expectType<commander.Command>(program.requiredOption('-s, --string [value]', 'default string', 'value'));
 expectType<commander.Command>(program.requiredOption('-b, --boolean', 'default boolean', false));
 expectType<commander.Command>(program.requiredOption('--drink <size', 'drink size', /small|medium|large/)); // deprecated


### PR DESCRIPTION
# Description

Update the `defaultValue` type.  Example, 

```typescript
program
  .requiredOption("-p --port <number>", "port number", 8080)
  .option("-n --number <number>", "other number", 123);
```

