### PR TITLE
Add custom usage compatibility to help menu

### DIFF
--- a/lib/help.js
+++ b/lib/help.js
@@ -141,10 +141,10 @@ class Help {
    */
 
   subcommandTerm(cmd) {
-    const term = cmd._name + (cmd._aliases[0] ? '|' + cmd._aliases[0] : '');
-    if (cmd._usage) return term + ' ' + cmd._usage;
+    const cmdNames = cmd._name + (cmd._aliases[0] ? '|' + cmd._aliases[0] : '');
+    if (cmd._usage) return cmdNames + ' ' + cmd._usage;
     const args = cmd._args.map(humanReadableArgName).join(' ');
-    return term +
+    return cmdNames +
       (cmd.options.length ? ' [options]' : '') + // simplistic check for non-help option
       (args ? ' ' + args : '');
   }

--- a/lib/help.js
+++ b/lib/help.js
@@ -141,10 +141,10 @@ class Help {
    */
 
   subcommandTerm(cmd) {
-    // Legacy. Ignores custom usage string, and nested commands.
-    const args = cmd._args.map(arg => humanReadableArgName(arg)).join(' ');
-    return cmd._name +
-      (cmd._aliases[0] ? '|' + cmd._aliases[0] : '') +
+    const term = cmd._name + (cmd._aliases[0] ? '|' + cmd._aliases[0] : '');
+    if (cmd._usage) return term + ' ' + cmd._usage;
+    const args = cmd._args.map(humanReadableArgName).join(' ');
+    return term +
       (cmd.options.length ? ' [options]' : '') + // simplistic check for non-help option
       (args ? ' ' + args : '');
   }

--- a/tests/help.commandTerm.test.js
+++ b/tests/help.commandTerm.test.js
@@ -40,4 +40,14 @@ describe('subcommandTerm', () => {
     const helper = new commander.Help();
     expect(helper.subcommandTerm(command)).toEqual('program|alias [options] <argument>');
   });
+
+  test('when command has usage then returns name|alias (usage)', () => {
+    const command = new commander.Command('program')
+      .usage('<argument> [options]')
+      .alias('alias')
+      .option('-a,--all')
+      .argument('<argument>');
+    const helper = new commander.Help();
+    expect(helper.subcommandTerm(command)).toEqual('program|alias <argument> [options]');
+  });
 });


### PR DESCRIPTION
# Pull Request

## Problem
The help menu does not display the custom command usage. If there are custom syntax changes that are critical for users to understand the program, this can be problematic.

## Solution

Currently, this can be fixed by reconfiguring the helper, which is fine, but it would be nice to have this functionality by default. So, I slightly altered how `subcommandTerm` outputs command usage. If that is not set by the user yet, it will default to the usual processing.

## Final Thoughts
Let me know if this was intentionally implemented, as it appeared that  `subcommandTerm` was stated to be a "legacy" function despite still being used to list subcommands in the help menu..