### PR TITLE
Add extra-typings to README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1012,7 +1012,7 @@ program
 ### TypeScript
 
 extra-typings: There is an optional project to infer extra type information from the option and argument definitions.
-This changes the action handler and `.opts()` from weakly typed to strongly typed.
+This adds strong typing to the options returned by `.opts()` and the parameters to `.action()`.
 See [commander-js/extra-typings](https://github.com/commander-js/extra-typings) for more.
 
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -1011,7 +1011,15 @@ program
 
 ### TypeScript
 
-If you use `ts-node` and  stand-alone executable subcommands written as `.ts` files, you need to call your program through node to get the subcommands called correctly. e.g.
+extra-typings: There is an optional project to infer extra type information from the option and argument definitions.
+This changes the action handler and `.opts()` from weakly typed to strongly typed.
+See [commander-js/extra-typings](https://github.com/commander-js/extra-typings) for more.
+
+```
+import { Command } from '@commander-js/extra-typings';
+```
+
+ts-node: If you use `ts-node` and  stand-alone executable subcommands written as `.ts` files, you need to call your program through node to get the subcommands called correctly. e.g.
 
 ```sh
 node -r ts-node/register pm.ts


### PR DESCRIPTION
We have experimental "extra-typings" available with strong inferred types. The type definition file is much more complex and comes with some downsides, so not a simple switch. Likely to stay as a separate project at least until we find out more.

Add mention to the README so has some visibility.

See #1774