### PR TITLE
Small improvement to configureHelp documentation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -919,7 +919,7 @@ The data properties are:
 - `sortOptions`: sort the options alphabetically
 - `showGlobalOptions`: show a section with the global options from the parent command(s)
 
-There are methods getting the visible lists of arguments, options, and subcommands. There are methods for formatting the items in the lists, with each item having a _term_ and _description_. Take a look at `.formatHelp()` to see how they are used.
+You can override any method on the [Help](./lib/help.js) class. There are methods getting the visible lists of arguments, options, and subcommands. There are methods for formatting the items in the lists, with each item having a _term_ and _description_. Take a look at `.formatHelp()` to see how they are used.
 
 Example file: [configure-help.js](./examples/configure-help.js)
 

--- a/examples/configure-help.js
+++ b/examples/configure-help.js
@@ -5,6 +5,8 @@ const program = new commander.Command();
 
 // This example shows a simple use of configureHelp.
 // This is used as an example in the README.
+// Any method on the Help class can be overridden
+// See: https://github.com/tj/commander.js/blob/master/lib/help.js
 
 program.configureHelp({
   sortSubcommands: true,


### PR DESCRIPTION
# Pull Request

## Problem

The full usage of `configureHelp` is not easy to find. The linked example only shows a few method overrides. There are mentions of the Help class, but a direct link would be much easier.

## Solution

- Added link to Help class in README.
- Added link to Help class in configureHelp example.