### PR TITLE
trim() input string of .arguments method

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -330,7 +330,7 @@ class Command extends EventEmitter {
    */
 
   arguments(names) {
-    names.split(/ +/).forEach((detail) => {
+    names.trim().split(/ +/).forEach((detail) => {
       this.argument(detail);
     });
     return this;


### PR DESCRIPTION
# Pull Request

## Problem

If there are trailing spaces in string with list of arguments passed to .arguments() method, script will expect extra argument with empty name ''. 

```
import {program} from 'commander'

program.arguments('<arg1> <arg2> ')
program.parse()

console.log(program.args);
```

And throw error when called, that is obscure on a first glance:

```
node commanderTest.js one two
error: missing required argument ''
```

## Solution

Trimmed string of arguments before splitting it in into array of individual names

## ChangeLog

leading and trailing spaces are now ignored by the .arguments() method.