### PR TITLE
Assume a string parameter to implies is name of boolean option.

### DIFF
--- a/examples/options-implies.js
+++ b/examples/options-implies.js
@@ -3,7 +3,6 @@
 const { Command, Option } = require('../'); // include commander in git clone of commander repo
 const program = new Command();
 
-// You can use .conflicts() with a single string, which is the camel-case name of the conflicting option.
 program
   .addOption(new Option('--quiet').implies({ logLevel: 'off' }))
   .addOption(new Option('--log-level <level>').choices(['info', 'warning', 'error', 'off']).default('info'))

--- a/lib/option.js
+++ b/lib/option.js
@@ -99,7 +99,12 @@ class Option {
    * @return {Option}
    */
   implies(impliedOptionValues) {
-    this.implied = Object.assign(this.implied || {}, impliedOptionValues);
+    let newImplied = impliedOptionValues;
+    if (typeof impliedOptionValues === 'string') {
+      // string is not documented, but easy mistake and we can do what user probably intended.
+      newImplied = { [impliedOptionValues]: true };
+    }
+    this.implied = Object.assign(this.implied || {}, newImplied);
     return this;
   }
 

--- a/tests/options.implies.test.js
+++ b/tests/options.implies.test.js
@@ -201,3 +201,14 @@ test('when implied option has custom processing then custom processing not calle
   expect(program.opts().bar).toEqual(true);
   expect(called).toEqual(false);
 });
+
+test('when passed string then treat as boolean', () => {
+  // Do something sensible instead of something silly if user passes just name of option.
+  // https://github.com/tj/commander.js/issues/1852
+  const program = new Command();
+  program
+    .addOption(new Option('--foo').implies('bar'))
+    .option('-b, --bar', 'description');
+  program.parse(['--foo'], { from: 'user' });
+  expect(program.opts().bar).toEqual(true);
+});


### PR DESCRIPTION
# Pull Request

## Problem

It is an easy mistake to pass a string to `.implies()` instead of a hash. We have other routines that do just take option names, like `.conflicts()`.

See: #1852

## Solution

Assume the users intent was to set the option to true, like a simple boolean option.

An alternative would be to throw an error, but that would probably need to wait for a semver major release since it would break programs that might otherwise be functional.

(Both of these were included as possible approaches in #1852.)

## ChangeLog

(Leaving out of changelog as this is a quiet fixup rather than a feature as such.)