### PR TITLE
Add copyInheritedSettings to README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -541,6 +541,7 @@ Configuration options can be passed with the call to `.command()` and `.addComma
 remove the command from the generated help output. Specifying `isDefault: true` will run the subcommand if no other
 subcommand is specified ([example](./examples/defaultCommand.js)).
 
+For safety, `.addCommand()` does not automatically copy the inherited settings from the parent command. There is a helper routine `.copyInheritedSettings()` for copying the settings when they are wanted.
 ### Command-arguments
 
 For subcommands, you can specify the argument syntax in the call to `.command()` (as shown above). This

--- a/Readme.md
+++ b/Readme.md
@@ -542,6 +542,7 @@ remove the command from the generated help output. Specifying `isDefault: true` 
 subcommand is specified ([example](./examples/defaultCommand.js)).
 
 For safety, `.addCommand()` does not automatically copy the inherited settings from the parent command. There is a helper routine `.copyInheritedSettings()` for copying the settings when they are wanted.
+
 ### Command-arguments
 
 For subcommands, you can specify the argument syntax in the call to `.command()` (as shown above). This


### PR DESCRIPTION
# Pull Request

## Problem

I deliberately didn't add `.copyInheritedSettings()` to README in #1557 as quite technical.

But it has come up now: #1778

## Solution

Only come up once, but I do prefer to mention everything offical in the README (and in a test!).
