### PR TITLE
Remove unused property

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -89,7 +89,6 @@ export class Option {
   optional: boolean; // A value is optional when the option is specified.
   variadic: boolean;
   mandatory: boolean; // The option must have a value after parsing, which usually means it must be specified on command line.
-  optionFlags: string;
   short?: string;
   long?: string;
   negate: boolean;


### PR DESCRIPTION
# Pull Request

## Problem

The TypeScript definition for option includes `optionFlags`, but that is not defined in the JavaScript.

Added but not used in #1331

## Solution

Delete `optionFlags` definition.

## ChangeLog

- Fixed: Remove unused `Option.optionFlags` property from TypeScript defintiion
