### PR TITLE
Wrap command description in help

### DIFF
--- a/lib/help.js
+++ b/lib/help.js
@@ -381,23 +381,27 @@ class Help {
    */
 
   wrap(str, width, indent, minColumnWidth = 40) {
-    // Detect manually wrapped and indented strings by searching for line breaks
-    // followed by multiple spaces/tabs.
-    if (str.match(/[\n]\s+/)) return str;
+    // Full \s characters, minus the linefeeds.
+    const hSpaces = ' \\f\\t\\v\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000\ufeff';
+    // Detect manually wrapped and indented strings by searching for line break followed by spaces.
+    const manualIndent = new RegExp(`[\\n][${hSpaces}]+`);
+    if (str.match(manualIndent)) return str;
     // Do not wrap if not enough room for a wrapped column of text (as could end up with a word per line).
     const columnWidth = width - indent;
     if (columnWidth < minColumnWidth) return str;
 
     const leadingStr = str.slice(0, indent);
     const columnText = str.slice(indent);
-
     const indentString = ' '.repeat(indent);
-    const regex = new RegExp('.{1,' + (columnWidth - 1) + '}([\\s\u200B]|$)|[^\\s\u200B]+?([\\s\u200B]|$)', 'g');
+    const zeroWidthSpace = '\u200B';
+    const lineEnd = '([\\n\u2028\u2029])';
+    const breaks = `\\s${zeroWidthSpace}`;
+    // match leading line end (so empty lines don't collapse),
+    // or as much text as will fit in column, or excess text up to first break
+    const regex = new RegExp(`${lineEnd}|.{1,${columnWidth - 1}}([${breaks}]|$)|[^${breaks}]+?([${breaks}]|$)`, 'g');
     const lines = columnText.match(regex) || [];
     return leadingStr + lines.map((line, i) => {
-      if (line.slice(-1) === '\n') {
-        line = line.slice(0, line.length - 1);
-      }
+      if (line === '\n') return ''; // preserve empty lines
       return ((i > 0) ? indentString : '') + line.trimEnd();
     }).join('\n');
   }

--- a/lib/help.js
+++ b/lib/help.js
@@ -322,7 +322,7 @@ class Help {
     // Description
     const commandDescription = helper.commandDescription(cmd);
     if (commandDescription.length > 0) {
-      output = output.concat([commandDescription, '']);
+      output = output.concat([helper.wrap(commandDescription, helpWidth, 0), '']);
     }
 
     // Arguments
@@ -398,7 +398,7 @@ class Help {
       if (line.slice(-1) === '\n') {
         line = line.slice(0, line.length - 1);
       }
-      return ((i > 0) ? indentString : '') + line.trimRight();
+      return ((i > 0) ? indentString : '') + line.trimEnd();
     }).join('\n');
   }
 }

