### PR TITLE
fix: add options field to Command type declaration

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -278,6 +278,7 @@ export class Command {
   args: string[];
   processedArgs: any[];
   commands: Command[];
+  options: Option[];
   parent: Command | null;
 
   constructor(name?: string);

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -277,8 +277,8 @@ export interface OptionValues {
 export class Command {
   args: string[];
   processedArgs: any[];
-  commands: Command[];
-  options: Option[];
+  readonly commands: Command[];
+  readonly options: Option[];
   parent: Command | null;
 
   constructor(name?: string);

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -277,8 +277,8 @@ export interface OptionValues {
 export class Command {
   args: string[];
   processedArgs: any[];
-  readonly commands: Command[];
-  readonly options: Option[];
+  readonly commands: readonly Command[];
+  readonly options: readonly Option[];
   parent: Command | null;
 
   constructor(name?: string);

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -28,7 +28,8 @@ expectType<commander.Argument>(commander.createArgument('<foo>'));
 expectType<string[]>(program.args);
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 expectType<any[]>(program.processedArgs);
-expectType<commander.Command[]>(program.commands);
+expectType<ReadonlyArray<commander.Command>>(program.commands);
+expectType<ReadonlyArray<commander.Option>>(program.options);
 expectType<commander.Command | null>(program.parent);
 
 // version


### PR DESCRIPTION
# Pull Request

<!--
The text in these markdown comments is instructions that will not appear in the displayed pull request,
and can be deleted.

Please submit pull requests against the develop branch.

Follow the existing code style. Check the tests succeed, including lint.
  npm run test
  npm run lint

Don't update the CHANGELOG or command version number. That gets done by maintainers when preparing the release.

Commander currently has zero production dependencies. That isn't a hard requirement, but is a simple story. Requests which 
add a dependency are much less likely to be accepted, and we are likely to ask if there alternative approaches to avoid the dependency.
-->

## Problem

The Command type for TypeScript doesn't expose the `options` field.
<!--
What problem are you solving?
What Issues does this relate to?
Show the broken output if appropriate.
-->

## Solution

Added the `options` field to the Command TypeScript type declaration, with the same type as specified in the JSDoc (`Option[]`)
<!--
How did you solve the problem? 
Show the fixed output if appropriate.

There are a lot of forms of documentation which could need updating for a change in functionality. It
is ok if you want to show us the code to discuss before doing the extra work, and
you should say so in your comments so we focus on the concept first before talking about all the other pieces:

- TypeScript typings
- JSDoc documentation in code
- tests
- README
- examples/
-->

## ChangeLog

fix: add options field to Command type declaration
<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->
