### PR TITLE
Add Command.awaitHook(), Argument.chainArgParserCalls() and Option.chainArgParserCalls()

### DIFF
--- a/lib/argument.js
+++ b/lib/argument.js
@@ -16,6 +16,7 @@ class Argument {
     this.description = description || '';
     this.variadic = false;
     this.parseArg = undefined;
+    this.chained = false;
     this.defaultValue = undefined;
     this.defaultValueDescription = undefined;
     this.argChoices = undefined;
@@ -86,6 +87,17 @@ class Argument {
 
   argParser(fn) {
     this.parseArg = fn;
+    return this;
+  }
+
+  /**
+   * When set to true, next call to the function provided via .argParser() will be chained to its return value if it is thenable.
+   *
+   * @param {boolean} [chained]
+   * @return {Argument}
+   */
+  chainArgParserCalls(chained = true) {
+    this.chained = !!chained;
     return this;
   }
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -1211,16 +1211,16 @@ Expecting one of '${allowedValues.join("', '")}'`);
    * @api private
    */
 
-  _handleChainError(target, value, handleError) {
+  _catchChainError(target, value, handleError) {
     if (target.chained && typeof value?.then === 'function') {
-      value.then(x => x, handleError);
+      return value.then(x => x, handleError);
     }
+
+    return value;
   }
 
   /**
    * Internal implementation shared by ._processArguments() and option and optionEnv event listeners.
-   *
-   * @api private
    *
    * @param {Argument|Option} target
    * @param {*} value
@@ -1239,14 +1239,14 @@ Expecting one of '${allowedValues.join("', '")}'`);
         (result) => {
           result = target.parseArg(value, result);
           // call with result and not parsedValue to not catch handleError exception repeatedly
-          this._handleChainError(target, result, handleError);
+          result = this._catchChainError(target, result, handleError);
           return result;
         }
       );
     } else {
       try {
         parsedValue = target.parseArg(value, previous);
-        this._handleChainError(target, parsedValue, handleError);
+        parsedValue = this._catchChainError(target, parsedValue, handleError);
       } catch (err) {
         handleError(err);
       }

--- a/lib/command.js
+++ b/lib/command.js
@@ -58,6 +58,14 @@ class Command extends EventEmitter {
     this._showHelpAfterError = false;
     this._showSuggestionAfterError = true;
 
+    this._chainedOptionEntryFilter = ([key]) => {
+      // TODO: Maybe replace by an attribute-name-to-option map
+      const option = this.options.find(
+        option => option.attributeName() === key
+      );
+      return option && option.chained;
+    };
+
     // see .configureOutput() for docs
     this._outputConfiguration = {
       writeOut: (str) => process.stdout.write(str),
@@ -551,7 +559,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     // handler for cli and env supplied values
     const handleOptionValue = (val, invalidValueMessage, valueSource) => {
       const handleError = (err) => {
-        if (err.code === 'commander.invalidArgument') {
+        if (err?.code === 'commander.invalidArgument') {
           const message = `${invalidValueMessage} ${err.message}`;
           this.error(message, { exitCode: err.exitCode, code: err.code });
         }
@@ -969,16 +977,24 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
     // Throws errors from custom processing.
     // Also prevents ERR_UNHANDLED_REJECTION by leaving no uncaught promises.
-    const toAwait = this.processedArgs.slice(0, this.args.length);
-    Object.entries(this.opts()).forEach(([key, value]) => {
-      const source = this.getOptionValueSource(key);
-      if (source === 'cli' || source === 'env') {
-        toAwait.push(value);
-      }
-    });
-    Object.values(this._overwrittenOptionValues).forEach((values) => {
-      values.forEach(value => toAwait.push(value));
-    });
+    const toAwait = this.processedArgs
+      .slice(0, this.args.length) // remove defaults
+      .filter((arg, i) => {
+        return this._args[i].chained;
+      });
+    Object.entries(this.opts())
+      .filter(this._chainedOptionEntryFilter)
+      .forEach(([key, value]) => {
+        const source = this.getOptionValueSource(key);
+        if (source === 'cli' || source === 'env') {
+          toAwait.push(value);
+        }
+      });
+    Object.entries(this._overwrittenOptionValues)
+      .filter(this._chainedOptionEntryFilter)
+      .forEach(([key, values]) => {
+        values.forEach(value => toAwait.push(value));
+      });
     await Promise.all(toAwait);
 
     return this;
@@ -1218,7 +1234,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
   _processArguments() {
     const myParseArg = (argument, value, previous) => {
       const handleError = (err) => {
-        if (err.code === 'commander.invalidArgument') {
+        if (err?.code === 'commander.invalidArgument') {
           const message = `error: command-argument value '${value}' is invalid for argument '${argument.name()}'. ${err.message}`;
           this.error(message, { exitCode: err.exitCode, code: err.code });
         }

--- a/lib/command.js
+++ b/lib/command.js
@@ -58,6 +58,14 @@ class Command extends EventEmitter {
     this._showHelpAfterError = false;
     this._showSuggestionAfterError = true;
 
+    /** @type {boolean | undefined} */
+    this._asyncParsing = undefined;
+    /** @type {boolean | undefined} */
+    this._awaitHook = undefined;
+    /** @type {{ preSubcommand: number, postArguments: number } | null} */
+    this._awaitHookIndices = null;
+    this.awaitHook();
+
     // see .configureOutput() for docs
     this._outputConfiguration = {
       writeOut: (str) => process.stdout.write(str),
@@ -400,7 +408,7 @@ class Command extends EventEmitter {
    */
 
   hook(event, listener) {
-    const allowedValues = ['preSubcommand', 'preAction', 'postAction'];
+    const allowedValues = ['preSubcommand', 'postArguments', 'preAction', 'postAction'];
     if (!allowedValues.includes(event)) {
       throw new Error(`Unexpected value for event passed to hook : '${event}'.
 Expecting one of '${allowedValues.join("', '")}'`);
@@ -448,35 +456,92 @@ Expecting one of '${allowedValues.join("', '")}'`);
    * @api private
    */
 
-  _awaitOptionsHook() {
-    this.hook('preSubcommand', (thisCommand, subcommand) => {
-      subcommand._awaitOptionsHook();
-      return Promise.all(thisCommand._getOptionPromises());
+  _shouldAwait() {
+    let shouldAwait;
+    let cmd = this;
+    // Only await if the nearest ancestor with explicitly set _awaitHook value has it set to true,
+    // or if there is no such ancestor and .parseAsync() was called on the top-level command.
+    do {
+      shouldAwait = cmd._awaitHook ?? cmd._asyncParsing;
+      cmd = cmd.parent;
+    } while (shouldAwait === undefined);
+    return shouldAwait;
+  }
+
+  /**
+   * @api private
+   */
+
+  _awaitHookPreSubcommand() {
+    this.hook('preSubcommand', () => {
+      if (this._shouldAwait()) {
+        return Promise.all(this._getOptionPromises());
+      }
     });
   }
 
   /**
-   * Add hook to await argument and option values before calling action handlers for this command and its nested subcommands.
+   * @api private
+   */
+
+  _awaitHookPostArguments() {
+    this.hook('postArguments', (thisCommand, actionCommand) => {
+      if ((
+        // Implicit hook only at top level
+        this._awaitHook || this._asyncParsing !== undefined
+      ) && actionCommand._shouldAwait()) {
+        const toAwait = actionCommand._getOptionPromises();
+
+        actionCommand.processedArgs.forEach((value, i) => {
+          if (typeof value?.then === 'function') {
+            toAwait.push((async() => {
+              actionCommand.processedArgs[i] = await value;
+            })());
+          }
+        });
+
+        return Promise.all(toAwait);
+      }
+    });
+  }
+
+  /**
+   * Add hook to await argument and option values.
    * Useful for asynchronous custom processing (parseArg) of arguments and option-arguments.
+   *
+   * Hook behaviour depends on the value of `enabled`:
+   * - If the value is `false`, do not await anything.
+   * - If the value is `true`, await for this command before dispatching subcommand; and for action command before calling action handlers if the "should await" condition applies (see below).
+   * - If the value is `undefined`, await for this command before dispatching subcommand if the "should await" condition applies (see below); and await for action command in the same manner as if the value were `true`, but only if this command is the top level command (i.e. has no parent).
+   *
+   * The "should await" condition for a command is as follows:
+   * - either the method was called with an `enabled` value of `true` on the nearest command ancestor for which the method was called with an `enabled` value other than `undefined`;
+   * - or there is no such ancestor and `parseAsync()` was called on the top-level command.
+   *
+   * @param {boolean | undefined} [enabled]
    * @return {Command} `this` command for chaining
    */
 
-  awaitHook() {
-    this._awaitOptionsHook();
+  awaitHook(enabled) {
+    this._awaitHook = enabled === undefined ? undefined : !!enabled;
 
-    this.hook('preAction', (thisCommand, actionCommand) => {
-      const toAwait = actionCommand._getOptionPromises();
-
-      actionCommand.processedArgs.forEach((value, i) => {
-        if (typeof value?.then === 'function') {
-          toAwait.push((async() => {
-            actionCommand.processedArgs[i] = await value;
-          })());
-        }
+    const events = ['preSubcommand', 'postArguments'];
+    if (this._awaitHookIndices) {
+      events.forEach((event) => {
+        this._lifeCycleHooks[event].splice(this._awaitHookIndices[event], 1);
       });
+      this._awaitHookIndices = null;
+    }
 
-      return Promise.all(toAwait);
-    });
+    if (this._awaitHook !== false) {
+      this._awaitHookPreSubcommand();
+      this._awaitHookPostArguments();
+
+      this._awaitHookIndices = events.reduce((obj, event) => {
+        obj[event] = this._lifeCycleHooks[event].length - 1;
+        return obj;
+      }, {});
+    }
 
     return this;
   }
@@ -983,10 +1048,16 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   parse(argv, parseOptions) {
-    const userArgs = this._prepareUserArgs(argv, parseOptions);
-    this._parseCommand([], userArgs);
+    this._asyncParsing = false;
 
-    return this;
+    try {
+      const userArgs = this._prepareUserArgs(argv, parseOptions);
+      this._parseCommand([], userArgs);
+
+      return this;
+    } finally {
+      this._asyncParsing = undefined;
+    }
   }
 
   /**
@@ -1009,10 +1080,16 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   async parseAsync(argv, parseOptions) {
-    const userArgs = this._prepareUserArgs(argv, parseOptions);
-    await this._parseCommand([], userArgs);
+    this._asyncParsing = true;
 
-    return this;
+    try {
+      const userArgs = this._prepareUserArgs(argv, parseOptions);
+      await this._parseCommand([], userArgs);
+
+      return this;
+    } finally {
+      this._asyncParsing = undefined;
+    }
   }
 
   /**
@@ -1258,6 +1335,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
   /**
    * Process this.args using this._args and save as this.processedArgs!
    *
+   * @return {Promise|undefined}
    * @api private
    */
 
@@ -1305,6 +1383,8 @@ Expecting one of '${allowedValues.join("', '")}'`);
       processedArgs[index] = value;
     });
     this.processedArgs = processedArgs;
+
+    return this._chainOrCallHooks(undefined, 'postArguments');
   }
 
   /**
@@ -1422,9 +1502,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     const commandEvent = `command:${this.name()}`;
     if (this._actionHandler) {
       checkForUnknownOptions();
-      this._processArguments();
-
-      let actionResult;
+      let actionResult = this._processArguments();
       actionResult = this._chainOrCallHooks(actionResult, 'preAction');
       actionResult = this._chainOrCall(actionResult, () => this._actionHandler(this.processedArgs));
       if (this.parent) {
@@ -1437,9 +1515,11 @@ Expecting one of '${allowedValues.join("', '")}'`);
     }
     if (this.parent && this.parent.listenerCount(commandEvent)) {
       checkForUnknownOptions();
-      this._processArguments();
+      const result = this._processArguments();
       this.parent.emit(commandEvent, operands, unknown); // legacy
-    } else if (operands.length) {
+      return result;
+    }
+    if (operands.length) {
       if (this._findCommand('*')) { // legacy default command
         return this._dispatchSubcommand('*', operands, unknown);
       }
@@ -1450,7 +1530,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
         this.unknownCommand();
       } else {
         checkForUnknownOptions();
-        this._processArguments();
+        return this._processArguments();
       }
     } else if (this.commands.length) {
       checkForUnknownOptions();
@@ -1458,7 +1538,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
       this.help({ error: true });
     } else {
       checkForUnknownOptions();
-      this._processArguments();
+      return this._processArguments();
       // fall through for caller to handle after calling .parse()
     }
   }

--- a/lib/command.js
+++ b/lib/command.js
@@ -413,6 +413,27 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   /**
+   * Add hook to await argument and option values before calling action handlers for this command and its nested subcommands.
+   * Useful for asynchronous custom processing (parseArg) of arguments and option-arguments.
+   */
+
+  awaitHook() {
+    this.hook('preAction', async function awaitHook(thisCommand, actionCommand) {
+      actionCommand.processedArgs = await Promise.all(
+        actionCommand.processedArgs
+      );
+
+      for (const [key, value] of Object.entries(actionCommand.opts())) {
+        actionCommand.setOptionValueWithSource(
+          key, await value, actionCommand._optionValueSources[key]
+        );
+      }
+    });
+
+    return this;
+  }
+
+  /**
    * Register callback to use as replacement for calling process.exit.
    *
    * @param {Function} [fn] optional callback which will be passed a CommanderError, defaults to throwing

--- a/lib/command.js
+++ b/lib/command.js
@@ -547,6 +547,14 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
     // handler for cli and env supplied values
     const handleOptionValue = (val, invalidValueMessage, valueSource) => {
+      const handleError = (err) => {
+        if (err.code === 'commander.invalidArgument') {
+          const message = `${invalidValueMessage} ${err.message}`;
+          this.error(message, { exitCode: err.exitCode, code: err.code });
+        }
+        throw err;
+      };
+
       // val is null for optional option used without an optional-argument.
       // val is undefined for boolean and negated option.
       if (val == null && option.presetArg !== undefined) {
@@ -555,15 +563,21 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
       // custom processing
       const oldValue = this.getOptionValue(name);
+
       if (val !== null && option.parseArg) {
-        try {
-          val = option.parseArg(val, oldValue);
-        } catch (err) {
-          if (err.code === 'commander.invalidArgument') {
-            const message = `${invalidValueMessage} ${err.message}`;
-            this.error(message, { exitCode: err.exitCode, code: err.code });
+        if (typeof oldValue?.then !== 'function') {
+          try {
+            val = option.parseArg(val, oldValue);
+          } catch (err) {
+            handleError(err);
           }
-          throw err;
+        } else {
+          // chain thenables
+          const originalVal = val;
+          val = oldValue.then(
+            (result) => option.parseArg(originalVal, result)
+          );
+          val.catch(handleError);
         }
       } else if (val !== null && option.variadic) {
         val = option._concatValue(val, oldValue);
@@ -1155,17 +1169,29 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
   _processArguments() {
     const myParseArg = (argument, value, previous) => {
+      const handleError = (err) => {
+        if (err.code === 'commander.invalidArgument') {
+          const message = `error: command-argument value '${value}' is invalid for argument '${argument.name()}'. ${err.message}`;
+          this.error(message, { exitCode: err.exitCode, code: err.code });
+        }
+        throw err;
+      };
+  
       // Extra processing for nice error message on parsing failure.
       let parsedValue = value;
       if (value !== null && argument.parseArg) {
-        try {
-          parsedValue = argument.parseArg(value, previous);
-        } catch (err) {
-          if (err.code === 'commander.invalidArgument') {
-            const message = `error: command-argument value '${value}' is invalid for argument '${argument.name()}'. ${err.message}`;
-            this.error(message, { exitCode: err.exitCode, code: err.code });
+        if (typeof previous?.then !== 'function') {
+          try {
+            parsedValue = argument.parseArg(value, previous);
+          } catch (err) {
+            handleError(err);
           }
-          throw err;
+        } else {
+          // chain thenables
+          parsedValue = previous.then(
+            (result) => argument.parseArg(value, result)
+          )
+          parsedValue.catch(handleError);
         }
       }
       return parsedValue;

--- a/lib/command.js
+++ b/lib/command.js
@@ -1192,10 +1192,8 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   _handleChainError(target, value, handleError) {
-    if (target.chained && ['then', 'catch'].every(
-      (key) => typeof value?.[key] === 'function'
-    )) {
-      value.catch(handleError);
+    if (target.chained && typeof value?.then === 'function') {
+      value.then(x => x, handleError);
     }
   }
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -425,11 +425,11 @@ Expecting one of '${allowedValues.join("', '")}'`);
    * @api private
    */
 
-  _getOptionPromises() {
+  _getOptionResavePromises() {
     const promises = [];
 
     Object.entries(this.opts()).forEach(([key, value]) => {
-      if (typeof value?.then === 'function') {
+      if (thenable(value)) {
         promises.push((async() => {
           this.setOptionValueWithSource(
             key, await value, this.getOptionValueSource(key)
@@ -440,7 +440,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
     Object.entries(this._overwrittenOptionValues).forEach(([key, values]) => {
       values.forEach(value => {
-        if (typeof value?.then === 'function') {
+        if (thenable(value)) {
           promises.push((async() => {
             await value;
           })());
@@ -474,7 +474,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
   _awaitHookPreSubcommand() {
     this.hook('preSubcommand', () => {
       if (this._shouldAwait()) {
-        const toAwait = this._getOptionPromises();
+        const toAwait = this._getOptionResavePromises();
         if (toAwait.length) return Promise.all(toAwait);
       }
     });
@@ -490,10 +490,10 @@ Expecting one of '${allowedValues.join("', '")}'`);
         // Implicit hook only at top level
         this._awaitHook || this._asyncParsing !== undefined
       ) && leafCommand._shouldAwait()) {
-        const toAwait = leafCommand._getOptionPromises();
+        const toAwait = leafCommand._getOptionResavePromises();
 
         leafCommand.processedArgs.forEach((value, i) => {
-          if (typeof value?.then === 'function') {
+          if (thenable(value)) {
             toAwait.push((async() => {
               leafCommand.processedArgs[i] = await value;
             })());
@@ -1313,7 +1313,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   _catchChainError(target, value, handleError) {
-    if (target.chained && typeof value?.then === 'function') {
+    if (target.chained && thenable(value)) {
       return value.then(x => x, handleError);
     }
 
@@ -1334,7 +1334,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
   _parseArg(target, value, previous, handleError) {
     let parsedValue;
 
-    if (target.chained && typeof previous?.then === 'function') {
+    if (target.chained && thenable(value)) {
       // chain thenables
       parsedValue = previous.then(
         (result) => {
@@ -1421,8 +1421,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   _chainOrCall(promise, fn) {
-    // thenable
-    if (promise && promise.then && typeof promise.then === 'function') {
+    if (thenable(promise)) {
       // already have a promise, chain callback
       return promise.then(() => fn());
     }
@@ -2424,6 +2423,16 @@ function getCommandAndParents(startCommand) {
     result.push(command);
   }
   return result;
+}
+
+/**
+ * @param {*} value
+ * @returns {boolean}
+ * @api private
+ */
+
+function thenable(value) {
+  return typeof value?.then === 'function';
 }
 
 exports.Command = Command;

--- a/lib/command.js
+++ b/lib/command.js
@@ -484,17 +484,17 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   _awaitHookPostArguments() {
-    this.hook('postArguments', (thisCommand, actionCommand) => {
+    this.hook('postArguments', (thisCommand, leafCommand) => {
       if ((
         // Implicit hook only at top level
         this._awaitHook || this._asyncParsing !== undefined
-      ) && actionCommand._shouldAwait()) {
-        const toAwait = actionCommand._getOptionPromises();
+      ) && leafCommand._shouldAwait()) {
+        const toAwait = leafCommand._getOptionPromises();
 
-        actionCommand.processedArgs.forEach((value, i) => {
+        leafCommand.processedArgs.forEach((value, i) => {
           if (typeof value?.then === 'function') {
             toAwait.push((async() => {
-              actionCommand.processedArgs[i] = await value;
+              leafCommand.processedArgs[i] = await value;
             })());
           }
         });

--- a/lib/command.js
+++ b/lib/command.js
@@ -474,7 +474,8 @@ Expecting one of '${allowedValues.join("', '")}'`);
   _awaitHookPreSubcommand() {
     this.hook('preSubcommand', () => {
       if (this._shouldAwait()) {
-        return Promise.all(this._getOptionPromises());
+        const toAwait = this._getOptionPromises();
+        if (toAwait.length) return Promise.all(toAwait);
       }
     });
   }
@@ -499,7 +500,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
           }
         });
 
-        return Promise.all(toAwait);
+        if (toAwait.length) return Promise.all(toAwait);
       }
     });
   }

--- a/lib/command.js
+++ b/lib/command.js
@@ -25,6 +25,7 @@ class Command extends EventEmitter {
     this.commands = [];
     /** @type {Option[]} */
     this.options = [];
+    this._optionsByAttributeName = {};
     this.parent = null;
     this._allowUnknownOption = false;
     this._allowExcessArguments = true;
@@ -57,14 +58,6 @@ class Command extends EventEmitter {
     /** @type {boolean | string} */
     this._showHelpAfterError = false;
     this._showSuggestionAfterError = true;
-
-    this._chainedOptionEntryFilter = ([key]) => {
-      // TODO: Maybe replace by an attribute-name-to-option map
-      const option = this.options.find(
-        option => option.attributeName() === key
-      );
-      return option && option.chained;
-    };
 
     // see .configureOutput() for docs
     this._outputConfiguration = {
@@ -555,6 +548,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
     // register the option
     this.options.push(option);
+    this._optionsByAttributeName[name] = option;
 
     // handler for cli and env supplied values
     const handleOptionValue = (val, invalidValueMessage, valueSource) => {
@@ -983,7 +977,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
         return this._args[i].chained;
       });
     Object.entries(this.opts())
-      .filter(this._chainedOptionEntryFilter)
+      .filter(([key]) => this._optionsByAttributeName[key])
       .forEach(([key, value]) => {
         const source = this.getOptionValueSource(key);
         if (source === 'cli' || source === 'env') {
@@ -991,7 +985,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
         }
       });
     Object.entries(this._overwrittenOptionValues)
-      .filter(this._chainedOptionEntryFilter)
+      .filter(([key]) => this._optionsByAttributeName[key])
       .forEach(([key, values]) => {
         values.forEach(value => toAwait.push(value));
       });
@@ -1920,6 +1914,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     const versionOption = this.createOption(flags, description);
     this._versionOptionName = versionOption.attributeName();
     this.options.push(versionOption);
+    this._optionsByAttributeName[this._versionOptionName] = versionOption;
     this.on('option:' + versionOption.name(), () => {
       this._outputConfiguration.writeOut(`${str}\n`);
       this._exit(0, 'commander.version', str);

--- a/lib/command.js
+++ b/lib/command.js
@@ -38,6 +38,7 @@ class Command extends EventEmitter {
     this._name = name || '';
     this._optionValues = {};
     this._optionValueSources = {}; // default, env, cli etc
+    this._overwrittenOptionValues = {};
     this._storeOptionsAsProperties = false;
     this._actionHandler = null;
     this._executableHandler = false;
@@ -567,6 +568,14 @@ Expecting one of '${allowedValues.join("', '")}'`);
       const oldValue = this.getOptionValue(name);
 
       if (val !== null && option.parseArg) {
+        const optionValues = this._storeOptionsAsProperties
+          ? this
+          : this._optionValues;
+        const overwrite = name in optionValues;
+        if (overwrite) {
+          this._overwrittenOptionValues[name] ??= [];
+          this._overwrittenOptionValues[name].push(this.getOptionValue(name));
+        }
         val = this._parseArg(option, val, oldValue, handleError);
       } else if (val !== null && option.variadic) {
         val = option._concatValue(val, oldValue);
@@ -967,6 +976,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
         toAwait.push(value);
       }
     });
+    Object.values(this._overwrittenOptionValues).forEach((values) => {
+      values.forEach(value => toAwait.push(value));
+    });
     await Promise.all(toAwait);
 
     return this;
@@ -1175,7 +1187,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
   _parseArg(target, value, previous, handleError) {
     let parsedValue;
 
-    if (typeof previous?.then === 'function') {
+    if (target.chained && typeof previous?.then === 'function') {
       // chain thenables
       parsedValue = previous.then(
         (result) => target.parseArg(value, result)
@@ -1188,7 +1200,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
       }
     }
 
-    if (['then', 'catch'].every(
+    if (target.chained && ['then', 'catch'].every(
       (key) => typeof parsedValue?.[key] === 'function'
     )) {
       parsedValue = parsedValue.catch(handleError);

--- a/lib/command.js
+++ b/lib/command.js
@@ -414,48 +414,68 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   /**
+   * @return {Promise[]}
+   * @api private
+   */
+
+  _getOptionPromises() {
+    const promises = [];
+
+    Object.entries(this.opts()).forEach(([key, value]) => {
+      if (typeof value?.then === 'function') {
+        promises.push((async() => {
+          this.setOptionValueWithSource(
+            key, await value, this.getOptionValueSource(key)
+          );
+        })());
+      }
+    });
+
+    Object.entries(this._overwrittenOptionValues).forEach(([key, values]) => {
+      values.forEach(value => {
+        if (typeof value?.then === 'function') {
+          promises.push((async() => {
+            await value;
+          })());
+        }
+      });
+    });
+
+    return promises;
+  }
+
+  /**
+   * @api private
+   */
+
+  _awaitOptionsHook() {
+    this.hook('preSubcommand', (thisCommand, subcommand) => {
+      subcommand._awaitOptionsHook();
+      return Promise.all(thisCommand._getOptionPromises());
+    });
+  }
+
+  /**
    * Add hook to await argument and option values before calling action handlers for this command and its nested subcommands.
    * Useful for asynchronous custom processing (parseArg) of arguments and option-arguments.
+   * @return {Command} `this` command for chaining
    */
 
   awaitHook() {
-    this.hook('preAction', async function awaitHook(thisCommand, actionCommand) {
-      const toAwait = actionCommand.processedArgs
-        // .slice(
-        //   0, actionCommand.args.length
-        // ) // ignore defaults
-        .map((value, i) => async() => {
-          if (typeof value?.then === 'function') {
+    this._awaitOptionsHook();
+
+    this.hook('preAction', (thisCommand, actionCommand) => {
+      const toAwait = actionCommand._getOptionPromises();
+
+      actionCommand.processedArgs.forEach((value, i) => {
+        if (typeof value?.then === 'function') {
+          toAwait.push((async() => {
             actionCommand.processedArgs[i] = await value;
-          }
-        });
+          })());
+        }
+      });
 
-      Object.entries(actionCommand.opts())
-        .forEach(([key, value]) => {
-          if (typeof value?.then === 'function') {
-            // const source = actionCommand.getOptionValueSource(key);
-            // if (source === 'cli' || source === 'env') {
-            toAwait.push(async() => {
-              actionCommand.setOptionValueWithSource(
-                key, await value, actionCommand.getOptionValueSource(key)
-              );
-            });
-            // }
-          }
-        });
-
-      Object.entries(actionCommand._overwrittenOptionValues)
-        .forEach(([key, values]) => {
-          values.forEach(value => {
-            if (typeof value?.then === 'function') {
-              toAwait.push(async() => {
-                await value;
-              });
-            }
-          });
-        });
-
-      return Promise.all(toAwait.map(fn => fn()));
+      return Promise.all(toAwait);
     });
 
     return this;

--- a/lib/command.js
+++ b/lib/command.js
@@ -1334,7 +1334,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
   _parseArg(target, value, previous, handleError) {
     let parsedValue;
 
-    if (target.chained && thenable(value)) {
+    if (target.chained && thenable(previous)) {
       // chain thenables
       parsedValue = previous.then(
         (result) => {

--- a/lib/command.js
+++ b/lib/command.js
@@ -960,13 +960,11 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
     // Throws errors from custom processing.
     // Also prevents ERR_UNHANDLED_REJECTION by leaving no uncaught promises.
-    const toAwait = this.processedArgs;
+    const toAwait = this.processedArgs.slice(0, this.args.length);
     Object.entries(this.opts()).forEach(([key, value]) => {
       const source = this.getOptionValueSource(key);
       if (source === 'cli' || source === 'env') {
-        if (typeof value?.then === 'function') {
-          toAwait.push(value);
-        }
+        toAwait.push(value);
       }
     });
     await Promise.all(toAwait);

--- a/lib/command.js
+++ b/lib/command.js
@@ -567,7 +567,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
       const oldValue = this.getOptionValue(name);
 
       if (val !== null && option.parseArg) {
-        val = this._parseArgs(option, val, oldValue, handleError);
+        val = this._parseArg(option, val, oldValue, handleError);
       } else if (val !== null && option.variadic) {
         val = option._concatValue(val, oldValue);
       }
@@ -958,6 +958,19 @@ Expecting one of '${allowedValues.join("', '")}'`);
     const userArgs = this._prepareUserArgs(argv, parseOptions);
     await this._parseCommand([], userArgs);
 
+    // Throws errors from custom processing.
+    // Also prevents ERR_UNHANDLED_REJECTION by leaving no uncaught promises.
+    const toAwait = this.processedArgs;
+    Object.entries(this.opts()).forEach(([key, value]) => {
+      const source = this.getOptionValueSource(key);
+      if (source === 'cli' || source === 'env') {
+        if (typeof value?.then === 'function') {
+          toAwait.push(value);
+        }
+      }
+    });
+    await Promise.all(toAwait);
+
     return this;
   }
 
@@ -1161,8 +1174,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
    * @api private
    */
 
-  _parseArgs(target, value, previous, handleError) {
+  _parseArg(target, value, previous, handleError) {
     let parsedValue;
+
     if (typeof previous?.then === 'function') {
       // chain thenables
       parsedValue = previous.then(
@@ -1175,11 +1189,13 @@ Expecting one of '${allowedValues.join("', '")}'`);
         handleError(err);
       }
     }
+
     if (['then', 'catch'].every(
       (key) => typeof parsedValue?.[key] === 'function'
     )) {
-      parsedValue.catch(handleError);
+      parsedValue = parsedValue.catch(handleError);
     }
+
     return parsedValue;
   }
 
@@ -1198,11 +1214,11 @@ Expecting one of '${allowedValues.join("', '")}'`);
         }
         throw err;
       };
-  
+
       // Extra processing for nice error message on parsing failure.
       let parsedValue = value;
       if (value !== null && argument.parseArg) {
-        parsedValue = this._parseArgs(argument, value, previous, handleError);
+        parsedValue = this._parseArg(argument, value, previous, handleError);
       }
       return parsedValue;
     };

--- a/lib/command.js
+++ b/lib/command.js
@@ -424,9 +424,11 @@ Expecting one of '${allowedValues.join("', '")}'`);
       );
 
       for (const [key, value] of Object.entries(actionCommand.opts())) {
-        actionCommand.setOptionValueWithSource(
-          key, await value, actionCommand._optionValueSources[key]
-        );
+        if (typeof value?.then === 'function') {
+          actionCommand.setOptionValueWithSource(
+            key, await value, actionCommand.getOptionValueSource(key)
+          );
+        }
       }
     });
 
@@ -565,20 +567,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
       const oldValue = this.getOptionValue(name);
 
       if (val !== null && option.parseArg) {
-        if (typeof oldValue?.then !== 'function') {
-          try {
-            val = option.parseArg(val, oldValue);
-          } catch (err) {
-            handleError(err);
-          }
-        } else {
-          // chain thenables
-          const originalVal = val;
-          val = oldValue.then(
-            (result) => option.parseArg(originalVal, result)
-          );
-          val.catch(handleError);
-        }
+        val = this._parseArgs(option, val, oldValue, handleError);
       } else if (val !== null && option.variadic) {
         val = option._concatValue(val, oldValue);
       }
@@ -1162,6 +1151,39 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   /**
+   * Internal implementation shared by ._processArguments() and option and optionEnv event listeners
+   *
+   * @param {Argument|Option} target
+   * @param {*} value
+   * @param {*} previous
+   * @param {Function} handleError
+   * @return {*}
+   * @api private
+   */
+
+  _parseArgs(target, value, previous, handleError) {
+    let parsedValue;
+    if (typeof previous?.then === 'function') {
+      // chain thenables
+      parsedValue = previous.then(
+        (result) => target.parseArg(value, result)
+      );
+    } else {
+      try {
+        parsedValue = target.parseArg(value, previous);
+      } catch (err) {
+        handleError(err);
+      }
+    }
+    if (['then', 'catch'].every(
+      (key) => typeof parsedValue?.[key] === 'function'
+    )) {
+      parsedValue.catch(handleError);
+    }
+    return parsedValue;
+  }
+
+  /**
    * Process this.args using this._args and save as this.processedArgs!
    *
    * @api private
@@ -1180,19 +1202,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
       // Extra processing for nice error message on parsing failure.
       let parsedValue = value;
       if (value !== null && argument.parseArg) {
-        if (typeof previous?.then !== 'function') {
-          try {
-            parsedValue = argument.parseArg(value, previous);
-          } catch (err) {
-            handleError(err);
-          }
-        } else {
-          // chain thenables
-          parsedValue = previous.then(
-            (result) => argument.parseArg(value, result)
-          )
-          parsedValue.catch(handleError);
-        }
+        parsedValue = this._parseArgs(argument, value, previous, handleError);
       }
       return parsedValue;
     };

--- a/lib/command.js
+++ b/lib/command.js
@@ -64,7 +64,6 @@ class Command extends EventEmitter {
     this._awaitHook = undefined;
     /** @type {{ preSubcommand: number, postArguments: number } | null} */
     this._awaitHookIndices = null;
-    this.awaitHook();
 
     // see .configureOutput() for docs
     this._outputConfiguration = {
@@ -506,6 +505,33 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   /**
+   * @api private
+   */
+
+  _addAwaitHook() {
+    this._awaitHookPreSubcommand();
+    this._awaitHookPostArguments();
+
+    const events = ['preSubcommand', 'postArguments'];
+    this._awaitHookIndices = events.reduce((obj, event) => {
+      obj[event] = this._lifeCycleHooks[event].length - 1;
+      return obj;
+    }, {});
+  }
+
+  /**
+   * @api private
+   */
+
+  _removeAwaitHook() {
+    const events = ['preSubcommand', 'postArguments'];
+    events.forEach((event) => {
+      this._lifeCycleHooks[event].splice(this._awaitHookIndices[event], 1);
+    });
+    this._awaitHookIndices = null;
+  }
+
+  /**
    * Add hook to await argument and option values.
    * Useful for asynchronous custom processing (parseArg) of arguments and option-arguments.
    *
@@ -525,22 +551,12 @@ Expecting one of '${allowedValues.join("', '")}'`);
   awaitHook(enabled) {
     this._awaitHook = enabled === undefined ? undefined : !!enabled;
 
-    const events = ['preSubcommand', 'postArguments'];
     if (this._awaitHookIndices) {
-      events.forEach((event) => {
-        this._lifeCycleHooks[event].splice(this._awaitHookIndices[event], 1);
-      });
-      this._awaitHookIndices = null;
+      this._removeAwaitHook();
     }
 
     if (this._awaitHook !== false) {
-      this._awaitHookPreSubcommand();
-      this._awaitHookPostArguments();
-
-      this._awaitHookIndices = events.reduce((obj, event) => {
-        obj[event] = this._lifeCycleHooks[event].length - 1;
-        return obj;
-      }, {});
+      this._addAwaitHook();
     }
 
     return this;
@@ -1081,14 +1097,21 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
   async parseAsync(argv, parseOptions) {
     this._asyncParsing = true;
+    const shouldAddAwaitHook = (
+      // Only true if awaitHook() has never been called
+      this._awaitHook === undefined && this._awaitHookIndices === null
+    );
 
     try {
+      if (shouldAddAwaitHook) this._addAwaitHook();
+
       const userArgs = this._prepareUserArgs(argv, parseOptions);
       await this._parseCommand([], userArgs);
 
       return this;
     } finally {
       this._asyncParsing = undefined;
+      if (shouldAddAwaitHook) this._removeAwaitHook();
     }
   }
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -25,7 +25,6 @@ class Command extends EventEmitter {
     this.commands = [];
     /** @type {Option[]} */
     this.options = [];
-    this._optionsByAttributeName = {};
     this.parent = null;
     this._allowUnknownOption = false;
     this._allowExcessArguments = true;
@@ -421,17 +420,42 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
   awaitHook() {
     this.hook('preAction', async function awaitHook(thisCommand, actionCommand) {
-      actionCommand.processedArgs = await Promise.all(
-        actionCommand.processedArgs
-      );
+      const toAwait = actionCommand.processedArgs
+        // .slice(
+        //   0, actionCommand.args.length
+        // ) // ignore defaults
+        .map((value, i) => async() => {
+          if (typeof value?.then === 'function') {
+            actionCommand.processedArgs[i] = await value;
+          }
+        });
 
-      for (const [key, value] of Object.entries(actionCommand.opts())) {
-        if (typeof value?.then === 'function') {
-          actionCommand.setOptionValueWithSource(
-            key, await value, actionCommand.getOptionValueSource(key)
-          );
-        }
-      }
+      Object.entries(actionCommand.opts())
+        .forEach(([key, value]) => {
+          if (typeof value?.then === 'function') {
+            // const source = actionCommand.getOptionValueSource(key);
+            // if (source === 'cli' || source === 'env') {
+            toAwait.push(async() => {
+              actionCommand.setOptionValueWithSource(
+                key, await value, actionCommand.getOptionValueSource(key)
+              );
+            });
+            // }
+          }
+        });
+
+      Object.entries(actionCommand._overwrittenOptionValues)
+        .forEach(([key, values]) => {
+          values.forEach(value => {
+            if (typeof value?.then === 'function') {
+              toAwait.push(async() => {
+                await value;
+              });
+            }
+          });
+        });
+
+      return Promise.all(toAwait.map(fn => fn()));
     });
 
     return this;
@@ -548,7 +572,6 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
     // register the option
     this.options.push(option);
-    this._optionsByAttributeName[name] = option;
 
     // handler for cli and env supplied values
     const handleOptionValue = (val, invalidValueMessage, valueSource) => {
@@ -969,28 +992,6 @@ Expecting one of '${allowedValues.join("', '")}'`);
     const userArgs = this._prepareUserArgs(argv, parseOptions);
     await this._parseCommand([], userArgs);
 
-    // Throws errors from custom processing.
-    // Also prevents ERR_UNHANDLED_REJECTION by leaving no uncaught promises.
-    const toAwait = this.processedArgs
-      .slice(0, this.args.length) // remove defaults
-      .filter((arg, i) => {
-        return this._args[i].chained;
-      });
-    Object.entries(this.opts())
-      .filter(([key]) => this._optionsByAttributeName[key])
-      .forEach(([key, value]) => {
-        const source = this.getOptionValueSource(key);
-        if (source === 'cli' || source === 'env') {
-          toAwait.push(value);
-        }
-      });
-    Object.entries(this._overwrittenOptionValues)
-      .filter(([key]) => this._optionsByAttributeName[key])
-      .forEach(([key, values]) => {
-        values.forEach(value => toAwait.push(value));
-      });
-    await Promise.all(toAwait);
-
     return this;
   }
 
@@ -1184,7 +1185,24 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   /**
-   * Internal implementation shared by ._processArguments() and option and optionEnv event listeners
+   * @param {Argument|Option} target
+   * @param {*} value
+   * @param {Function} handleError
+   * @api private
+   */
+
+  _handleChainError(target, value, handleError) {
+    if (target.chained && ['then', 'catch'].every(
+      (key) => typeof value?.[key] === 'function'
+    )) {
+      value.catch(handleError);
+    }
+  }
+
+  /**
+   * Internal implementation shared by ._processArguments() and option and optionEnv event listeners.
+   *
+   * @api private
    *
    * @param {Argument|Option} target
    * @param {*} value
@@ -1200,20 +1218,20 @@ Expecting one of '${allowedValues.join("', '")}'`);
     if (target.chained && typeof previous?.then === 'function') {
       // chain thenables
       parsedValue = previous.then(
-        (result) => target.parseArg(value, result)
+        (result) => {
+          result = target.parseArg(value, result);
+          // call with result and not parsedValue to not catch handleError exception repeatedly
+          this._handleChainError(target, result, handleError);
+          return result;
+        }
       );
     } else {
       try {
         parsedValue = target.parseArg(value, previous);
+        this._handleChainError(target, parsedValue, handleError);
       } catch (err) {
         handleError(err);
       }
-    }
-
-    if (target.chained && ['then', 'catch'].every(
-      (key) => typeof parsedValue?.[key] === 'function'
-    )) {
-      parsedValue = parsedValue.catch(handleError);
     }
 
     return parsedValue;
@@ -1914,7 +1932,6 @@ Expecting one of '${allowedValues.join("', '")}'`);
     const versionOption = this.createOption(flags, description);
     this._versionOptionName = versionOption.attributeName();
     this.options.push(versionOption);
-    this._optionsByAttributeName[this._versionOptionName] = versionOption;
     this.on('option:' + versionOption.name(), () => {
       this._outputConfiguration.writeOut(`${str}\n`);
       this._exit(0, 'commander.version', str);

--- a/lib/option.js
+++ b/lib/option.js
@@ -31,6 +31,7 @@ class Option {
     this.presetArg = undefined;
     this.envVar = undefined;
     this.parseArg = undefined;
+    this.chained = false;
     this.hidden = false;
     this.argChoices = undefined;
     this.conflictsWith = [];
@@ -132,6 +133,17 @@ class Option {
 
   argParser(fn) {
     this.parseArg = fn;
+    return this;
+  }
+
+  /**
+   * When set to true, next call to the function provided via .argParser() will be chained to its return value if it is thenable.
+   *
+   * @param {boolean} [chained]
+   * @return {Argument}
+   */
+  chainArgParserCalls(chained = true) {
+    this.chained = !!chained;
     return this;
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "commander",
-      "version": "10.0.1",
+      "version": "11.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.2.4",

--- a/tests/argument.chain.test.js
+++ b/tests/argument.chain.test.js
@@ -13,6 +13,12 @@ describe('Argument methods that should return this for chaining', () => {
     expect(result).toBe(argument);
   });
 
+  test('when call .chainArgParserCalls() then returns this', () => {
+    const argument = new Argument('<value>');
+    const result = argument.chainArgParserCalls();
+    expect(result).toBe(argument);
+  });
+
   test('when call .choices() then returns this', () => {
     const argument = new Argument('<value>');
     const result = argument.choices(['a']);

--- a/tests/command.argumentVariations.test.js
+++ b/tests/command.argumentVariations.test.js
@@ -9,7 +9,8 @@ test.each(getSingleArgCases('<explicit-required>'))('when add "<arg>" using %s t
     _name: 'explicit-required',
     required: true,
     variadic: false,
-    description: ''
+    description: '',
+    chained: false
   };
   expect(argument).toEqual(expectedShape);
 });
@@ -20,7 +21,8 @@ test.each(getSingleArgCases('implicit-required'))('when add "arg" using %s then 
     _name: 'implicit-required',
     required: true,
     variadic: false,
-    description: ''
+    description: '',
+    chained: false
   };
   expect(argument).toEqual(expectedShape);
 });
@@ -31,7 +33,8 @@ test.each(getSingleArgCases('[optional]'))('when add "[arg]" using %s then argum
     _name: 'optional',
     required: false,
     variadic: false,
-    description: ''
+    description: '',
+    chained: false
   };
   expect(argument).toEqual(expectedShape);
 });
@@ -42,7 +45,8 @@ test.each(getSingleArgCases('<explicit-required...>'))('when add "<arg...>" usin
     _name: 'explicit-required',
     required: true,
     variadic: true,
-    description: ''
+    description: '',
+    chained: false
   };
   expect(argument).toEqual(expectedShape);
 });
@@ -53,7 +57,8 @@ test.each(getSingleArgCases('implicit-required...'))('when add "arg..." using %s
     _name: 'implicit-required',
     required: true,
     variadic: true,
-    description: ''
+    description: '',
+    chained: false
   };
   expect(argument).toEqual(expectedShape);
 });
@@ -64,7 +69,8 @@ test.each(getSingleArgCases('[optional...]'))('when add "[arg...]" using %s then
     _name: 'optional',
     required: false,
     variadic: true,
-    description: ''
+    description: '',
+    chained: false
   };
   expect(argument).toEqual(expectedShape);
 });

--- a/tests/command.awaitHook.test.js
+++ b/tests/command.awaitHook.test.js
@@ -60,9 +60,13 @@ describe('awaitHook with arguments', () => {
     const awaited = [coercion(args[0], undefined)];
     const mockCoercion = jest.fn().mockImplementation(coercion);
 
+    const argument = new commander.Argument('<arg...>', 'desc')
+      .argParser(mockCoercion)
+      .chainArgParserCalls();
+
     const program = new commander.Command();
     program
-      .argument('<arg...>', 'desc', mockCoercion);
+      .addArgument(argument);
 
     await testWithArguments(program, args, resolvedValues, awaited);
   });
@@ -150,9 +154,13 @@ describe('awaitHook with options', () => {
     const awaited = { a: coercion(args.slice(1)[0], undefined) };
     const mockCoercion = jest.fn().mockImplementation(coercion);
 
+    const option = new commander.Option('-a <arg...>', 'desc')
+      .argParser(mockCoercion)
+      .chainArgParserCalls();
+
     const program = new commander.Command();
     program
-      .option('-a <arg...>', 'desc', mockCoercion);
+      .addOption(option);
 
     await testWithOptions(program, args, resolvedValues, awaited);
     expect(program.getOptionValueSource('a')).toEqual('cli');

--- a/tests/command.awaitHook.test.js
+++ b/tests/command.awaitHook.test.js
@@ -5,13 +5,12 @@ const makeThenable = (function() {
   return (value) => {
     if (cache.has(value)) {
       return cache.get(value);
-    } else {
-      const thenable = {
-        then: (fn) => makeThenable(fn(value))
-      };
-      cache.set(value, thenable);
-      return thenable;
     }
+    const thenable = {
+      then: (fn) => makeThenable(fn(value))
+    };
+    cache.set(value, thenable);
+    return thenable;
   };
 })();
 

--- a/tests/command.awaitHook.test.js
+++ b/tests/command.awaitHook.test.js
@@ -145,6 +145,27 @@ describe('awaitHook with options', () => {
     expect(program.getOptionValueSource('b')).toEqual('implied');
   });
 
+  test('when awaitHook and non-variadic repeated option with chained asynchronous custom processing then .opts() resolved from chain', async() => {
+    const args = ['-a', '1', '-a', '2'];
+    const resolvedValues = { a: '12' };
+    const coercion = async(value, previousValue) => (
+      previousValue === undefined ? value : previousValue + value
+    );
+    const awaited = { a: coercion(args.slice(1)[0], undefined) };
+    const mockCoercion = jest.fn().mockImplementation(coercion);
+
+    const option = new commander.Option('-a [arg]', 'desc')
+      .argParser(mockCoercion)
+      .chainArgParserCalls();
+
+    const program = new commander.Command();
+    program
+      .addOption(option);
+
+    await testWithOptions(program, args, resolvedValues, awaited);
+    expect(program.getOptionValueSource('a')).toEqual('cli');
+  });
+
   test('when awaitHook and variadic option with chained asynchronous custom processing then .opts() resolved from chain', async() => {
     const args = ['-a', '1', '2'];
     const resolvedValues = { a: '12' };

--- a/tests/command.awaitHook.test.js
+++ b/tests/command.awaitHook.test.js
@@ -8,7 +8,7 @@ describe('awaitHook with arguments', () => {
       .action((...args) => {
         actionValues = args.slice(0, resolvedValues.length);
       });
-  
+
     const result = program.parseAsync(args, { from: 'user' });
     expect(program.processedArgs).toEqual(awaited);
     await result;
@@ -73,7 +73,7 @@ describe('awaitHook with options', () => {
     program
       .awaitHook()
       .action(() => {});
-  
+
     const result = program.parseAsync(args, { from: 'user' });
     expect(program.opts()).toEqual(awaited);
     await result;

--- a/tests/command.awaitHook.test.js
+++ b/tests/command.awaitHook.test.js
@@ -1,7 +1,23 @@
 const commander = require('../');
 
 describe('awaitHook with arguments', () => {
+  async function testWithArguments(program, args, resolvedValues, awaited) {
+    let actionValues;
+    program
+      .awaitHook()
+      .action((...args) => {
+        actionValues = args.slice(0, resolvedValues.length);
+      });
+  
+    const result = program.parseAsync(args, { from: 'user' });
+    expect(program.processedArgs).toEqual(awaited);
+    await result;
+    expect(program.processedArgs).toEqual(resolvedValues);
+    expect(actionValues).toEqual(resolvedValues);
+  }
+
   test('when awaitHook and arguments with custom processing then .processedArgs and actioon arguments resolved from callback', async() => {
+    const args = ['1', '2'];
     const resolvedValues = [3, 4];
     const awaited = [
       { then: (fn) => fn(resolvedValues[0]) },
@@ -11,50 +27,61 @@ describe('awaitHook with arguments', () => {
       value => jest.fn().mockImplementation(() => value)
     );
 
-    let actionValues;
     const program = new commander.Command();
     program
       .argument('<arg>', 'desc', mockCoercions[0])
-      .argument('[arg]', 'desc', mockCoercions[1])
-      .awaitHook()
-      .action((...args) => {
-        actionValues = args.slice(0, resolvedValues.length);
-      });
+      .argument('[arg]', 'desc', mockCoercions[1]);
 
-    const result = program.parseAsync(['1', '2'], { from: 'user' });
-    expect(program.processedArgs).toEqual(awaited);
-    await result;
-    expect(program.processedArgs).toEqual(resolvedValues);
-    expect(actionValues).toEqual(resolvedValues);
+    await testWithArguments(program, args, resolvedValues, awaited);
   });
 
   test('when awaitHook and arguments not specified with default values then .processedArgs and actioon arguments resolved from default values', async() => {
+    const args = [];
     const resolvedValues = [1, 2];
     const awaited = [
       { then: (fn) => fn(resolvedValues[0]) },
       resolvedValues[1]
     ];
 
-    let actionValues;
     const program = new commander.Command();
     program
       .argument('[arg]', 'desc', awaited[0])
-      .argument('[arg]', 'desc', awaited[1])
-      .awaitHook()
-      .action((...args) => {
-        actionValues = args.slice(0, resolvedValues.length);
-      });
+      .argument('[arg]', 'desc', awaited[1]);
 
-    const result = program.parseAsync([], { from: 'user' });
-    expect(program.processedArgs).toEqual(awaited);
-    await result;
-    expect(program.processedArgs).toEqual(resolvedValues);
-    expect(actionValues).toEqual(resolvedValues);
+    await testWithArguments(program, args, resolvedValues, awaited);
+  });
+
+  test('when awaitHook and variadic argument with asynchronous custom processing then .processedArgs and actioon arguments resolved from thenable chain', async() => {
+    const args = ['1', '2'];
+    const resolvedValues = ['12'];
+    const coercion = async(value, previousValue) => (
+      previousValue === undefined ? value : previousValue + value
+    );
+    const awaited = [coercion(args[0], undefined)];
+    const mockCoercion = jest.fn().mockImplementation(coercion);
+
+    const program = new commander.Command();
+    program
+      .argument('<arg...>', 'desc', mockCoercion);
+
+    await testWithArguments(program, args, resolvedValues, awaited);
   });
 });
 
 describe('awaitHook with options', () => {
+  async function testWithOptions(program, args, resolvedValues, awaited) {
+    program
+      .awaitHook()
+      .action(() => {});
+  
+    const result = program.parseAsync(args, { from: 'user' });
+    expect(program.opts()).toEqual(awaited);
+    await result;
+    expect(program.opts()).toEqual(resolvedValues);
+  }
+
   test('when awaitHook and options with custom processing then .opts() resolved from callback', async() => {
+    const args = ['-a', '1', '-b', '2'];
     const resolvedValues = { a: 3, b: 4 };
     const awaited = {
       a: { then: (fn) => fn(resolvedValues.a) },
@@ -68,19 +95,15 @@ describe('awaitHook with options', () => {
     const program = new commander.Command();
     program
       .option('-a <arg>', 'desc', mockCoercions.a)
-      .option('-b [arg]', 'desc', mockCoercions.b)
-      .awaitHook()
-      .action(() => {});
+      .option('-b [arg]', 'desc', mockCoercions.b);
 
-    const result = program.parseAsync(['-a', '1', '-b', '2'], { from: 'user' });
-    expect(program.opts()).toEqual(awaited);
-    await result;
-    expect(program.opts()).toEqual(resolvedValues);
+    await testWithOptions(program, args, resolvedValues, awaited);
     expect(program.getOptionValueSource('a')).toEqual('cli');
     expect(program.getOptionValueSource('b')).toEqual('cli');
   });
 
   test('when awaitHook and options not specified with default values then .opts() resolved from default values', async() => {
+    const args = [];
     const resolvedValues = { a: 1, b: 2 };
     const awaited = {
       a: { then: (fn) => fn(resolvedValues.a) },
@@ -90,23 +113,20 @@ describe('awaitHook with options', () => {
     const program = new commander.Command();
     program
       .option('-a <arg>', 'desc', awaited.a)
-      .option('-b [arg]', 'desc', awaited.b)
-      .awaitHook()
-      .action(() => {});
+      .option('-b [arg]', 'desc', awaited.b);
 
-    const result = program.parseAsync([], { from: 'user' });
-    expect(program.opts()).toEqual(awaited);
-    await result;
-    expect(program.opts()).toEqual(resolvedValues);
+    await testWithOptions(program, args, resolvedValues, awaited);
     expect(program.getOptionValueSource('a')).toEqual('default');
     expect(program.getOptionValueSource('b')).toEqual('default');
   });
 
   test('when awaitHook and implied option values then .opts() resolved from implied values', async() => {
-    const resolvedValues = { a: 1, b: 2 };
+    const args = ['-c'];
+    const resolvedValues = { a: 1, b: 2, c: true };
     const awaited = {
       a: { then: (fn) => fn(resolvedValues.a) },
-      b: resolvedValues.b
+      b: resolvedValues.b,
+      c: true
     };
 
     const option = new commander.Option('-c').implies(awaited);
@@ -114,15 +134,27 @@ describe('awaitHook with options', () => {
     program
       .option('-a <arg>')
       .option('-b [arg]')
-      .addOption(option)
-      .awaitHook()
-      .action(() => {});
+      .addOption(option);
 
-    const result = program.parseAsync(['-c'], { from: 'user' });
-    expect(program.opts()).toEqual({ ...awaited, c: true });
-    await result;
-    expect(program.opts()).toEqual({ ...resolvedValues, c: true });
+    await testWithOptions(program, args, resolvedValues, awaited);
     expect(program.getOptionValueSource('a')).toEqual('implied');
     expect(program.getOptionValueSource('b')).toEqual('implied');
+  });
+
+  test('when awaitHook and variadic option with asynchronous custom processing then .opts() resolved from thenable chain', async() => {
+    const args = ['-a', '1', '2'];
+    const resolvedValues = { a: '12' };
+    const coercion = async(value, previousValue) => (
+      previousValue === undefined ? value : previousValue + value
+    );
+    const awaited = { a: coercion(args.slice(1)[0], undefined) };
+    const mockCoercion = jest.fn().mockImplementation(coercion);
+
+    const program = new commander.Command();
+    program
+      .option('-a <arg...>', 'desc', mockCoercion);
+
+    await testWithOptions(program, args, resolvedValues, awaited);
+    expect(program.getOptionValueSource('a')).toEqual('cli');
   });
 });

--- a/tests/command.awaitHook.test.js
+++ b/tests/command.awaitHook.test.js
@@ -51,7 +51,7 @@ describe('awaitHook with arguments', () => {
     await testWithArguments(program, args, resolvedValues, awaited);
   });
 
-  test('when awaitHook and variadic argument with asynchronous custom processing then .processedArgs and actioon arguments resolved from thenable chain', async() => {
+  test('when awaitHook and variadic argument with chained asynchronous custom processing then .processedArgs and actioon arguments resolved from chain', async() => {
     const args = ['1', '2'];
     const resolvedValues = ['12'];
     const coercion = async(value, previousValue) => (
@@ -145,7 +145,7 @@ describe('awaitHook with options', () => {
     expect(program.getOptionValueSource('b')).toEqual('implied');
   });
 
-  test('when awaitHook and variadic option with asynchronous custom processing then .opts() resolved from thenable chain', async() => {
+  test('when awaitHook and variadic option with chained asynchronous custom processing then .opts() resolved from chain', async() => {
     const args = ['-a', '1', '2'];
     const resolvedValues = { a: '12' };
     const coercion = async(value, previousValue) => (

--- a/tests/command.awaitHook.test.js
+++ b/tests/command.awaitHook.test.js
@@ -1,0 +1,128 @@
+const commander = require('../');
+
+describe('awaitHook with arguments', () => {
+  test('when awaitHook and arguments with custom processing then .processedArgs and actioon arguments resolved from callback', async() => {
+    const resolvedValues = [3, 4];
+    const awaited = [
+      { then: (fn) => fn(resolvedValues[0]) },
+      resolvedValues[1]
+    ];
+    const mockCoercions = awaited.map(
+      value => jest.fn().mockImplementation(() => value)
+    );
+
+    let actionValues;
+    const program = new commander.Command();
+    program
+      .argument('<arg>', 'desc', mockCoercions[0])
+      .argument('[arg]', 'desc', mockCoercions[1])
+      .awaitHook()
+      .action((...args) => {
+        actionValues = args.slice(0, resolvedValues.length);
+      });
+
+    const result = program.parseAsync(['1', '2'], { from: 'user' });
+    expect(program.processedArgs).toEqual(awaited);
+    await result;
+    expect(program.processedArgs).toEqual(resolvedValues);
+    expect(actionValues).toEqual(resolvedValues);
+  });
+
+  test('when awaitHook and arguments not specified with default values then .processedArgs and actioon arguments resolved from default values', async() => {
+    const resolvedValues = [1, 2];
+    const awaited = [
+      { then: (fn) => fn(resolvedValues[0]) },
+      resolvedValues[1]
+    ];
+
+    let actionValues;
+    const program = new commander.Command();
+    program
+      .argument('[arg]', 'desc', awaited[0])
+      .argument('[arg]', 'desc', awaited[1])
+      .awaitHook()
+      .action((...args) => {
+        actionValues = args.slice(0, resolvedValues.length);
+      });
+
+    const result = program.parseAsync([], { from: 'user' });
+    expect(program.processedArgs).toEqual(awaited);
+    await result;
+    expect(program.processedArgs).toEqual(resolvedValues);
+    expect(actionValues).toEqual(resolvedValues);
+  });
+});
+
+describe('awaitHook with options', () => {
+  test('when awaitHook and options with custom processing then .opts() resolved from callback', async() => {
+    const resolvedValues = { a: 3, b: 4 };
+    const awaited = {
+      a: { then: (fn) => fn(resolvedValues.a) },
+      b: resolvedValues.b
+    };
+    const mockCoercions = Object.entries(awaited).reduce((acc, [key, value]) => {
+      acc[key] = jest.fn().mockImplementation(() => value);
+      return acc;
+    }, {});
+
+    const program = new commander.Command();
+    program
+      .option('-a <arg>', 'desc', mockCoercions.a)
+      .option('-b [arg]', 'desc', mockCoercions.b)
+      .awaitHook()
+      .action(() => {});
+
+    const result = program.parseAsync(['-a', '1', '-b', '2'], { from: 'user' });
+    expect(program.opts()).toEqual(awaited);
+    await result;
+    expect(program.opts()).toEqual(resolvedValues);
+    expect(program.getOptionValueSource('a')).toEqual('cli');
+    expect(program.getOptionValueSource('b')).toEqual('cli');
+  });
+
+  test('when awaitHook and options not specified with default values then .opts() resolved from default values', async() => {
+    const resolvedValues = { a: 1, b: 2 };
+    const awaited = {
+      a: { then: (fn) => fn(resolvedValues.a) },
+      b: resolvedValues.b
+    };
+
+    const program = new commander.Command();
+    program
+      .option('-a <arg>', 'desc', awaited.a)
+      .option('-b [arg]', 'desc', awaited.b)
+      .awaitHook()
+      .action(() => {});
+
+    const result = program.parseAsync([], { from: 'user' });
+    expect(program.opts()).toEqual(awaited);
+    await result;
+    expect(program.opts()).toEqual(resolvedValues);
+    expect(program.getOptionValueSource('a')).toEqual('default');
+    expect(program.getOptionValueSource('b')).toEqual('default');
+  });
+
+  test('when awaitHook and implied option values then .opts() resolved from implied values', async() => {
+    const resolvedValues = { a: 1, b: 2 };
+    const awaited = {
+      a: { then: (fn) => fn(resolvedValues.a) },
+      b: resolvedValues.b
+    };
+
+    const option = new commander.Option('-c').implies(awaited);
+    const program = new commander.Command();
+    program
+      .option('-a <arg>')
+      .option('-b [arg]')
+      .addOption(option)
+      .awaitHook()
+      .action(() => {});
+
+    const result = program.parseAsync(['-c'], { from: 'user' });
+    expect(program.opts()).toEqual({ ...awaited, c: true });
+    await result;
+    expect(program.opts()).toEqual({ ...resolvedValues, c: true });
+    expect(program.getOptionValueSource('a')).toEqual('implied');
+    expect(program.getOptionValueSource('b')).toEqual('implied');
+  });
+});

--- a/tests/command.awaitHook.test.js
+++ b/tests/command.awaitHook.test.js
@@ -32,7 +32,6 @@ describe('awaitHook with arguments', () => {
   async function testWithArguments(program, args, resolvedValues, awaited) {
     let actionValues;
     program
-      .awaitHook()
       .action((...args) => {
         actionValues = args.slice(0, resolvedValues.length);
       });
@@ -108,7 +107,6 @@ describe('awaitHook with arguments', () => {
 describe('awaitHook with options', () => {
   async function testWithOptions(program, args, resolvedValues, awaited) {
     program
-      .awaitHook()
       .action(() => {});
 
     const result = program.parseAsync(args, { from: 'user' });
@@ -258,7 +256,6 @@ describe('awaitHook with options', () => {
     const program = new commander.Command();
     program
       .option('-a <arg>', 'desc', mockCoercion)
-      .awaitHook()
       .command('subcommand')
       .option('-b <arg>', 'desc', mockSyncCoercion)
       .action(() => {});

--- a/tests/command.chain.test.js
+++ b/tests/command.chain.test.js
@@ -172,6 +172,12 @@ describe('Command methods that should return this for chaining', () => {
     expect(result).toBe(program);
   });
 
+  test('when call .awaitHook() then returns this', () => {
+    const program = new Command();
+    const result = program.awaitHook();
+    expect(result).toBe(program);
+  });
+
   test('when call .setOptionValue() then returns this', () => {
     const program = new Command();
     const result = program.setOptionValue('foo', 'bar');

--- a/tests/command.hook.test.js
+++ b/tests/command.hook.test.js
@@ -258,7 +258,6 @@ describe('action hooks async', () => {
     const calls = [];
     const program = new commander.Command();
     program
-      .awaitHook(false)
       .hook('preAction', () => calls.push('before'))
       .hook('postAction', () => calls.push('after'))
       .action(async() => {
@@ -291,7 +290,6 @@ describe('action hooks async', () => {
     const calls = [];
     const program = new commander.Command();
     program
-      .awaitHook(false)
       .hook('preAction', () => calls.push('1'))
       .hook('preAction', async() => {
         await 0;

--- a/tests/command.hook.test.js
+++ b/tests/command.hook.test.js
@@ -243,6 +243,7 @@ describe('action hooks async', () => {
     const calls = [];
     const program = new commander.Command();
     program
+      .awaitHook(false)
       .hook('postAction', async() => {
         await 0;
         calls.push('after');
@@ -258,6 +259,7 @@ describe('action hooks async', () => {
     const calls = [];
     const program = new commander.Command();
     program
+      .awaitHook(false)
       .hook('preAction', () => calls.push('before'))
       .hook('postAction', () => calls.push('after'))
       .action(async() => {
@@ -290,6 +292,7 @@ describe('action hooks async', () => {
     const calls = [];
     const program = new commander.Command();
     program
+      .awaitHook(false)
       .hook('preAction', () => calls.push('1'))
       .hook('preAction', async() => {
         await 0;

--- a/tests/command.hook.test.js
+++ b/tests/command.hook.test.js
@@ -243,7 +243,6 @@ describe('action hooks async', () => {
     const calls = [];
     const program = new commander.Command();
     program
-      .awaitHook(false)
       .hook('postAction', async() => {
         await 0;
         calls.push('after');

--- a/tests/command.parse.test.js
+++ b/tests/command.parse.test.js
@@ -95,10 +95,15 @@ describe('return type', () => {
       error => jest.fn().mockRejectedValue(error)
     );
 
+    const args = mockCoercions.map(fn => (
+      new commander.Argument('[arg]', 'desc')
+        .argParser(fn)
+        .chainArgParserCalls()
+    ));
     const program = new commander.Command();
     program
-      .argument('[arg]', 'desc', mockCoercions[0])
-      .argument('[arg]', 'desc', mockCoercions[1])
+      .addArgument(args[0])
+      .addArgument(args[1])
       .action(() => { });
 
     const result = program.parseAsync(['1', '2'], { from: 'user' });
@@ -114,14 +119,18 @@ describe('return type', () => {
 
     const program = new commander.Command();
     program
-      .option('-a [arg]', 'desc', mockCoercion)
+      .addOption(
+        new commander.Option('-a [arg]', 'desc')
+          .argParser(mockCoercion)
+          .chainArgParserCalls()
+      )
       .action(() => { });
 
     const result = program.parseAsync(
       ['-a', '1', '-a', '2', '-a', '3'], { from: 'user' }
     );
     await expect(result).rejects.toBeInstanceOf(MyError);
-    expect(mockCoercion).toHaveBeenCalledTimes(3);
+    expect(mockCoercion).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/tests/command.parse.test.js
+++ b/tests/command.parse.test.js
@@ -121,7 +121,7 @@ describe('return type', () => {
       ['-a', '1', '-a', '2', '-a', '3'], { from: 'user' }
     );
     await expect(result).rejects.toBeInstanceOf(MyError);
-    expect(mockCoercion).toHaveBeenCalledTimes(1);
+    expect(mockCoercion).toHaveBeenCalledTimes(3);
   });
 });
 

--- a/tests/option.chain.test.js
+++ b/tests/option.chain.test.js
@@ -13,6 +13,12 @@ describe('Option methods that should return this for chaining', () => {
     expect(result).toBe(option);
   });
 
+  test('when call .chainArgParserCalls() then returns this', () => {
+    const option = new Option('-e,--example <value>');
+    const result = option.chainArgParserCalls();
+    expect(result).toBe(option);
+  });
+
   test('when call .makeOptionMandatory() then returns this', () => {
     const option = new Option('-e,--example <value>');
     const result = option.makeOptionMandatory();

--- a/tests/options.custom-processing.test.js
+++ b/tests/options.custom-processing.test.js
@@ -140,7 +140,30 @@ test('when commaSeparatedList x,y,z then value is [x, y, z]', () => {
   expect(program.opts().list).toEqual(['x', 'y', 'z']);
 });
 
-test('when custom with .chainArgParserCalls() then parsed to chain', async() => {
+test('when custom non-variadic repeated with .chainArgParserCalls() then parsed to chain', async() => {
+  const args = ['-a', '1', '-a', '2'];
+  const resolvedValue = '12';
+  const coercion = async(value, previousValue) => (
+    previousValue === undefined ? value : previousValue + value
+  );
+  const awaited = coercion(args[1], undefined);
+  const mockCoercion = jest.fn().mockImplementation(coercion);
+
+  const option = new commander.Option('-a <arg...>', 'desc')
+    .argParser(mockCoercion)
+    .chainArgParserCalls();
+
+  const program = new commander.Command();
+  program
+    .addOption(option)
+    .action(() => {});
+
+  program.parse(args, { from: 'user' });
+  expect(program.opts()).toEqual({ a: awaited });
+  await expect(program.opts().a).resolves.toEqual(resolvedValue);
+});
+
+test('when custom variadic with .chainArgParserCalls() then parsed to chain', async() => {
   const args = ['-a', '1', '2'];
   const resolvedValue = '12';
   const coercion = async(value, previousValue) => (

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -68,7 +68,7 @@ export class Argument {
   /**
    * When set to true, next call to the function provided via .argParser() will be chained to its return value if it is thenable.
    */
-  chainArgParserCalls(chained: boolean): this;
+  chainArgParserCalls(chained?: boolean): this;
 
   /**
    * Only allow argument value to be one of choices.
@@ -167,7 +167,7 @@ export class Option {
   /**
    * When set to true, next call to the function provided via .argParser() will be chained to its return value if it is thenable.
    */
-  chainArgParserCalls(chained: boolean): this;
+  chainArgParserCalls(chained?: boolean): this;
 
   /**
    * Whether the option is mandatory and must have a value after parsing.

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -66,6 +66,11 @@ export class Argument {
   argParser<T>(fn: (value: string, previous: T) => T): this;
 
   /**
+   * When set to true, next call to the function provided via .argParser() will be chained to its return value if it is thenable.
+   */
+  chainArgParserCalls(chained: boolean): this;
+
+  /**
    * Only allow argument value to be one of choices.
    */
   choices(values: readonly string[]): this;
@@ -158,6 +163,11 @@ export class Option {
    * Set the custom handler for processing CLI option arguments into option values.
    */
   argParser<T>(fn: (value: string, previous: T) => T): this;
+
+  /**
+   * When set to true, next call to the function provided via .argParser() will be chained to its return value if it is thenable.
+   */
+  chainArgParserCalls(chained: boolean): this;
 
   /**
    * Whether the option is mandatory and must have a value after parsing.

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -281,7 +281,7 @@ export interface OutputConfiguration {
 }
 
 export type AddHelpTextPosition = 'beforeAll' | 'before' | 'after' | 'afterAll';
-export type HookEvent = 'preSubcommand' | 'preAction' | 'postAction';
+export type HookEvent = 'preSubcommand' | 'postArguments' | 'preAction' | 'postAction';
 export type OptionValueSource = 'default' | 'config' | 'env' | 'cli' | 'implied';
 
 export type OptionValues = Record<string, any>;
@@ -429,10 +429,19 @@ export class Command {
   hook(event: HookEvent, listener: (thisCommand: Command, actionCommand: Command) => void | Promise<void>): this;
 
   /**
-   * Add hook to await argument and option values before calling action handlers for this command and its nested subcommands.
+   * Add hook to await argument and option values.
    * Useful for asynchronous custom processing (parseArg) of arguments and option-arguments.
+   *
+   * Hook behaviour depends on the value of `enabled`:
+   * - If the value is `false`, do not await anything.
+   * - If the value is `true`, await for this command before dispatching subcommand; and for action command before calling action handlers if the "should await" condition applies (see below).
+   * - If the value is `undefined`, await for this command before dispatching subcommand if the "should await" condition applies (see below); and await for action command in the same manner as if the value were `true`, but only if this command is the top level command (i.e. has no parent).
+   *
+   * The "should await" condition for a command is as follows:
+   * - either the method was called with an `enabled` value of `true` on the nearest command ancestor for which the method was called with an `enabled` value other than `undefined`;
+   * - or there is no such ancestor and `parseAsync()` was called on the top-level command.
    */
-  awaitHook(): this;
+  awaitHook(enabled?: boolean | undefined): this;
 
   /**
    * Register callback to use as replacement for calling process.exit.

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -419,6 +419,12 @@ export class Command {
   hook(event: HookEvent, listener: (thisCommand: Command, actionCommand: Command) => void | Promise<void>): this;
 
   /**
+   * Add hook to await argument and option values before calling action handlers for this command and its nested subcommands.
+   * Useful for asynchronous custom processing (parseArg) of arguments and option-arguments.
+   */
+  awaitHook(): this;
+
+  /**
    * Register callback to use as replacement for calling process.exit.
    */
   exitOverride(callback?: (err: CommanderError) => never | void): this;

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -83,23 +83,33 @@ expectType<never>(program.error('Goodbye', { exitCode: 2 }));
 expectType<never>(program.error('Goodbye', { code: 'my.error', exitCode: 2 }));
 
 // hook
-expectType<commander.Command>(program.hook('preAction', () => {}));
-expectType<commander.Command>(program.hook('postAction', () => {}));
-expectType<commander.Command>(program.hook('preAction', async() => {}));
-expectType<commander.Command>(program.hook('preAction', (thisCommand, actionCommand) => {
-  // implicit parameter types
-  expectType<commander.Command>(thisCommand);
-  expectType<commander.Command>(actionCommand);
-}));
 expectType<commander.Command>(program.hook('preSubcommand', () => {}));
 expectType<commander.Command>(program.hook('preSubcommand', (thisCommand, subcommand) => {
   // implicit parameter types
   expectType<commander.Command>(thisCommand);
   expectType<commander.Command>(subcommand);
 }));
+expectType<commander.Command>(program.hook('postArguments', () => {}));
+expectType<commander.Command>(program.hook('postArguments', async() => {}));
+expectType<commander.Command>(program.hook('postArguments', (thisCommand, leafCommand) => {
+  // implicit parameter types
+  expectType<commander.Command>(thisCommand);
+  expectType<commander.Command>(leafCommand);
+}));
+expectType<commander.Command>(program.hook('preAction', () => {}));
+expectType<commander.Command>(program.hook('preAction', async() => {}));
+expectType<commander.Command>(program.hook('preAction', (thisCommand, actionCommand) => {
+  // implicit parameter types
+  expectType<commander.Command>(thisCommand);
+  expectType<commander.Command>(actionCommand);
+}));
+expectType<commander.Command>(program.hook('postAction', () => {}));
 
 // awaitHook
 expectType<commander.Command>(program.awaitHook());
+expectType<commander.Command>(program.awaitHook(true));
+expectType<commander.Command>(program.awaitHook(false));
+expectType<commander.Command>(program.awaitHook(undefined));
 
 // action
 expectType<commander.Command>(program.action(() => {}));
@@ -421,6 +431,11 @@ expectType<string>(baseOption.fullDescription());
 expectType<commander.Option>(baseOption.argParser((value: string) => parseInt(value)));
 expectType<commander.Option>(baseOption.argParser((value: string, previous: string[]) => { return previous.concat(value); }));
 
+// chainArgParserCalls
+expectType<commander.Option>(baseOption.chainArgParserCalls());
+expectType<commander.Option>(baseOption.chainArgParserCalls(true));
+expectType<commander.Option>(baseOption.chainArgParserCalls(false));
+
 // makeOptionMandatory
 expectType<commander.Option>(baseOption.makeOptionMandatory());
 expectType<commander.Option>(baseOption.makeOptionMandatory(true));
@@ -468,6 +483,11 @@ expectType<commander.Argument>(baseArgument.default(60, 'one minute'));
 // argParser
 expectType<commander.Argument>(baseArgument.argParser((value: string) => parseInt(value)));
 expectType<commander.Argument>(baseArgument.argParser((value: string, previous: string[]) => { return previous.concat(value); }));
+
+// chainArgParserCalls
+expectType<commander.Argument>(baseArgument.chainArgParserCalls());
+expectType<commander.Argument>(baseArgument.chainArgParserCalls(true));
+expectType<commander.Argument>(baseArgument.chainArgParserCalls(false));
 
 // choices
 expectType<commander.Argument>(baseArgument.choices(['a', 'b']));

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -98,6 +98,9 @@ expectType<commander.Command>(program.hook('preSubcommand', (thisCommand, subcom
   expectType<commander.Command>(subcommand);
 }));
 
+// awaitHook
+expectType<commander.Command>(program.awaitHook());
+
 // action
 expectType<commander.Command>(program.action(() => {}));
 expectType<commander.Command>(program.action(async() => {}));


### PR DESCRIPTION
# Pull Request

## Problem

#1900

At the moment, [a few lines of extra code](https://github.com/tj/commander.js/issues/1900#issuecomment-1622757806) are required to enable intuitive use of asynchronous custom processing of arguments and option-arguments by means of `async` argument parsers.

## Solution

The extra code is wrapped in the `awaitHook()` method of the `Command` class. It additionally awaits values that the custom processing is not applied to, namely default argument values as well as default and implied option values.

A `chainArgParserCalls()` method causing thenables returned from `parseArg()` to be chained is added to both `Argument` and `Option` classes. This is relevant when `parseArg()` is called with second argument supplied, which is the case for variadic arguments and options and repeated non-variadic options.

<!--
How did you solve the problem? 
Show the fixed output if appropriate.

There are a lot of forms of documentation which could need updating for a change in functionality. It
is ok if you want to show us the code to discuss before doing the extra work, and
you should say so in your comments so we focus on the concept first before talking about all the other pieces:

- TypeScript typings
- JSDoc documentation in code
- tests
- README
- examples/
-->
