### PR TITLE
Add documentation on parsing life cycle and hooks

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -730,6 +730,8 @@ The supported events are:
 | `preAction`, `postAction` |  before/after action handler for this command and its nested subcommands |   `(thisCommand, actionCommand)` |
 | `preSubcommand` | before parsing direct subcommand  | `(thisCommand, subcommand)` |
 
+For an overview of the life cycle events see [parsing life cycle and hooks](./docs/parsing-and-hooks.md).
+
 ## Automated help
 
 The help information is auto-generated based on the information commander already knows about your program. The default
@@ -1114,6 +1116,7 @@ There is more information available about:
 
 - [deprecated](./docs/deprecated.md) features still supported for backwards compatibility
 - [options taking varying arguments](./docs/options-taking-varying-arguments.md)
+- [parsing life cycle and hooks](./docs/parsing-and-hooks.md)
 
 ## Support
 

--- a/docs/parsing-and-hooks.md
+++ b/docs/parsing-and-hooks.md
@@ -9,7 +9,7 @@ Starting with top-level command (program):
 - parse env: look for environment variables (for this command)
 - process implied: set any implied option values (for this command)
 - if the first arg is a subcommand
-    - call `preSubcommand` hook
+    - call `preSubcommand` hooks
     - pass remaining arguments to subcommand, and process same way
 
 Once reach final (leaf) command:
@@ -18,6 +18,6 @@ Once reach final (leaf) command:
 - check for conflicting options
 - check for unknown options
 - process remaining args as command-arguments
-- call `preAction` hook
+- call `preAction` hooks
 - call action handler
-- call `postAction` hook
+- call `postAction` hooks

--- a/docs/parsing-and-hooks.md
+++ b/docs/parsing-and-hooks.md
@@ -14,10 +14,10 @@ Starting with top-level command (program):
 
 Once reach final (leaf) command:
 
-  - check for missing mandatory options
-  - check for conflicting options
-  - check for unknown options
-  - process remaining args as command-arguments
-  - call `preAction` hook
-  - call action handler
-  - call `postAction` hook
+- check for missing mandatory options
+- check for conflicting options
+- check for unknown options
+- process remaining args as command-arguments
+- call `preAction` hook
+- call action handler
+- call `postAction` hook

--- a/docs/parsing-and-hooks.md
+++ b/docs/parsing-and-hooks.md
@@ -1,0 +1,23 @@
+# Parsing life cycle and hooks
+
+The processing starts with an array of args. Each command processes and removes the options it understands, and passes the remaining args to the next subcommand.
+The final command calls the action handler.
+
+Starting with top-level command (program):
+
+- parse options: parse recognised options (for this command) and remove from args
+- parse env: look for environment variables (for this command)
+- process implied: set any implied option values (for this command)
+- if the first arg is a subcommand
+    - call `preSubcommand` hook
+    - pass remaining arguments to subcommand, and process same way
+
+Once reach final (leaf) command:
+
+  - check for missing mandatory options
+  - check for conflicting options
+  - check for unknown options
+  - process remaining args as command-arguments
+  - call `preAction` hook
+  - call action handler
+  - call `postAction` hook


### PR DESCRIPTION
# Pull Request

## Problem

It can be hard to work out where to plugin extra functionality using the hooks. A specific example is reading configuration files.

See: #1843

> Perhaps the full life cycle of executing commands should be documented.

See also: #1762 https://github.com/tj/commander.js/issues/1787#issuecomment-1236027554

## Solution

Add a separate description of the processing life cycles and where the hooks fit in. This will be useful when discussions come up about adding more parsing affected hooks, and thinking about where config files can fit in.
