### PR TITLE
Add mention of .alias() to README.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -543,6 +543,8 @@ Configuration options can be passed with the call to `.command()` and `.addComma
 remove the command from the generated help output. Specifying `isDefault: true` will run the subcommand if no other
 subcommand is specified ([example](./examples/defaultCommand.js)).
 
+You can add alternative names for a command with `.alias()`. ([example](./examples/alias.js))
+
 For safety, `.addCommand()` does not automatically copy the inherited settings from the parent command. There is a helper routine `.copyInheritedSettings()` for copying the settings when they are wanted.
 
 ### Command-arguments

--- a/examples/alias.js
+++ b/examples/alias.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+// This example shows giving alternative names for a command.
+
+// const { Command } = require('commander'); // (normal include)
+const { Command } = require('../'); // include commander in git clone of commander repo
+const program = new Command();
+
+program
+  .command('exec')
+  .argument('<script>')
+  .alias('ex')
+  .action((script) => {
+    console.log(`execute: ${script}`);
+  });
+
+program
+  .command('print')
+  .argument('<file>')
+  // Multiple aliases is unusual but supported! You can call alias multiple times,
+  // and/or add multiple aliases at once. Only the first alias is displayed in the help.
+  .alias('p')
+  .alias('pr')
+  .aliases(['display', 'show'])
+  .action((file) => {
+    console.log(`print: ${file}`);
+  });
+
+program.parse();
+
+// Try the following:
+//    node alias.js --help
+//    node alias.js exec script
+//    node alias.js ex script
+//    node alias.js print file
+//    node alias.js pr file
+//    node alias.js show file


### PR DESCRIPTION
# Problem

There is no longer any mention of `.alias()` in the README.

See: #1831

## Solution

Add a brief mention and example file.
