### PR TITLE
Update lock version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "commander",
-      "version": "10.0.1",
+      "version": "11.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.2.4",


### PR DESCRIPTION
# Pull Request

Minor.

## Problem

PR are including an update to `package-lock.json`, because it gets updated to be self-consistent when developers do a clean install.

## Solution

Bump version so self consistent.
