### PR TITLE
setOptionValue should clear option source

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -780,7 +780,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   setOptionValue(key, value) {
-    return this.setOptionValueWithSource(key, value);
+    return this.setOptionValueWithSource(key, value, undefined);
   }
 
   /**

--- a/lib/command.js
+++ b/lib/command.js
@@ -780,12 +780,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   setOptionValue(key, value) {
-    if (this._storeOptionsAsProperties) {
-      this[key] = value;
-    } else {
-      this._optionValues[key] = value;
-    }
-    return this;
+    return this.setOptionValueWithSource(key, value);
   }
 
   /**
@@ -798,7 +793,11 @@ Expecting one of '${allowedValues.join("', '")}'`);
     */
 
   setOptionValueWithSource(key, value, source) {
-    this.setOptionValue(key, value);
+    if (this._storeOptionsAsProperties) {
+      this[key] = value;
+    } else {
+      this._optionValues[key] = value;
+    }
     this._optionValueSources[key] = source;
     return this;
   }

--- a/tests/options.getset.test.js
+++ b/tests/options.getset.test.js
@@ -28,7 +28,7 @@ test('when setOptionValueWithSource then value returned by opts', () => {
   const cheeseValue = 'blue';
   program
     .option('--cheese [type]', 'cheese type')
-    .setOptionValue('cheese', cheeseValue);
+    .setOptionValueWithSource('cheese', cheeseValue, 'cli');
   expect(program.opts().cheese).toBe(cheeseValue);
 });
 
@@ -56,4 +56,13 @@ test('when option value parsed from cli then option source is cli', () => {
     .addOption(new commander.Option('-f, --foo').env('BAR'));
   program.parse(['--foo'], { from: 'user' });
   expect(program.getOptionValueSource('foo')).toBe('cli');
+});
+
+test('when setOptionValue then clears previous source', () => {
+  const program = new commander.Command();
+  program
+    .option('--foo', 'description', 'default value');
+  expect(program.getOptionValueSource('foo')).toBe('default');
+  program.setOptionValue('foo', 'bar');
+  expect(program.getOptionValueSource('foo')).toBeUndefined();
 });


### PR DESCRIPTION
# Pull Request

## Problem

Calling `.setOptionValue()` would leave behind any previous value for option source.

## Solution

Move the implementation of `.setOptionValue()` into `.setOptionValueWithSource()` and call it.

## ChangeLog

- fix: `.setOptionValue()` clears option source