### PR TITLE
Add Command.options to TypeScript

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -277,7 +277,8 @@ export interface OptionValues {
 export class Command {
   args: string[];
   processedArgs: any[];
-  commands: Command[];
+  readonly commands: readonly Command[];
+  readonly options: readonly Option[];
   parent: Command | null;
 
   constructor(name?: string);

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -28,7 +28,8 @@ expectType<commander.Argument>(commander.createArgument('<foo>'));
 expectType<string[]>(program.args);
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 expectType<any[]>(program.processedArgs);
-expectType<commander.Command[]>(program.commands);
+expectType<readonly commander.Command[]>(program.commands);
+expectType<readonly commander.Option[]>(program.options);
 expectType<commander.Command | null>(program.parent);
 
 // version


### PR DESCRIPTION
# Pull Request

## Problem

People want to access `options` on the command object from TypeScript. See: #1784 #1825

But we don't want people to muck with the options array...

I have been suggesting `Help.visibleOptions()`, but it is really only a good match for cases where client wants the automatic options included or the hidden options removed. It is a bit indirect as a general access method.

## Solution

Add `options`. 

Make both `options` and `commands` readonly to discourage direct modification, as suggested in #1184 by @vonagam and in #1784 by @mshima.

All three authors of previous related PR added as co-authors on this PR. Thanks for your past contributions!

## ChangeLog

- added: TypeScript: `options` property of `Command`
- changed: TypeScript: `commands` property of `Command` is now readonly
