### PR TITLE
Support of multiple values from env for variadic options

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -545,7 +545,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
           throw err;
         }
       } else if (val !== null && option.variadic) {
-        val = option._concatValue(val, oldValue);
+        val = option._concatValue(val.split(/ +/), oldValue || []);
       }
 
       // Fill-in appropriate missing values. Long winded but easy to follow.

--- a/tests/options.env.test.js
+++ b/tests/options.env.test.js
@@ -206,12 +206,27 @@ describe('custom argParser', () => {
 });
 
 describe('variadic', () => {
-  test('when env defined and no cli then array from env', () => {
+  test('when env defined and no cli then array from env with single value', () => {
     const program = new commander.Command();
     process.env.BAR = 'env';
     program.addOption(new commander.Option('-f, --foo <required...>').env('BAR'));
     program.parse([], { from: 'user' });
     expect(program.opts().foo).toEqual(['env']);
+    delete process.env.BAR;
+  });
+
+  test('when env defined and no cli then array from env with multiple values', () => {
+    const program = new commander.Command();
+    process.env.BAR = 'firstItem secondItem thirdItem';
+    program.addOption(
+      new commander.Option('-f, --foo <required...>').env('BAR')
+    );
+    program.parse([], { from: 'user' });
+    expect(program.opts().foo).toEqual([
+      'firstItem',
+      'secondItem',
+      'thirdItem'
+    ]);
     delete process.env.BAR;
   });
 


### PR DESCRIPTION
# Pull Request

## Problem

We already support multiple values parsed from CLI for variadic options but we didn't have that same feature for values parsed from env.

```js
BAR=firstItem secondItem thirdItem ./cli
// options.bar=['firstItem', 'secondItem', 'thirdItem']
```

## Solution

We solved the problem by splitting the env value with blank spaces just the way we parse values from CLI.

## ChangeLog

Add support of multiple values from env for variadic options
