### PR TITLE
Have help command call help directly for subcommands, when possible

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -1085,6 +1085,26 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   /**
+   * Invoke help directly if possible, or dispatch if necessary.
+   * e.g. help foo
+   *
+   * @api private
+   */
+
+  _dispatchHelpCommand(subcommandName) {
+    if (!subcommandName) {
+      this.help();
+    }
+    const subCommand = this._findCommand(subcommandName);
+    if (subCommand && !subCommand._executableHandler) {
+      subCommand.help();
+    }
+
+    // Fallback to parsing the help flag to invoke the help.
+    return this._dispatchSubcommand(subcommandName, [], [this._helpLongFlag]);
+  }
+
+  /**
    * Check this.args against expected this._args.
    *
    * @api private
@@ -1248,10 +1268,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
       return this._dispatchSubcommand(operands[0], operands.slice(1), unknown);
     }
     if (this._hasImplicitHelpCommand() && operands[0] === this._helpCommandName) {
-      if (operands.length === 1) {
-        this.help();
-      }
-      return this._dispatchSubcommand(operands[1], [], [this._helpLongFlag]);
+      return this._dispatchHelpCommand(operands[1]);
     }
     if (this._defaultCommandName) {
       outputHelpIfRequested(this, unknown); // Run the help for default command from parent rather than passing to default command

--- a/tests/command.helpCommand.test.js
+++ b/tests/command.helpCommand.test.js
@@ -123,4 +123,41 @@ describe('help command processed on correct command', () => {
       program.parse('node test.js help'.split(' '));
     }).toThrow('program');
   });
+
+  test('when no long help flag then "help sub" works', () => {
+    const program = new commander.Command();
+    program.exitOverride();
+    program.helpOption('-H');
+    const sub = program.command('sub');
+    // Patch help for easy way to check called.
+    sub.help = () => { throw new Error('sub help'); };
+    expect(() => {
+      program.parse(['help', 'sub'], { from: 'user' });
+    }).toThrow('sub help');
+  });
+
+  test('when no help options in sub then "help sub" works', () => {
+    const program = new commander.Command();
+    program.exitOverride();
+    const sub = program.command('sub')
+      .helpOption(false);
+    // Patch help for easy way to check called.
+    sub.help = () => { throw new Error('sub help'); };
+    expect(() => {
+      program.parse(['help', 'sub'], { from: 'user' });
+    }).toThrow('sub help');
+  });
+
+  test('when different help options in sub then "help sub" works', () => {
+    const program = new commander.Command();
+    program.exitOverride();
+    const sub = program.command('sub');
+    program.helpOption('-h, --help');
+    sub.helpOption('-a, --assist');
+    // Patch help for easy way to check called.
+    sub.help = () => { throw new Error('sub help'); };
+    expect(() => {
+      program.parse(['help', 'sub'], { from: 'user' });
+    }).toThrow('sub help');
+  });
 });


### PR DESCRIPTION
# Pull Request

## Problem

The implementation of the help command like `my-util help foo` is a bit fragile. The implementation invokes the subcommand passing `this._helpLongFlag`. This can fail if:
- the current command does not have a long flag
- the subcommand uses different help flags
- the subcommand has the help option disabled

See: #1863 (help option disabled)

## Solution

Call `.help()` directly for a known (non-external) subcommand. Just use the help flags as a fallback for external subcommands.

This takes a little extra code, but I have never been happy about passing through the help flags so I think it is worth it.

## ChangeLog

- Fixed: help command works when help option is disabled

