### PR TITLE
Update minimum version of node in v10 README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1106,7 +1106,7 @@ There is more information available about:
 
 ## Support
 
-The current version of Commander is fully supported on Long Term Support versions of Node.js, and requires at least v12.20.0.
+The current version of Commander is fully supported on Long Term Support versions of Node.js, and requires at least v14.
 (For older versions of Node.js, use an older version of Commander.)
 
 The main forum for free and community support is the project [Issues](https://github.com/tj/commander.js/issues) on GitHub.

--- a/Readme_zh-CN.md
+++ b/Readme_zh-CN.md
@@ -1059,7 +1059,7 @@ program
 
 ## 支持
 
-当前版本的 Commander 在 LTS 版本的 Node.js 上完全支持。并且至少需要 v12.20.0。
+当前版本的 Commander 在 LTS 版本的 Node.js 上完全支持。并且至少需要 v14。
 （使用更低版本 Node.js 的用户建议安装更低版本的 Commander）
 
 社区支持请访问项目的 [Issues](https://github.com/tj/commander.js/issues)。


### PR DESCRIPTION
I bumped the required version of node in `package.json` for Commander v10, but missed the mention in the README.