### PR TITLE
Add help description wrapping to README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -761,6 +761,8 @@ shell help spawn
 shell spawn --help
 ```
 
+Long descriptions are wrapped to fit the available width. (However, a  description that includes a line-break followed by whitespace is assumed to be pre-formatted and not wrapped.)
+
 ### Custom help
 
 You can add extra text to be displayed along with the built-in help.


### PR DESCRIPTION
## Problem

People with more complex help descriptions may want to know about the auto-wrapping, to have their description wrapped by Commander or pre-formatted by the author.

See: #1822

## Solution

Add a brief description that there is auto-wrapping, and what is considered pre-formatted text and not wrapped.
