### PR TITLE
Add separate type file for esm per TypeScript guidelines

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,7 @@ const javascriptSettings = {
 };
 
 const typescriptSettings = {
-  files: ['*.ts'],
+  files: ['*.ts', '*.mts'],
   parserOptions: {
     project: './tsconfig.json'
   },

--- a/package.json
+++ b/package.json
@@ -33,17 +33,27 @@
     "lib/*.js",
     "esm.mjs",
     "typings/index.d.ts",
+    "typings/esm.d.mts",
     "package-support.json"
   ],
   "type": "commonjs",
   "main": "./index.js",
   "exports": {
     ".": {
-      "types": "./typings/index.d.ts",
-      "require": "./index.js",
-      "import": "./esm.mjs"
+      "require": {
+        "types": "./typings/index.d.ts",
+        "default": "./index.js"
+      },
+      "import": {
+        "types": "./typings/esm.d.mts",
+        "default": "./esm.mjs"
+      },
+      "default": "./index.js"
     },
-    "./esm.mjs": "./esm.mjs"
+    "./esm.mjs": {
+      "types": "./typings/esm.d.mts",
+      "import": "./esm.mjs"
+    }
   },
   "devDependencies": {
     "@types/jest": "^29.2.4",

--- a/typings/esm.d.mts
+++ b/typings/esm.d.mts
@@ -1,0 +1,3 @@
+// Just reexport the types from cjs
+// This is a bit indirect. There is not an index.js, but TypeScript will look for index.d.ts for types.
+export * from './index.js';


### PR DESCRIPTION
# Pull Request

## Problem

TypeScript wants a type definition file which matches the implementation file, like foo.js + foo.d.ts, bar.mjs + bar.d.mts. 

See #1880 for more detail.

## Solution

Adding the file was easy. Working out how to just reexport the existing types was tricky! I am using:

```
// This is a bit indirect. There is not an index.js, but TypeScript will look for index.d.ts for types.
export * from './index.js';
```

The direct `./esm.mjs` entry is stale, but tidy it up too.

## ChangeLog

- changed: refine "types" exports for ESM to follow TypeScript guidelines