--- a/lib/help.js
+++ b/lib/help.js
@@ -391,11 +391,11 @@ class Help {
     if (columnWidth < minColumnWidth) return str;
 
     const leadingStr = str.slice(0, indent);
-    const columnText = str.slice(indent);
+    const columnText = str.slice(indent).replace('\r\n', '\n');
     const indentString = ' '.repeat(indent);
     const zeroWidthSpace = '\u200B';
     const breaks = `\\s${zeroWidthSpace}`;
-    // Match leading line end (so empty lines don't collapse),
+    // Match line end (so empty lines don't collapse),
     // or as much text as will fit in column, or excess text up to first break.
     const regex = new RegExp(`\n|.{1,${columnWidth - 1}}([${breaks}]|$)|[^${breaks}]+?([${breaks}]|$)`, 'g');
     const lines = columnText.match(regex) || [];

--- a/lib/help.js
+++ b/lib/help.js
@@ -382,9 +382,9 @@ class Help {
 
   wrap(str, width, indent, minColumnWidth = 40) {
     // Full \s characters, minus the linefeeds.
-    const hSpaces = ' \\f\\t\\v\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000\ufeff';
+    const indents = ' \\f\\t\\v\u00a0\u1680\u2000-\u200a\u202f\u205f\u3000\ufeff';
     // Detect manually wrapped and indented strings by searching for line break followed by spaces.
-    const manualIndent = new RegExp(`[\\n][${hSpaces}]+`);
+    const manualIndent = new RegExp(`[\\n][${indents}]+`);
     if (str.match(manualIndent)) return str;
     // Do not wrap if not enough room for a wrapped column of text (as could end up with a word per line).
     const columnWidth = width - indent;
@@ -394,11 +394,10 @@ class Help {
     const columnText = str.slice(indent);
     const indentString = ' '.repeat(indent);
     const zeroWidthSpace = '\u200B';
-    const lineEnd = '([\\n\u2028\u2029])';
     const breaks = `\\s${zeroWidthSpace}`;
-    // match leading line end (so empty lines don't collapse),
-    // or as much text as will fit in column, or excess text up to first break
-    const regex = new RegExp(`${lineEnd}|.{1,${columnWidth - 1}}([${breaks}]|$)|[^${breaks}]+?([${breaks}]|$)`, 'g');
+    // Match leading line end (so empty lines don't collapse),
+    // or as much text as will fit in column, or excess text up to first break.
+    const regex = new RegExp(`\n|.{1,${columnWidth - 1}}([${breaks}]|$)|[^${breaks}]+?([${breaks}]|$)`, 'g');
     const lines = columnText.match(regex) || [];
     return leadingStr + lines.map((line, i) => {
       if (line === '\n') return ''; // preserve empty lines

--- a/tests/help.wrap.test.js
+++ b/tests/help.wrap.test.js
@@ -97,7 +97,7 @@ Options:
     expect(program.helpInformation()).toBe(expectedOutput);
   });
 
-  test('when long command description then wrap and indent', () => {
+  test('when long subcommand description then wrap and indent', () => {
     const program = new commander.Command();
     program
       .configureHelp({ helpWidth: 80 })
@@ -142,7 +142,7 @@ Commands:
     expect(program.helpInformation()).toBe(expectedOutput);
   });
 
-  test('when option descripton preformatted then only add small indent', () => {
+  test('when option description pre-formatted then only add small indent', () => {
     // #396: leave custom format alone, apart from space-space indent
     const optionSpec = '-t, --time <HH:MM>';
     const program = new commander.Command();
@@ -166,6 +166,27 @@ Options:
   -h, --help          display help for command
 `;
 
+    expect(program.helpInformation()).toBe(expectedOutput);
+  });
+
+  test('when command description long then wrapped', () => {
+    const program = new commander.Command();
+    program
+      .configureHelp({ helpWidth: 80 })
+      .description(`Do fugiat eiusmod ipsum laboris excepteur pariatur sint ullamco tempor labore eu Do fugiat eiusmod ipsum laboris excepteur pariatur sint ullamco tempor labore eu
+After line break Do fugiat eiusmod ipsum laboris excepteur pariatur sint ullamco tempor labore eu Do fugiat eiusmod ipsum laboris excepteur pariatur sint ullamco tempor labore eu`);
+    const expectedOutput = `Usage:  [options]
+
+Do fugiat eiusmod ipsum laboris excepteur pariatur sint ullamco tempor labore
+eu Do fugiat eiusmod ipsum laboris excepteur pariatur sint ullamco tempor
+labore eu
+After line break Do fugiat eiusmod ipsum laboris excepteur pariatur sint
+ullamco tempor labore eu Do fugiat eiusmod ipsum laboris excepteur pariatur
+sint ullamco tempor labore eu
+
+Options:
+  -h, --help  display help for command
+`;
     expect(program.helpInformation()).toBe(expectedOutput);
   });
 });

--- a/tests/help.wrap.test.js
+++ b/tests/help.wrap.test.js
@@ -41,11 +41,18 @@ ${' '.repeat(10)}${'a '.repeat(5)}a`);
     expect(wrapped).toEqual(text);
   });
 
-  test('when text has line breaks then respect and indent', () => {
+  test('when text has line break then respect and indent', () => {
     const text = 'term description\nanother line';
     const helper = new commander.Help();
     const wrapped = helper.wrap(text, 78, 5);
     expect(wrapped).toEqual('term description\n     another line');
+  });
+
+  test('when text has consecutive line breaks then respect and indent', () => {
+    const text = 'term description\n\nanother line';
+    const helper = new commander.Help();
+    const wrapped = helper.wrap(text, 78, 5);
+    expect(wrapped).toEqual('term description\n\n     another line');
   });
 
   test('when text already formatted with line breaks and indent then do not touch', () => {

--- a/tests/help.wrap.test.js
+++ b/tests/help.wrap.test.js
@@ -55,6 +55,20 @@ ${' '.repeat(10)}${'a '.repeat(5)}a`);
     expect(wrapped).toEqual('term description\n\n     another line');
   });
 
+  test('when text has Windows line break then respect and indent', () => {
+    const text = 'term description\r\nanother line';
+    const helper = new commander.Help();
+    const wrapped = helper.wrap(text, 78, 5);
+    expect(wrapped).toEqual('term description\n     another line');
+  });
+
+  test('when text has Windows consecutive line breaks then respect and indent', () => {
+    const text = 'term description\r\n\r\nanother line';
+    const helper = new commander.Help();
+    const wrapped = helper.wrap(text, 78, 5);
+    expect(wrapped).toEqual('term description\n\n     another line');
+  });
+
   test('when text already formatted with line breaks and indent then do not touch', () => {
     const text = 'term a '.repeat(25) + '\n   ' + 'a '.repeat(25) + 'a';
     const helper = new commander.Help();


### PR DESCRIPTION
# Pull Request

## Problem

The "full" command description is not being wrapped in the help.

See: #1785

## Solution

Add wrapping of full description.

To work nicely with complex multiline descriptions, some subtle changes to the patterns:
- don't block wrapping just because text contains consecutive empty lines (look for pre-indented lines)
- preserve empty lines in description

Being conservative and marked as semver major because changing help may break client unit tests that depend on the exact output, although only a cosmetic change.

## ChangeLog

- add wrapping of command description in help
