### PR TITLE
Rework `Help.wrap()`

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -30,7 +30,7 @@ class CommanderError extends Error {
 class InvalidArgumentError extends CommanderError {
   /**
    * Constructs the InvalidArgumentError class
-   * @param {string} [message] explanation of why argument is invalid
+   * @param {string} message explanation of why argument is invalid
    * @constructor
    */
   constructor(message) {

--- a/lib/help.js
+++ b/lib/help.js
@@ -531,7 +531,7 @@ class Help {
       width = this.helpWidth ?? Number.POSITIVE_INFINITY;
     }
 
-    const leadingStr = str.slice(0, leadingStrLength);
+    let leadingStr = str.slice(0, leadingStrLength);
     const columnText = str.slice(leadingStrLength).replaceAll('\r\n', '\n');
 
     const newline = /\r?\n/;
@@ -540,7 +540,8 @@ class Help {
       const whitespaceClass = '[^\\S\n\r\u2028\u2029]';
       // Detect manually wrapped and indented strings by searching for lines starting with spaces.
       const preformattedRegex = new RegExp(`\n${whitespaceClass}`);
-      preformatted = preformattedRegex.test(columnText);
+      preformatted = preformattedRegex.test(leadingStr);
+      preformatted ||= preformattedRegex.test(columnText);
     }
     const nowrap = preformatted || width === Number.POSITIVE_INFINITY;
     const lines = nowrap ? columnText.split(newline) : [];
@@ -552,7 +553,7 @@ class Help {
         (max, line) => Math.max(max, line.length), 0
       );
       leadingStrLines.forEach((line, i) => {
-        leadingStrLines[i] = line.padEnd(leadingStrWidth)
+        leadingStrLines[i] = line.padEnd(leadingStrWidth);
       });
     };
     processLeadingStr();
@@ -587,9 +588,7 @@ class Help {
       if (columnWidth < 0) {
         // Fit leadingStr in available width.
         // Only really makes sense if it is one line.
-        leadingStr = wrap(
-          leadingStr, leadingStrWidth + columnWidth, { preformatted: false }
-        );
+        leadingStr = this.wrap(leadingStr, leadingStrWidth + columnWidth);
         processLeadingStr();
         columnWidth = 0;
       }
@@ -655,9 +654,7 @@ class Help {
         ? globalIndentString + leadingStrLines[i] + columnGapString
         : overflowIndentString;
       return preformatted
-        ? line
-          ? prefix + line
-          : prefix.trimEnd() + line
+        ? line ? prefix + line : prefix.trimEnd()
         : (prefix + line).trimEnd();
     }).join('\n');
   }

--- a/lib/help.js
+++ b/lib/help.js
@@ -522,14 +522,16 @@ class Help {
       columnGap
     } = options;
 
-    // TODO: Error message
-    if (width < 0 || leadingStrLength < 0 || globalIndent < 0 || columnGap < 0) {
-      throw new CommanderError(0, 'commander.helpWrapInvalidArgument', '');
-    }
-
     if (width === undefined) {
       width = this.helpWidth ?? Number.POSITIVE_INFINITY;
     }
+
+    // TODO: Error message
+    if (width - 1 <= 0 || leadingStrLength < 0 || globalIndent < 0 || columnGap < 0) {
+      throw new CommanderError(0, 'commander.helpWrapInvalidArgument', '');
+    }
+
+    if (globalIndent >= width - 1) globalIndent = 0;
 
     let leadingStr = str.slice(0, leadingStrLength);
     const columnText = str.slice(leadingStrLength).replaceAll('\r\n', '\n');
@@ -567,9 +569,12 @@ class Help {
     // If negative, used to indent lines before overflow.
     // If positive, used to indent overflowing lines unless width is insufficient.
     // When computing the value, ignore indentation implied by leadingStr if preformatted.
-    const fullIndent = globalIndent + Number(!preformatted) * (
+    let fullIndent = globalIndent + Number(!preformatted) * (
       leadingStrWidth + columnGap
     ) + overflowShift;
+    if (Math.abs(fullIndent) >= width - 1) {
+      fullIndent = Math.abs(overflowShift) >= width - 1 ? overflowShift : 0;
+    }
 
     // Make overflowing lines appear shifted by negative overflowShift
     // even if there is not enough room for such a shift
@@ -585,7 +590,8 @@ class Help {
 
     if (!nowrap) {
       let columnWidth = width - globalIndent - leadingStrWidth - columnGap;
-      if (columnWidth <= 0) {
+      if (columnWidth - 1 <= 0) {
+        if (globalIndent + columnGap >= width - 1) columnGap = 0;
         // Fit leadingStr in available width.
         // Only really makes sense if it is one line.
         leadingStr = this.wrap(leadingStr, leadingStrWidth + columnWidth);

--- a/lib/help.js
+++ b/lib/help.js
@@ -1,4 +1,5 @@
 const { humanReadableArgName } = require('./argument.js');
+const { CommanderError } = require('./error.js');
 
 /**
  * TypeScript import types for JSDoc, used by Visual Studio Code IntelliSense and `npm run typescript-checkJS`
@@ -352,13 +353,21 @@ class Help {
     const itemSeparatorWidth = 2; // between term and description
     function formatItem(term, description) {
       if (description) {
-        const fullText = `${term.padEnd(termWidth + itemSeparatorWidth)}${description}`;
-        return helper.wrap(fullText, helpWidth - itemIndentWidth, termWidth + itemSeparatorWidth);
+        const fullText = `${term.padEnd(termWidth)}${description}`;
+        return helper.wrap(
+          fullText,
+          helpWidth,
+          termWidth,
+          40,
+          0,
+          itemIndentWidth,
+          itemSeparatorWidth
+        );
       }
-      return term;
+      return ' '.repeat(itemIndentWidth) + term;
     }
     function formatList(textArray) {
-      return textArray.join('\n').replace(/^/gm, ' '.repeat(itemIndentWidth));
+      return textArray.join('\n');
     }
 
     // Usage
@@ -424,39 +433,145 @@ class Help {
   }
 
   /**
-   * Wrap the given string to width characters per line, with lines after the first indented.
-   * Do not wrap if insufficient room for wrapping (minColumnWidth), or string is manually formatted.
+   * Merge left table defined by first `leftTableLength` characters of `str` with right table defined by remaining characters, wrapping the output to `width - 1` characters per line. Table rows in both input and output are separated by line breaks.
+   *
+   * Do not wrap if right table text is manually formatted.
+   *
+   * Input table rows are indented by `globalIndent - Math.min(0, fullIndent)` and overflowing new table lines by `fullIndent` if it is positive and does not cause overflow display to be too narrow, where `fullIndent = globalIndent + leftTableWidth + tableGap + overflowShift` with `leftTableWidth` being the computed width of the left table. `leftTableWidth` and `tableGap` are omitted from the computation if right table text is manually formatted.
+   *
+   * `leftTableLength`, `overflowShift`, `globalIndent` and `tableGap` all default to 0.
+   *
+   * Overflow display is considered too narrow when available width is less than `minOverflowWidth` which defaults to 40.
+   *
+   * Unless `preformatted` is specified explicitly, right table text is considered manually formatted if it includes a line break followed by a whitespace.
    *
    * @param {string} str
    * @param {number} width
-   * @param {number} indent
-   * @param {number} [minColumnWidth=40]
+   * @param {number} [leftTableLength=0]
+   * @param {number} [minOverflowWidth=40]
+   * @param {number} [overflowShift=0]
+   * @param {number} [globalIndent=0]
+   * @param {number} [tableGap=0]
+   * @param {boolean} [preformatted]
    * @return {string}
-   *
    */
 
-  wrap(str, width, indent, minColumnWidth = 40) {
-    // Full \s characters, minus the linefeeds.
-    const indents = ' \\f\\t\\v\u00a0\u1680\u2000-\u200a\u202f\u205f\u3000\ufeff';
-    // Detect manually wrapped and indented strings by searching for line break followed by spaces.
-    const manualIndent = new RegExp(`[\\n][${indents}]+`);
-    if (str.match(manualIndent)) return str;
-    // Do not wrap if not enough room for a wrapped column of text (as could end up with a word per line).
-    const columnWidth = width - indent;
-    if (columnWidth < minColumnWidth) return str;
+  wrap(
+    str,
+    width,
+    leftTableLength = 0,
+    minOverflowWidth = 40,
+    overflowShift = 0,
+    globalIndent = 0,
+    tableGap = 0,
+    preformatted
+  ) {
+    // TODO: Error message
+    if (width < 0 || leftTableLength < 0 || globalIndent < 0 || tableGap < 0) {
+      throw new CommanderError(0, 'commander.helpWrapInvalidArgument', '');
+    }
 
-    const leadingStr = str.slice(0, indent);
-    const columnText = str.slice(indent).replace('\r\n', '\n');
-    const indentString = ' '.repeat(indent);
-    const zeroWidthSpace = '\u200B';
-    const breaks = `\\s${zeroWidthSpace}`;
-    // Match line end (so empty lines don't collapse),
-    // or as much text as will fit in column, or excess text up to first break.
-    const regex = new RegExp(`\n|.{1,${columnWidth - 1}}([${breaks}]|$)|[^${breaks}]+?([${breaks}]|$)`, 'g');
-    const lines = columnText.match(regex) || [];
-    return leadingStr + lines.map((line, i) => {
-      if (line === '\n') return ''; // preserve empty lines
-      return ((i > 0) ? indentString : '') + line.trimEnd();
+    if (width === undefined) width = Infinity;
+
+    const newline = /\r?\n/;
+
+    const leftTableLines = str.slice(0, leftTableLength).split(newline);
+    const leftTableWidth = leftTableLines.reduce(
+      (max, line) => Math.max(max, line.length), 0
+    );
+    leftTableLines.forEach((line, i) => {
+      leftTableLines[i] = line.padEnd(leftTableWidth);
+    });
+
+    let rightTableText = str.slice(leftTableLength).replaceAll('\r\n', '\n');
+
+    // Full \s characters, minus line terminatros (ECMAScript 12.3 Line Terminators)
+    const whitespaces = '^\\S\n\r\u2028\u2029';
+    if (preformatted === undefined) {
+      // Detect manually wrapped and indented strings by searching for lines starting with spaces.
+      const preformattedRegex = new RegExp(`\n[${whitespaces}]+`);
+      preformatted = preformattedRegex.test(rightTableText);
+    }
+    const nowrap = preformatted || width === Number.POSITIVE_INFINITY;
+
+    const lines = nowrap ? rightTableText.split(newline) : [];
+    const missingLineCount = () => Math.max(
+      0, leftTableLines.length - lines.length
+    );
+    const missingLineArray = () => Array(missingLineCount()).fill('');
+
+    // If negative, used to indent expanded lines of previous table.
+    // If positive, used to indent overflowing lines unless width is insufficient.
+    // When computing the value, ignore indentation implied by table if preformatted.
+    const fullIndent = globalIndent + Number(!preformatted) * (
+      leftTableWidth + tableGap
+    ) + overflowShift;
+
+    const tableIndent = globalIndent - Math.min(0, fullIndent);
+    let overflowIndent = fullIndent;
+
+    let overflowWidth = width - overflowIndent;
+    if (overflowIndent < 0 || overflowWidth < minOverflowWidth) {
+      overflowIndent = 0;
+      overflowWidth = width;
+    }
+
+    if (!nowrap) {
+      const rightTableWidth = width - tableIndent - leftTableWidth - tableGap;
+
+      const zeroWidthSpace = '\u200B';
+      const breaks = `\\s${zeroWidthSpace}`;
+      const breakGroupWithoutLF = `[^\\S\n]|${zeroWidthSpace}|$`;
+      // Captured substring is used in code, so be careful with parentheses when changing the expression. Prefer non-capturing groups.
+      const makeRegex = (width) => new RegExp( // minus one still necessary???
+        // capture as much text as will fit in a column of width "width-1"
+        `([^\n]{0,${width - 1}})` +
+        // and collapse all following breaks except for \n at positions after first,
+        `(?:\n|(?:${breakGroupWithoutLF})+\n?)` +
+        // or match exactly width-1 non-breaking characters
+        `|[^${breaks}]{${width - 1}}`,
+        'y' // use lastIndex
+      );
+      const tableRegex = makeRegex(rightTableWidth);
+      const overflowRegex = makeRegex(overflowWidth);
+
+      let overflow = false;
+      let regex = tableRegex;
+      const setOverflow = (index) => {
+        rightTableText = rightTableText.slice(index); // consume non-overflowing part
+        overflow = true;
+        regex = overflowRegex;
+      };
+
+      while (regex.lastIndex < rightTableText.length) { // input is not yet fully consumed
+        const { 0: match, 1: line, index } = regex.exec(rightTableText);
+        if (!overflow && overflowShift < 0 && line == null) {
+          // If word does not fit in table, it might still fit in overflow when overflowShift is negative.
+          // Leave column empty for cases when user wants to add previous columns / leading string manually afterwards.
+          lines.push(...missingLineArray());
+          setOverflow(index);
+        } else {
+          lines.push(line ?? match);
+          if (!overflow && lines.length >= leftTableLines.length) {
+            setOverflow(regex.lastIndex);
+          }
+        }
+      }
+    }
+
+    const tableIndentString = ' '.repeat(tableIndent);
+    const tableGapString = ' '.repeat(tableGap);
+    const overflowIndentString = ' '.repeat(overflowIndent);
+
+    return lines.concat(missingLineArray()).map((line, i) => {
+      const prefix = i < leftTableLines.length
+        ? tableIndentString + leftTableLines[i] + tableGapString
+        : overflowIndentString;
+      return preformatted
+        ? line
+          ? prefix + line
+          : prefix.trimEnd() + line // prev table is assumed to not be preformatted
+        : (prefix + line).trimEnd();
     }).join('\n');
   }
 }

--- a/lib/help.js
+++ b/lib/help.js
@@ -594,9 +594,9 @@ class Help {
         if (globalIndent + columnGap >= width - 1) columnGap = 0;
         // Fit leadingStr in available width.
         // Only really makes sense if it is one line.
-        leadingStr = this.wrap(leadingStr, leadingStrWidth + columnWidth);
+        leadingStr = this.wrap(leadingStr, width - globalIndent - columnGap);
         processLeadingStr();
-        columnWidth = 0;
+        columnWidth = 1;
       }
 
       const zeroWidthSpace = '\u200B';
@@ -627,7 +627,7 @@ class Help {
         regex = overflowRegex;
         regex.lastIndex = index; // consume non-overflowing part
       };
-      if (!columnWidth) {
+      if (!(columnWidth - 1)) {
         pushMissingLines();
         setOverflow(0);
       }
@@ -638,7 +638,6 @@ class Help {
         if (!overflow && overflowShift < 0 && !fits) {
           // If word does not fit in non-overflowing part,
           // it might still fit in overflow when overflowShift is negative.
-          // Leave column empty for when user wants to add leading string manually afterwards.
           pushMissingLines();
           setOverflow(index);
         } else {

--- a/lib/help.js
+++ b/lib/help.js
@@ -16,6 +16,8 @@ const { CommanderError } = require('./error.js');
 class Help {
   constructor() {
     this.helpWidth = undefined;
+    this.minWidthGuideline = 40;
+    this.preformatted = undefined;
     this.sortSubcommands = false;
     this.sortOptions = false;
     this.showGlobalOptions = false;
@@ -490,7 +492,8 @@ class Help {
   wrap(str, width, ...restArguments) {
     const options = {
       leadingStrLength: 0,
-      minWidthGuideline: 40,
+      minWidthGuideline: this.minWidthGuideline,
+      preformatted: this.preformatted,
       overflowShift: 0,
       globalIndent: 0,
       columnGap: 0
@@ -509,7 +512,6 @@ class Help {
     if (typeof restArguments.at(-1) === 'object') {
       Object.assign(options, restArguments.pop());
     }
-    console.log(options);
 
     let {
       leadingStrLength,
@@ -525,7 +527,9 @@ class Help {
       throw new CommanderError(0, 'commander.helpWrapInvalidArgument', '');
     }
 
-    if (width === undefined) width = this.helpWidth ?? Infinity;
+    if (width === undefined) {
+      width = this.helpWidth ?? Number.POSITIVE_INFINITY;
+    }
 
     const newline = /\r?\n/;
 

--- a/lib/help.js
+++ b/lib/help.js
@@ -433,25 +433,25 @@ class Help {
   }
 
   /**
-   * Merge left table defined by first `leftTableLength` characters of `str` with right table defined by remaining characters, wrapping the output to `width - 1` characters per line. Table rows in both input and output are separated by line breaks.
+   * Merge left text column defined by first `leadingStrLength` characters of `str` with right text column defined by remaining characters, wrapping the output to `width - 1` characters per line.
    *
-   * Do not wrap if right table text is manually formatted.
+   * Do not wrap if right column text is manually formatted.
    *
-   * Input table rows are indented by `globalIndent - Math.min(0, fullIndent)` and overflowing new table lines by `fullIndent` if it is positive and does not cause overflow display to be too narrow, where `fullIndent = globalIndent + leftTableWidth + tableGap + overflowShift` with `leftTableWidth` being the computed width of the left table. `leftTableWidth` and `tableGap` are omitted from the computation if right table text is manually formatted.
+   * Lines containing left column are indented by `globalIndent - Math.min(0, fullIndent)` and all new lines due to overflow by `fullIndent` if it is positive and does not cause text display width to be too narrow, where `fullIndent = globalIndent + leadingStrWidth + columnGap + overflowShift` with `leadingStrWidth` being the computed width of the left column. `leadingStrWidth` and `columnGap` are omitted from the computation if right column text is manually formatted.
    *
-   * `leftTableLength`, `overflowShift`, `globalIndent` and `tableGap` all default to 0.
+   * `leadingStrLength`, `overflowShift`, `globalIndent` and `columnGap` all default to 0.
    *
-   * Overflow display is considered too narrow when available width is less than `minOverflowWidth` which defaults to 40.
+   * Text display width is considered too narrow when it is less than `minWidthGuideline` which defaults to 40.
    *
-   * Unless `preformatted` is specified explicitly, right table text is considered manually formatted if it includes a line break followed by a whitespace.
+   * Unless `preformatted` is specified explicitly, right column text is considered manually formatted if it includes a line break followed by a whitespace.
    *
    * @param {string} str
    * @param {number} width
-   * @param {number} [leftTableLength=0]
-   * @param {number} [minOverflowWidth=40]
+   * @param {number} [leadingStrLength=0]
+   * @param {number} [minWidthGuideline=40]
    * @param {number} [overflowShift=0]
    * @param {number} [globalIndent=0]
-   * @param {number} [tableGap=0]
+   * @param {number} [columnGap=0]
    * @param {boolean} [preformatted]
    * @return {string}
    */
@@ -459,15 +459,15 @@ class Help {
   wrap(
     str,
     width,
-    leftTableLength = 0,
-    minOverflowWidth = 40,
+    leadingStrLength = 0,
+    minWidthGuideline = 40,
     overflowShift = 0,
     globalIndent = 0,
-    tableGap = 0,
+    columnGap = 0,
     preformatted
   ) {
     // TODO: Error message
-    if (width < 0 || leftTableLength < 0 || globalIndent < 0 || tableGap < 0) {
+    if (width < 0 || leadingStrLength < 0 || globalIndent < 0 || columnGap < 0) {
       throw new CommanderError(0, 'commander.helpWrapInvalidArgument', '');
     }
 
@@ -475,49 +475,53 @@ class Help {
 
     const newline = /\r?\n/;
 
-    const leftTableLines = str.slice(0, leftTableLength).split(newline);
-    const leftTableWidth = leftTableLines.reduce(
+    const leadingStr = str.slice(0, leadingStrLength);
+    const leadingStrLines = leadingStr.split(newline);
+    const leadingStrWidth = leadingStrLines.reduce(
       (max, line) => Math.max(max, line.length), 0
     );
-    leftTableLines.forEach((line, i) => {
-      leftTableLines[i] = line.padEnd(leftTableWidth);
+    leadingStrLines.forEach((line, i) => {
+      leadingStrLines[i] = line.padEnd(leadingStrWidth);
     });
 
-    let rightTableText = str.slice(leftTableLength).replaceAll('\r\n', '\n');
+    let columnText = str.slice(leadingStrLength).replaceAll('\r\n', '\n');
 
     if (preformatted === undefined) {
       // Full \s characters, minus line terminatros (ECMAScript 12.3 Line Terminators)
       const whitespaceClass = '[^\\S\n\r\u2028\u2029]';
       // Detect manually wrapped and indented strings by searching for lines starting with spaces.
       const preformattedRegex = new RegExp(`\n${whitespaceClass}`);
-      preformatted = preformattedRegex.test(rightTableText);
+      preformatted = preformattedRegex.test(columnText);
     }
     const nowrap = preformatted || width === Number.POSITIVE_INFINITY;
 
-    const lines = nowrap ? rightTableText.split(newline) : [];
+    const lines = nowrap ? columnText.split(newline) : [];
     const missingLineCount = () => Math.max(
-      0, leftTableLines.length - lines.length
+      0, leadingStrLines.length - lines.length
     );
     const missingLineArray = () => Array(missingLineCount()).fill('');
 
-    // If negative, used to indent expanded lines of previous table.
+    // If negative, used to indent lines before overflow.
     // If positive, used to indent overflowing lines unless width is insufficient.
-    // When computing the value, ignore indentation implied by table if preformatted.
+    // When computing the value, ignore indentation implied by leadingStr if preformatted.
     const fullIndent = globalIndent + Number(!preformatted) * (
-      leftTableWidth + tableGap
+      leadingStrWidth + columnGap
     ) + overflowShift;
 
-    const tableIndent = globalIndent - Math.min(0, fullIndent);
-    let overflowIndent = fullIndent;
+    // Make overflowing lines appear shifted by negative overflowShift
+    // even if there is not enough room for such a shift
+    // by additionally indenting lines before overflow.
+    globalIndent -= Math.min(0, fullIndent);
 
+    let overflowIndent = fullIndent;
     let overflowWidth = width - overflowIndent;
-    if (overflowIndent < 0 || overflowWidth < minOverflowWidth) {
+    if (overflowIndent < 0 || overflowWidth < minWidthGuideline) {
       overflowIndent = 0;
       overflowWidth = width;
     }
 
     if (!nowrap) {
-      const rightTableWidth = width - tableIndent - leftTableWidth - tableGap;
+      const columnWidth = width - globalIndent - leadingStrWidth - columnGap;
 
       const zeroWidthSpace = '\u200B';
       const breakGroupWithoutLF = `[^\\S\n]|${zeroWidthSpace}|$`;
@@ -537,45 +541,46 @@ class Help {
         `|.{${width - 1}}`,
         'y' // expose and use lastIndex
       );
-      const tableRegex = makeRegex(rightTableWidth);
+      const columnRegex = makeRegex(columnWidth);
       const overflowRegex = makeRegex(overflowWidth);
 
       let overflow = false;
-      let regex = tableRegex;
+      let regex = columnRegex;
       const setOverflow = (index) => {
-        rightTableText = rightTableText.slice(index); // consume non-overflowing part
+        columnText = columnText.slice(index); // consume non-overflowing part
         overflow = true;
         regex = overflowRegex;
       };
 
-      while (regex.lastIndex < rightTableText.length) { // input is not yet fully consumed
-        const { 0: match, 1: line, index } = regex.exec(rightTableText);
+      while (regex.lastIndex < columnText.length) { // input is not yet fully consumed
+        const { 0: match, 1: line, index } = regex.exec(columnText);
         if (!overflow && overflowShift < 0 && line == null) {
-          // If word does not fit in table, it might still fit in overflow when overflowShift is negative.
-          // Leave column empty for cases when user wants to add previous columns / leading string manually afterwards.
+          // If word does not fit in column,
+          // it might still fit in overflow when overflowShift is negative.
+          // Leave column empty for when user wants to add leading string manually afterwards.
           lines.push(...missingLineArray());
           setOverflow(index);
         } else {
           lines.push(line ?? match);
-          if (!overflow && lines.length >= leftTableLines.length) {
+          if (!overflow && lines.length >= leadingStrLines.length) {
             setOverflow(regex.lastIndex);
           }
         }
       }
     }
 
-    const tableIndentString = ' '.repeat(tableIndent);
-    const tableGapString = ' '.repeat(tableGap);
+    const globalIndentString = ' '.repeat(globalIndent);
+    const columnGapString = ' '.repeat(columnGap);
     const overflowIndentString = ' '.repeat(overflowIndent);
 
     return lines.concat(missingLineArray()).map((line, i) => {
-      const prefix = i < leftTableLines.length
-        ? tableIndentString + leftTableLines[i] + tableGapString
+      const prefix = i < leadingStrLines.length
+        ? globalIndentString + leadingStrLines[i] + columnGapString
         : overflowIndentString;
       return preformatted
         ? line
           ? prefix + line
-          : prefix.trimEnd() + line // prev table is assumed to not be preformatted
+          : prefix.trimEnd() + line // leadingStr is assumed to not be preformatted
         : (prefix + line).trimEnd();
     }).join('\n');
   }

--- a/lib/help.js
+++ b/lib/help.js
@@ -471,7 +471,7 @@ class Help {
       throw new CommanderError(0, 'commander.helpWrapInvalidArgument', '');
     }
 
-    if (width === undefined) width = Infinity;
+    if (width === undefined) width = this.helpWidth ?? Infinity;
 
     const newline = /\r?\n/;
 
@@ -484,7 +484,7 @@ class Help {
       leadingStrLines[i] = line.padEnd(leadingStrWidth);
     });
 
-    let columnText = str.slice(leadingStrLength).replaceAll('\r\n', '\n');
+    const columnText = str.slice(leadingStrLength).replaceAll('\r\n', '\n');
 
     if (preformatted === undefined) {
       // Full \s characters, minus line terminatros (ECMAScript 12.3 Line Terminators)
@@ -547,15 +547,16 @@ class Help {
       let overflow = false;
       let regex = columnRegex;
       const setOverflow = (index) => {
-        columnText = columnText.slice(index); // consume non-overflowing part
         overflow = true;
         regex = overflowRegex;
+        regex.lastIndex = index; // consume non-overflowing part
       };
 
       while (regex.lastIndex < columnText.length) { // input is not yet fully consumed
         const { 0: match, 1: line, index } = regex.exec(columnText);
-        if (!overflow && overflowShift < 0 && line == null) {
-          // If word does not fit in column,
+        const fits = line != null;
+        if (!overflow && overflowShift < 0 && !fits) {
+          // If word does not fit in non-overflowing part,
           // it might still fit in overflow when overflowShift is negative.
           // Leave column empty for when user wants to add leading string manually afterwards.
           lines.push(...missingLineArray());

--- a/lib/help.js
+++ b/lib/help.js
@@ -531,19 +531,10 @@ class Help {
       width = this.helpWidth ?? Number.POSITIVE_INFINITY;
     }
 
-    const newline = /\r?\n/;
-
     const leadingStr = str.slice(0, leadingStrLength);
-    const leadingStrLines = leadingStr.split(newline);
-    const leadingStrWidth = leadingStrLines.reduce(
-      (max, line) => Math.max(max, line.length), 0
-    );
-    leadingStrLines.forEach((line, i) => {
-      leadingStrLines[i] = line.padEnd(leadingStrWidth);
-    });
-
     const columnText = str.slice(leadingStrLength).replaceAll('\r\n', '\n');
 
+    const newline = /\r?\n/;
     if (preformatted === undefined) {
       // Full \s characters, minus line terminators (ECMAScript 12.3 Line Terminators)
       const whitespaceClass = '[^\\S\n\r\u2028\u2029]';
@@ -552,12 +543,25 @@ class Help {
       preformatted = preformattedRegex.test(columnText);
     }
     const nowrap = preformatted || width === Number.POSITIVE_INFINITY;
-
     const lines = nowrap ? columnText.split(newline) : [];
+
+    let leadingStrLines, leadingStrWidth;
+    const processLeadingStr = () => {
+      leadingStrLines = leadingStr.split(newline);
+      leadingStrWidth = leadingStrLines.reduce(
+        (max, line) => Math.max(max, line.length), 0
+      );
+      leadingStrLines.forEach((line, i) => {
+        leadingStrLines[i] = line.padEnd(leadingStrWidth)
+      });
+    };
+    processLeadingStr();
+
     const missingLineCount = () => Math.max(
       0, leadingStrLines.length - lines.length
     );
     const missingLineArray = () => Array(missingLineCount()).fill('');
+    const pushMissingLines = () => lines.push(...missingLineArray());
 
     // If negative, used to indent lines before overflow.
     // If positive, used to indent overflowing lines unless width is insufficient.
@@ -579,7 +583,16 @@ class Help {
     }
 
     if (!nowrap) {
-      const columnWidth = width - globalIndent - leadingStrWidth - columnGap;
+      let columnWidth = width - globalIndent - leadingStrWidth - columnGap;
+      if (columnWidth < 0) {
+        // Fit leadingStr in available width.
+        // Only really makes sense if it is one line.
+        leadingStr = wrap(
+          leadingStr, leadingStrWidth + columnWidth, { preformatted: false }
+        );
+        processLeadingStr();
+        columnWidth = 0;
+      }
 
       const zeroWidthSpace = '\u200B';
       const breakGroupWithoutLF = `[^\\S\n]|${zeroWidthSpace}|$`;
@@ -609,6 +622,10 @@ class Help {
         regex = overflowRegex;
         regex.lastIndex = index; // consume non-overflowing part
       };
+      if (!columnWidth) {
+        pushMissingLines();
+        setOverflow(0);
+      }
 
       while (regex.lastIndex < columnText.length) { // input is not yet fully consumed
         const { 0: match, 1: line, index } = regex.exec(columnText);
@@ -617,7 +634,7 @@ class Help {
           // If word does not fit in non-overflowing part,
           // it might still fit in overflow when overflowShift is negative.
           // Leave column empty for when user wants to add leading string manually afterwards.
-          lines.push(...missingLineArray());
+          pushMissingLines();
           setOverflow(index);
         } else {
           lines.push(line ?? match);
@@ -632,14 +649,15 @@ class Help {
     const columnGapString = ' '.repeat(columnGap);
     const overflowIndentString = ' '.repeat(overflowIndent);
 
-    return lines.concat(missingLineArray()).map((line, i) => {
+    pushMissingLines();
+    return lines.map((line, i) => {
       const prefix = i < leadingStrLines.length
         ? globalIndentString + leadingStrLines[i] + columnGapString
         : overflowIndentString;
       return preformatted
         ? line
           ? prefix + line
-          : prefix.trimEnd() + line // leadingStr is assumed to not be preformatted
+          : prefix.trimEnd() + line
         : (prefix + line).trimEnd();
     }).join('\n');
   }

--- a/lib/help.js
+++ b/lib/help.js
@@ -585,7 +585,7 @@ class Help {
 
     if (!nowrap) {
       let columnWidth = width - globalIndent - leadingStrWidth - columnGap;
-      if (columnWidth < 0) {
+      if (columnWidth <= 0) {
         // Fit leadingStr in available width.
         // Only really makes sense if it is one line.
         leadingStr = this.wrap(leadingStr, leadingStrWidth + columnWidth);

--- a/lib/help.js
+++ b/lib/help.js
@@ -485,11 +485,11 @@ class Help {
 
     let rightTableText = str.slice(leftTableLength).replaceAll('\r\n', '\n');
 
-    // Full \s characters, minus line terminatros (ECMAScript 12.3 Line Terminators)
-    const whitespaces = '^\\S\n\r\u2028\u2029';
     if (preformatted === undefined) {
+      // Full \s characters, minus line terminatros (ECMAScript 12.3 Line Terminators)
+      const whitespaceClass = '[^\\S\n\r\u2028\u2029]';
       // Detect manually wrapped and indented strings by searching for lines starting with spaces.
-      const preformattedRegex = new RegExp(`\n[${whitespaces}]+`);
+      const preformattedRegex = new RegExp(`\n${whitespaceClass}`);
       preformatted = preformattedRegex.test(rightTableText);
     }
     const nowrap = preformatted || width === Number.POSITIVE_INFINITY;
@@ -520,17 +520,22 @@ class Help {
       const rightTableWidth = width - tableIndent - leftTableWidth - tableGap;
 
       const zeroWidthSpace = '\u200B';
-      const breaks = `\\s${zeroWidthSpace}`;
       const breakGroupWithoutLF = `[^\\S\n]|${zeroWidthSpace}|$`;
-      // Captured substring is used in code, so be careful with parentheses when changing the expression. Prefer non-capturing groups.
+      // Captured substring is used in code,
+      // so be careful with parentheses when changing the regex template.
+      // Prefer non-capturing groups.
       const makeRegex = (width) => new RegExp( // minus one still necessary???
-        // capture as much text as will fit in a column of width "width-1"
+        // Capture as much text as will fit in a column of width (width - 1)
+        // without having to split words
         `([^\n]{0,${width - 1}})` +
-        // and collapse all following breaks except for \n at positions after first,
+        // and include all following breaks in match, stopping at the first \n,
+        // so that they can be collapsed.
         `(?:\n|(?:${breakGroupWithoutLF})+\n?)` +
-        // or match exactly width-1 non-breaking characters
-        `|[^${breaks}]{${width - 1}}`,
-        'y' // use lastIndex
+        // If not possible, match exactly (width - 1) characters instead.
+        // In this case, a word has to be split.
+        // Indicated by the fact nothing was captured.
+        `|.{${width - 1}}`,
+        'y' // expose and use lastIndex
       );
       const tableRegex = makeRegex(rightTableWidth);
       const overflowRegex = makeRegex(overflowWidth);

--- a/lib/help.js
+++ b/lib/help.js
@@ -7,6 +7,7 @@ const { CommanderError } = require('./error.js');
  * @typedef { import("./argument.js").Argument } Argument
  * @typedef { import("./command.js").Command } Command
  * @typedef { import("./option.js").Option } Option
+ * @typedef { import("..").WrapOptions } WrapOptions
  */
 
 // @ts-check
@@ -349,22 +350,16 @@ class Help {
   formatHelp(cmd, helper) {
     const termWidth = helper.padWidth(cmd, helper);
     const helpWidth = helper.helpWidth || 80;
-    const itemIndentWidth = 2;
-    const itemSeparatorWidth = 2; // between term and description
+    const globalIndent = 2;
+    const columnGap = 2; // between term and description
     function formatItem(term, description) {
       if (description) {
         const fullText = `${term.padEnd(termWidth)}${description}`;
-        return helper.wrap(
-          fullText,
-          helpWidth,
-          termWidth,
-          40,
-          0,
-          itemIndentWidth,
-          itemSeparatorWidth
-        );
+        return helper.wrap(fullText, helpWidth, termWidth, {
+          globalIndent, columnGap
+        });
       }
-      return ' '.repeat(itemIndentWidth) + term;
+      return ' '.repeat(globalIndent) + term;
     }
     function formatList(textArray) {
       return textArray.join('\n');
@@ -433,6 +428,48 @@ class Help {
   }
 
   /**
+   * @see {@link Help.wrap()}
+   * @overload
+   * @param {string} str
+   * @param {number} width
+   * @param {WrapOptions} [options]
+   * @return {string}
+   */
+
+  /**
+   * @see {@link Help.wrap()}
+   * @overload
+   * @param {string} str
+   * @param {number} width
+   * @param {number} leadingStrLength
+   * @param {WrapOptions} [options]
+   * @return {string}
+   */
+
+  /**
+   * @see {@link Help.wrap()}
+   * @overload
+   * @param {string} str
+   * @param {number} width
+   * @param {number} leadingStrLength
+   * @param {number} minWidthGuideline
+   * @param {WrapOptions} [options]
+   * @return {string}
+   */
+
+  /**
+   * @see {@link Help.wrap()}
+   * @overload
+   * @param {string} str
+   * @param {number} width
+   * @param {number} leadingStrLength
+   * @param {number} minWidthGuideline
+   * @param {boolean} preformatted
+   * @param {WrapOptions} [options]
+   * @return {string}
+   */
+
+  /**
    * Merge left text column defined by first `leadingStrLength` characters of `str` with right text column defined by remaining characters, wrapping the output to `width - 1` characters per line.
    *
    * Do not wrap if right column text is manually formatted.
@@ -447,25 +484,42 @@ class Help {
    *
    * @param {string} str
    * @param {number} width
-   * @param {number} [leadingStrLength=0]
-   * @param {number} [minWidthGuideline=40]
-   * @param {number} [overflowShift=0]
-   * @param {number} [globalIndent=0]
-   * @param {number} [columnGap=0]
-   * @param {boolean} [preformatted]
+   * @param {[Options]|[number, Options]|[number, number, Options]|[number, number, boolean, Options]} restArguments
    * @return {string}
    */
+  wrap(str, width, ...restArguments) {
+    const options = {
+      leadingStrLength: 0,
+      minWidthGuideline: 40,
+      overflowShift: 0,
+      globalIndent: 0,
+      columnGap: 0
+    };
 
-  wrap(
-    str,
-    width,
-    leadingStrLength = 0,
-    minWidthGuideline = 40,
-    overflowShift = 0,
-    globalIndent = 0,
-    columnGap = 0,
-    preformatted
-  ) {
+    // Options from individual option parameters
+    for (const [i, key] of Object.entries([
+      'leadingStrLength', 'minWidthGuideline', 'preformatted'
+    ])) {
+      if (+i === restArguments.length) break;
+      if (typeof restArguments[i] === 'object') break;
+      options[key] = restArguments[i];
+    }
+
+    // Options from `options` parameter
+    if (typeof restArguments.at(-1) === 'object') {
+      Object.assign(options, restArguments.pop());
+    }
+    console.log(options);
+
+    let {
+      leadingStrLength,
+      minWidthGuideline,
+      preformatted,
+      overflowShift,
+      globalIndent,
+      columnGap
+    } = options;
+
     // TODO: Error message
     if (width < 0 || leadingStrLength < 0 || globalIndent < 0 || columnGap < 0) {
       throw new CommanderError(0, 'commander.helpWrapInvalidArgument', '');
@@ -487,7 +541,7 @@ class Help {
     const columnText = str.slice(leadingStrLength).replaceAll('\r\n', '\n');
 
     if (preformatted === undefined) {
-      // Full \s characters, minus line terminatros (ECMAScript 12.3 Line Terminators)
+      // Full \s characters, minus line terminators (ECMAScript 12.3 Line Terminators)
       const whitespaceClass = '[^\\S\n\r\u2028\u2029]';
       // Detect manually wrapped and indented strings by searching for lines starting with spaces.
       const preformattedRegex = new RegExp(`\n${whitespaceClass}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "commander",
-      "version": "10.0.1",
+      "version": "11.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.2.4",

--- a/tests/help.wrap.test.js
+++ b/tests/help.wrap.test.js
@@ -63,7 +63,7 @@ ${'a'.repeat(11)}`);
   test('when negative shift and first word exceeds column width then place in overflow', () => {
     const text = ' '.repeat(5) + 'a'.repeat(49);
     const helper = new commander.Help();
-    const wrapped = helper.wrap(text, 50, 5, 40, -5);
+    const wrapped = helper.wrap(text, 50, 5, { overflowShift: -5 });
     expect(wrapped).toEqual(`
 ${'a'.repeat(49)}`);
   });
@@ -71,7 +71,7 @@ ${'a'.repeat(49)}`);
   test('when negative shift and first word exceeds overflow width then place in overflow', () => {
     const text = ' '.repeat(5) + 'a'.repeat(60);
     const helper = new commander.Help();
-    const wrapped = helper.wrap(text, 50, 5, 40, -5);
+    const wrapped = helper.wrap(text, 50, 5, { overflowShift: -5 });
     expect(wrapped).toEqual(`
 ${'a'.repeat(49)}
 ${'a'.repeat(11)}`);
@@ -116,14 +116,18 @@ ${'a '.repeat(11)}a`);
   test('when more whitespaces after line than available width then collapse all', () => {
     const text = `abcd${whitespaces}\ne`;
     const helper = new commander.Help();
-    const wrapped = helper.wrap(text, 5, 0);
+    const wrapped = helper.wrap(text, 5);
     expect(wrapped).toEqual('abcd\ne');
   });
 
   test('when line of whitespaces then do not indent', () => {
     const text = whitespaces;
     const helper = new commander.Help();
-    const wrapped = helper.wrap(text, 50, 0, 40, 3, 3, 3);
+    const wrapped = helper.wrap(text, 50, {
+      overflowShift: 3,
+      globalIndent: 3,
+      columnGap: 3
+    });
     expect(wrapped).toEqual('');
   });
 
@@ -132,7 +136,11 @@ ${'a '.repeat(11)}a`);
       '\n\na ' + // text to wrap and indent (new, second column) before overflow
       '\n\na '; // overflowing lines of the text (column overflow)
     const helper = new commander.Help();
-    const wrapped = helper.wrap(text, 50, 3, 40, -3, 3, 3);
+    const wrapped = helper.wrap(text, 50, 3, {
+      overflowShift: -3,
+      globalIndent: 3,
+      columnGap: 3
+    });
     expect(wrapped).toEqual(`
    a
        a

--- a/tests/help.wrap.test.js
+++ b/tests/help.wrap.test.js
@@ -60,7 +60,7 @@ ${'a'.repeat(11)}`);
    ${'a'.repeat(11)}`);
   });
 
-  test('when negative shift and first word exceeds right table width then place in overflow', () => {
+  test('when negative shift and first word exceeds column width then place in overflow', () => {
     const text = ' '.repeat(5) + 'a'.repeat(49);
     const helper = new commander.Help();
     const wrapped = helper.wrap(text, 50, 5, 40, -5);
@@ -128,9 +128,9 @@ ${'a '.repeat(11)}a`);
   });
 
   test('when not pre-formatted then trim ends of output lines', () => {
-    const text = '\na\n' + // original table
-      '\n\na ' + // new column
-      '\n\na '; // overflow
+    const text = '\na\n' + // leadingStr (first column)
+      '\n\na ' + // text to wrap and indent (new, second column) before overflow
+      '\n\na '; // overflowing lines of the text (column overflow)
     const helper = new commander.Help();
     const wrapped = helper.wrap(text, 50, 3, 40, -3, 3, 3);
     expect(wrapped).toEqual(`

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -241,19 +241,19 @@ export class Help {
   padWidth(cmd: Command, helper: Help): number;
 
   /**
-   * Merge left table defined by first `leftTableLength` characters of `str` with right table defined by remaining characters, wrapping the output to `width - 1` characters per line. Table rows in both input and output are separated by line breaks.
+   * Merge left text column defined by first `leadingStrLength` characters of `str` with right text column defined by remaining characters, wrapping the output to `width - 1` characters per line.
    *
-   * Do not wrap if right table text is manually formatted.
+   * Do not wrap if right column text is manually formatted.
    *
-   * Input table rows are indented by `globalIndent - Math.min(0, fullIndent)` and overflowing new table lines by `fullIndent` if it is positive and does not cause overflow display to be too narrow, where `fullIndent = globalIndent + leftTableWidth + tableGap + overflowShift` with `leftTableWidth` being the computed width of the left table. `leftTableWidth` and `tableGap` are omitted from the computation if right table text is manually formatted.
+   * Lines containing left column are indented by `globalIndent - Math.min(0, fullIndent)` and all new lines due to overflow by `fullIndent` if it is positive and does not cause text display width to be too narrow, where `fullIndent = globalIndent + leadingStrWidth + columnGap + overflowShift` with `leadingStrWidth` being the computed width of the left column. `leadingStrWidth` and `columnGap` are omitted from the computation if right column text is manually formatted.
    *
-   * `leftTableLength`, `overflowShift`, `globalIndent` and `tableGap` all default to 0.
+   * `leadingStrLength`, `overflowShift`, `globalIndent` and `columnGap` all default to 0.
    *
-   * Overflow display is considered too narrow when available width is less than `minOverflowWidth` which defaults to 40.
+   * Text display width is considered too narrow when it is less than `minWidthGuideline` which defaults to 40.
    *
-   * Unless `preformatted` is specified explicitly, right table text is considered manually formatted if it includes a line break followed by a whitespace.
+   * Unless `preformatted` is specified explicitly, right column text is considered manually formatted if it includes a line break followed by a whitespace.
    */
-  wrap(str: string, width: number, leftTableLength?: number, minOverflowWidth?: number, overflowShift?: number, globalIndent?: number, tableGap?: number, preformatted?: boolean): string;
+  wrap(str: string, width: number, leadingStrLength?: number, minWidthGuideline?: number, overflowShift?: number, globalIndent?: number, columnGap?: number, preformatted?: boolean): string;
 
   /** Generate the built-in help text. */
   formatHelp(cmd: Command, helper: Help): string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -205,6 +205,8 @@ export interface WrapOptions {
 export class Help {
   /** output helpWidth, long lines are wrapped to fit */
   helpWidth?: number;
+  minWidthGuideline: number;
+  preformatted?: boolean;
   sortSubcommands: boolean;
   sortOptions: boolean;
   showGlobalOptions: boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -193,6 +193,15 @@ export class Option {
   isBoolean(): boolean;
 }
 
+export interface WrapOptions {
+  leadingStrLength?: number;
+  minWidthGuideline?: number;
+  preformatted?: boolean;
+  overflowShift?: number;
+  globalIndent?: number;
+  columnGap?: number;
+}
+
 export class Help {
   /** output helpWidth, long lines are wrapped to fit */
   helpWidth?: number;
@@ -253,7 +262,10 @@ export class Help {
    *
    * Unless `preformatted` is specified explicitly, right column text is considered manually formatted if it includes a line break followed by a whitespace.
    */
-  wrap(str: string, width: number, leadingStrLength?: number, minWidthGuideline?: number, overflowShift?: number, globalIndent?: number, columnGap?: number, preformatted?: boolean): string;
+  wrap(str: string, width: number, options?: WrapOptions): string;
+  wrap(str: string, width: number, leadingStrLength: number, options?: WrapOptions): string;
+  wrap(str: string, width: number, leadingStrLength: number, minWidthGuideline: number, options?: WrapOptions): string;
+  wrap(str: string, width: number, leadingStrLength: number, minWidthGuideline: number, preformatted: boolean, options?: WrapOptions): string;
 
   /** Generate the built-in help text. */
   formatHelp(cmd: Command, helper: Help): string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -241,10 +241,19 @@ export class Help {
   padWidth(cmd: Command, helper: Help): number;
 
   /**
-   * Wrap the given string to width characters per line, with lines after the first indented.
-   * Do not wrap if insufficient room for wrapping (minColumnWidth), or string is manually formatted.
+   * Merge left table defined by first `leftTableLength` characters of `str` with right table defined by remaining characters, wrapping the output to `width - 1` characters per line. Table rows in both input and output are separated by line breaks.
+   *
+   * Do not wrap if right table text is manually formatted.
+   *
+   * Input table rows are indented by `globalIndent - Math.min(0, fullIndent)` and overflowing new table lines by `fullIndent` if it is positive and does not cause overflow display to be too narrow, where `fullIndent = globalIndent + leftTableWidth + tableGap + overflowShift` with `leftTableWidth` being the computed width of the left table. `leftTableWidth` and `tableGap` are omitted from the computation if right table text is manually formatted.
+   *
+   * `leftTableLength`, `overflowShift`, `globalIndent` and `tableGap` all default to 0.
+   *
+   * Overflow display is considered too narrow when available width is less than `minOverflowWidth` which defaults to 40.
+   *
+   * Unless `preformatted` is specified explicitly, right table text is considered manually formatted if it includes a line break followed by a whitespace.
    */
-  wrap(str: string, width: number, indent: number, minColumnWidth?: number): string;
+  wrap(str: string, width: number, leftTableLength?: number, minOverflowWidth?: number, overflowShift?: number, globalIndent?: number, tableGap?: number, preformatted?: boolean): string;
 
   /** Generate the built-in help text. */
   formatHelp(cmd: Command, helper: Help): string;


### PR DESCRIPTION
# Pull Request

## Problem

I first thought of reworking `wrap()` when I wanted to wrap lines of text in a custom help message in such a way that only the first output line is indented. (At that moment, I did not think of manually indenting the lines before passing them to the function for some reason.)

I also did not like the fact text was not wrapped whenever the decision was made to not indent it due to insufficient width – I see no reason why the all-or-nothing principle had to be applied here.

Not being able to apply wrapping just because some lines are indented manually by even just a small amount also seemed pretty lame.

<!--
What problem are you solving?
What Issues does this relate to?
Show the broken output if appropriate.
-->

## Solution

An attempt to make just one change to solve my problem ended up in a (more or less) complete rework of `wrap()`. The new function can be used to format entire tables, while remaining for the most part compatible with the current implementation.

### (Updated) new method signature

with my made up "skippable" argument syntax to fit everything in one signature.

```javascript
interface WrapOptions {
  leadingStrLength?: number;
  minWidthGuideline?: number;
  preformatted?: boolean;
  overflowShift?: number;
  globalIndent?: number;
  columnGap?: number;
}

wrap(
  str: string,
  width: number,
  [leadingStrLength: number = 0,
  [minWidthGuideline: number = 40,
  [preformatted: boolean]]],
  options?: WrapOptions
): string;
```

### Example

```javascript
const { Help } = require('.');

const table = `
Country      Languages
-------      ---------
Argentina    Spanish
Canada       English, French
Germany      German
Switzerland  German, French, Italian, Romansh`;

const newColumn = `
Capital
-------
Buenos Aires
Ottawa
Berlin
(Not mentioned in the constitution, but Bern is the de facto capital)

It is cool to learn about the world!

  I am not pre-formatted!`;

const result = `
  Country      Languages                         Capital
  -------      ---------                         -------
  Argentina    Spanish                           Buenos Aires
  Canada       English, French                   Ottawa
  Germany      German                            Berlin
  Switzerland  German, French, Italian, Romansh  (Not mentioned in the
                                  constitution, but Bern is the de facto
                                  capital)

                                  It is cool to learn about the world!

                                    I am not pre-formatted!`;
/*
..,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,:::::::::::::;;/////////////////////////////

      . - `globalIndent`
, and : - `leadingStrWidth` inferred from `str.slice(0, leadingStrLength)`
      ; - `columnGap`
      / - wrapped column width = `(width - 1)` minus everything before
: and ; - `overflowShift` (negative)
*/

new Help().wrap(
  table + newColumn, // input string
  80, // output width plus 1
  table.length, // length of part representing the table to expand
  20, // minimum width to allow indentation (allowed here)
  {
    preformatted: false, // explicitly specifying lack of pre-formatting
    overflowShift: -15, // amount to shift overflow by
    globalIndent: 2, // global indentation amount
    columnGap: 2 // gap to insert between table and new column
  }
) === result; // true
```

Despite table support and many other changes not being essential for internal use in Commander, they make `wrap()` a quite powerful library function that can be used to format custom help messages and more, while at the same time preserving the original functionality and not introducing any performance penalties (although I haven't measured it, getting rid of lazy quantifiers in regular expressions might have even improved it).

### Footnotes used in change descriptions

[^1]: Cosmetic change
[^2]: Minor functionality change
[^3]: (Relating to a) breaking change
[^4]: (Relating to a) new feature – all backwards compatible

- [^1] Cosmetic change
- [^2] Minor functionality change
- [^3] (Relating to a) breaking change
- [^4] (Relating to a) new feature – all backwards compatible

### Changes include:

- [^2] `width` can now be infinite and is considered such if `undefined` is passed (could easily happen in `formatHelp()` if it did not resort to 80)
- [^1] `indent` has been renamed to `leadingStrLength` to better reflect the argument's true meaning and avoid confusion with other values affecting indentation
- [^2] `leadingStrLength` now defaults to 0
- [^4] support for multiline column merging like in the example above that boils down to treating first `leadingStr.split('\n').length` lines the same way only the very first line is treated in the current implementation (where `leadingStr = str.slice(0, leadingStrLength)`). Indentation amount is equal to the length of the longest line in `leadingStr` (`leadingStrWidth`), which degenerates to `leadingStrLength` (or currently `indent`) if there is only one line
- [^4] `overflowShift` can be specified to shift overflowing column text by some amount. Negative values are allowed, and therefore it can be used to solve my original problem of indenting only the first line, see details below
- [^1] `minColumnWidth` has been renamed to `minWidthGuideline`, again, to better reflect its meaning:
  - `Column` omitted because only overflowing text width is compared to this value, and it is not entirely clear whether the overflow can be considered part of the column when it is shifted
  - `Guideline` added because even when no indentation is used, the width could still be insufficient, and we would not be able to do anything about it
  - `Overflow` not added instead of `Column` because the fact we use it just for overflow does not mean the value of this guideline is bound to this context. *(For example, it could be used to wrap entire text columns to next "column line" when the remaining width for next column rendering is insufficient – check CSS `flex-wrap` property to see what I mean)*
- [^4] `globalIndent` can be specified to indent all non-empty lines by some amount, except when there is not enough space to display overflowing lines adequately, in which case no indentation to such lines is applied. As a result, `formatHelp()` does not have to postprocess the lines by prepending 2 spaces anymore, and the actual terminal width can be passed to `wrap()` without modfications. But the fact only non-empty lines are indented has the following breaking change as a consequence:
- [^3][^4] **breaking:** since `formatHelp()` now relies on `wrap()` for applying indentation, empty lines in pre-formatted argument/option/command descriptions are not indented by 2 spaces anymore *(test updated)*
- [^4] `columnGap` can be specified to adjust distance between text column defined by `leadingStr` and one defined by the remaining part of `str` (in the traditional use case, it would be the distance between term and description). Again, `formatHelp()` can now simply pass the item separator to `wrap()` instead of having to deal with it by itself
- [^4] `preformatted` can be specified to request treatment of text as (not) manually formatted (opens possibilities to extend API that could solve #1822)
- [^2]<sup>/</sup>[^3]<sup>/</sup>[^4] error messages are thrown if arguments that are expected to be non-negative are passed negative values. Especially important for `leadingStrLength`, since it is exclusively used in calls to strings' `slice()` method which does not fail on negatives
- [^4] if the full indent `globalIndent + leadingStrWidth + columnGap + overflowShift` is negative, the non-overflowing output part will be indented by the absolute value of this number in addition to `globalIndent`. This is required to make room for a negative `overflowShift`, so this is the solution to the original line indentation problem. For example, let's say `leadingStrLength = 0`, `overflowShift = -10`, `globalIndent = 3` and `columnGap = 0`, then the first line will be indenten by `-(3 - 10) = 7` additional spaces so that it would appear that all other lines are shifted by -10
- [^3] **breaking:** if width is insufficient to display overflow adequately, overflowing lines are not indented but still wrapped *(test updated)*
- [^4] there are now two regular expression used for line matching, one for non-overflowing and one for overflowing text
- [^3] the regular expression structure has been reworked: newline part and lazy quantifier have been removed, part is captured for later manual processing, other groups are non-capturing, `g` flag dropped, `y` added. Some breaking changes, too:
- [^3] **breaking:** the regular expressions now never match a line of more than `width - 1` non-breaking characters. As a result, overflowing words are now wrapped *(tests added)*
- [^3] **breaking:** all whitespaces at the end of a matched line are collapsed, so `wrap('a     b', 2) === 'a\nb'` *(test added)*
- [^4] if word does not fit in column in non-overflowing part and `overflowShift` is negative, the algorithm will try to place it in overflow instead of splitting

### Additional infos

- Only 2 tests had to be changed 😊
- Despite all the new complexity, `formatHelp()` code did not actually have to be altered and would work the same as before (and the first mentioned breaking change would not be there), but I decided to let `wrap()` do the job of inserting the "item indent" and "item separator" because
  - it now can, so why not make use of that
  - `width` argument value is the entire available width which is nice
  - I wanted to illustrate the new use pattern
  - there is no need to indent empty lines anyway

## To-dos

- [ ] Tests for new features
- [ ] Error message(s)
- Extend API to allow explicitly specifying argument/option/command descriptions and custom help as (non-)pre-formatted?
  - [x] Added `preformatted` property to `Help` class instead

## Questions

- Can the appearance of extra lines with no text as described [here](https://github.com/tj/commander.js/pull/956#issuecomment-491452374) be reproduced now with the new code if `width-1` is replaced with `width` in the regular expressions? If not, I think it would make sense to do the change so that the function behavior is more intuitive.

<!--
How did you solve the problem? 
Show the fixed output if appropriate.

There are a lot of forms of documentation which could need updating for a change in functionality. It
is ok if you want to show us the code to discuss before doing the extra work, and
you should say so in your comments so we focus on the concept first before talking about all the other pieces:

- TypeScript typings
- JSDoc documentation in code
- tests
- README
- examples/
-->

<!-- ## ChangeLog -->

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->