### PR TITLE
Add getOptionValueSourceWithGlobals

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -815,6 +815,25 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   /**
+    * Get source of option value. See also .optsWithGlobals().
+    * Expected values are default | config | env | cli | implied
+    *
+    * @param {string} key
+    * @return {string}
+    */
+
+  getOptionValueSourceWithGlobals(key) {
+    // global overwrites local, like optsWithGlobals
+    let source;
+    getCommandAndParents(this).forEach((cmd) => {
+      if (cmd.getOptionValueSource(key) !== undefined) {
+        source = cmd.getOptionValueSource(key);
+      }
+    });
+    return source;
+  }
+
+  /**
    * Get user arguments from implied or explicit arguments.
    * Side-effects: set _scriptPath if args included script. Used for default program name, and subcommand searches.
    *

--- a/tests/options.optsWithGlobals.test.js
+++ b/tests/options.optsWithGlobals.test.js
@@ -1,63 +1,115 @@
 const commander = require('../');
 
-test('when variety of options used with program then opts is same as optsWithGlobals', () => {
-  const program = new commander.Command();
-  program
-    .option('-b, --boolean')
-    .option('-r, --require-value <value)')
-    .option('-f, --float <value>', 'description', parseFloat)
-    .option('-d, --default-value <value)', 'description', 'default value')
-    .option('-n, --no-something');
+// Testing optsWithGlobals and getOptionValueSourceWithGlobals with focus on globals.
 
-  program.parse(['-b', '-r', 'req', '-f', '1e2'], { from: 'user' });
-  expect(program.opts()).toEqual(program.optsWithGlobals());
+describe('optsWithGlobals', () => {
+  test('when variety of options used with program then opts is same as optsWithGlobals', () => {
+    const program = new commander.Command();
+    program
+      .option('-b, --boolean')
+      .option('-r, --require-value <value)')
+      .option('-f, --float <value>', 'description', parseFloat)
+      .option('-d, --default-value <value)', 'description', 'default value')
+      .option('-n, --no-something');
+
+    program.parse(['-b', '-r', 'req', '-f', '1e2'], { from: 'user' });
+    expect(program.opts()).toEqual(program.optsWithGlobals());
+  });
+
+  test('when options in sub and program then optsWithGlobals includes both', () => {
+    const program = new commander.Command();
+    let mergedOptions;
+    program
+      .option('-g, --global <value>');
+    program
+      .command('sub')
+      .option('-l, --local <value)')
+      .action((options, cmd) => {
+        mergedOptions = cmd.optsWithGlobals();
+      });
+
+    program.parse(['-g', 'GGG', 'sub', '-l', 'LLL'], { from: 'user' });
+    expect(mergedOptions).toEqual({ global: 'GGG', local: 'LLL' });
+  });
+
+  test('when options in sub and subsub then optsWithGlobals includes both', () => {
+    const program = new commander.Command();
+    let mergedOptions;
+    program
+      .command('sub')
+      .option('-g, --global <value)')
+      .command('subsub')
+      .option('-l, --local <value)')
+      .action((options, cmd) => {
+        mergedOptions = cmd.optsWithGlobals();
+      });
+
+    program.parse(['sub', '-g', 'GGG', 'subsub', '-l', 'LLL'], { from: 'user' });
+    expect(mergedOptions).toEqual({ global: 'GGG', local: 'LLL' });
+  });
+
+  test('when same named option in sub and program then optsWithGlobals includes global', () => {
+    const program = new commander.Command();
+    let mergedOptions;
+    program
+      .option('-c, --common <value>')
+      .enablePositionalOptions();
+    program
+      .command('sub')
+      .option('-c, --common <value)')
+      .action((options, cmd) => {
+        mergedOptions = cmd.optsWithGlobals();
+      });
+
+    program.parse(['-c', 'GGG', 'sub', '-c', 'LLL'], { from: 'user' });
+    expect(mergedOptions).toEqual({ common: 'GGG' });
+  });
 });
 
-test('when options in sub and program then optsWithGlobals includes both', () => {
-  const program = new commander.Command();
-  let mergedOptions;
-  program
-    .option('-g, --global <value>');
-  program
-    .command('sub')
-    .option('-l, --local <value)')
-    .action((options, cmd) => {
-      mergedOptions = cmd.optsWithGlobals();
-    });
+describe('getOptionValueSourceWithGlobals', () => {
+  test('when option used with simple command then source is defined', () => {
+    const program = new commander.Command();
+    program
+      .option('-g, --global');
 
-  program.parse(['-g', 'GGG', 'sub', '-l', 'LLL'], { from: 'user' });
-  expect(mergedOptions).toEqual({ global: 'GGG', local: 'LLL' });
-});
+    program.parse(['-g'], { from: 'user' });
+    expect(program.getOptionValueSourceWithGlobals('global')).toEqual('cli');
+  });
 
-test('when options in sub and subsub then optsWithGlobals includes both', () => {
-  const program = new commander.Command();
-  let mergedOptions;
-  program
-    .command('sub')
-    .option('-g, --global <value)')
-    .command('subsub')
-    .option('-l, --local <value)')
-    .action((options, cmd) => {
-      mergedOptions = cmd.optsWithGlobals();
-    });
+  test('when option used with program then source is defined', () => {
+    const program = new commander.Command();
+    program
+      .option('-g, --global');
+    const sub = program.command('sub')
+      .option('-l, --local')
+      .action(() => {});
 
-  program.parse(['sub', '-g', 'GGG', 'subsub', '-l', 'LLL'], { from: 'user' });
-  expect(mergedOptions).toEqual({ global: 'GGG', local: 'LLL' });
-});
+    program.parse(['sub', '-g'], { from: 'user' });
+    expect(sub.getOptionValueSourceWithGlobals('global')).toEqual('cli');
+  });
 
-test('when same named option in sub and program then optsWithGlobals includes global', () => {
-  const program = new commander.Command();
-  let mergedOptions;
-  program
-    .option('-c, --common <value>')
-    .enablePositionalOptions();
-  program
-    .command('sub')
-    .option('-c, --common <value)')
-    .action((options, cmd) => {
-      mergedOptions = cmd.optsWithGlobals();
-    });
+  test('when option used with subcommand then source is defined', () => {
+    const program = new commander.Command();
+    program
+      .option('-g, --global');
+    const sub = program.command('sub')
+      .option('-l, --local')
+      .action(() => {});
 
-  program.parse(['-c', 'GGG', 'sub', '-c', 'LLL'], { from: 'user' });
-  expect(mergedOptions).toEqual({ common: 'GGG' });
+    program.parse(['sub', '-l'], { from: 'user' });
+    expect(sub.getOptionValueSourceWithGlobals('local')).toEqual('cli');
+  });
+
+  test('when same named option in sub and program then source is defined by global', () => {
+    const program = new commander.Command();
+    program
+      .enablePositionalOptions()
+      .option('-c, --common <value>', 'description', 'default value');
+    const sub = program.command('sub')
+      .option('-c, --common <value>')
+      .action(() => {});
+
+    program.parse(['sub', '--common', 'value'], { from: 'user' });
+    expect(sub.getOptionValueSourceWithGlobals('common')).toEqual('default');
+  });
 });

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -600,9 +600,14 @@ export class Command {
   setOptionValueWithSource(key: string, value: unknown, source: OptionValueSource): this;
 
   /**
-   * Retrieve option value source.
+   * Get source of option value.
    */
   getOptionValueSource(key: string): OptionValueSource | undefined;
+
+  /**
+    * Get source of option value. See also .optsWithGlobals().
+   */
+  getOptionValueSourceWithGlobals(key: string): OptionValueSource | undefined;
 
   /**
    * Alter parsing of short flags with optional values.

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -174,6 +174,9 @@ expectType<commander.Command>(program.setOptionValueWithSource('example', [], 'c
 // getOptionValueSource
 expectType<commander.OptionValueSource | undefined>(program.getOptionValueSource('example'));
 
+// getOptionValueSourceWithGlobals
+expectType<commander.OptionValueSource | undefined>(program.getOptionValueSourceWithGlobals('example'));
+
 // combineFlagAndOptionalValue
 expectType<commander.Command>(program.combineFlagAndOptionalValue());
 expectType<commander.Command>(program.combineFlagAndOptionalValue(false));


### PR DESCRIPTION
# Pull Request

## Problem

We added `.optWithGlobals()` to make working with globals easier. And `.getOptionValueSource()` for more complex programs. But how do you get the option value source including globals?

See #1713

## Solution

Added `.getOptionValueSourceWithGlobals()`.

Sticking with the obvious and _long_ name. Not planning to add to README.

## ChangeLog

- Added: `.getOptionValueSourceWithGlobals()`
