### PR TITLE
Add helpGroup for options and commands

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -72,11 +72,14 @@ class Command extends EventEmitter {
     this._helpDescription = 'display help for command';
     this._helpShortFlag = '-h';
     this._helpLongFlag = '--help';
+    this._helpOptionGroup = undefined;
     this._addImplicitHelpCommand = undefined; // Deliberately undefined, not decided whether true or false
     this._helpCommandName = 'help';
     this._helpCommandnameAndArgs = 'help [command]';
     this._helpCommandDescription = 'display help for command';
+    this._helpCommandGroup = undefined;
     this._helpConfiguration = {};
+    this._helpGroupTitle = undefined;
   }
 
   /**
@@ -153,6 +156,7 @@ class Command extends EventEmitter {
     cmd._hidden = !!(opts.noHelp || opts.hidden); // noHelp is deprecated old name for hidden
     cmd._executableFile = opts.executableFile || null; // Custom name for executable file, set missing to null to match constructor
     if (args) cmd.arguments(args);
+    if (opts.helpGroup) cmd.helpGroup(opts.helpGroup);
     this.commands.push(cmd);
     cmd.parent = this;
     cmd.copyInheritedSettings(this);
@@ -361,19 +365,24 @@ class Command extends EventEmitter {
    *    addHelpCommand(false); // force off
    *    addHelpCommand('help [cmd]', 'display help for [cmd]'); // force on with custom details
    *
+   * @param {boolean | string} enableOrNameAndArgs
+   * @param {string} [description]
+   * @param {object} [helpOpts]
+   * @param {string} [helpOpts.helpGroup]
    * @return {Command} `this` command for chaining
    */
 
-  addHelpCommand(enableOrNameAndArgs, description) {
-    if (enableOrNameAndArgs === false) {
-      this._addImplicitHelpCommand = false;
+  addHelpCommand(enableOrNameAndArgs, description, helpOpts) {
+    if (typeof enableOrNameAndArgs === 'boolean') {
+      this._addImplicitHelpCommand = enableOrNameAndArgs;
     } else {
       this._addImplicitHelpCommand = true;
-      if (typeof enableOrNameAndArgs === 'string') {
+      if (enableOrNameAndArgs) {
         this._helpCommandName = enableOrNameAndArgs.split(' ')[0];
         this._helpCommandnameAndArgs = enableOrNameAndArgs;
       }
       this._helpCommandDescription = description || this._helpCommandDescription;
+      this._helpCommandGroup = helpOpts?.helpGroup;
     }
     return this;
   }
@@ -1805,20 +1814,23 @@ Expecting one of '${allowedValues.join("', '")}'`);
    * This method auto-registers the "-V, --version" flag
    * which will print the version number when passed.
    *
-   * You can optionally supply the  flags and description to override the defaults.
+   * You can optionally supply the flags and description and helpFlag to override the defaults.
    *
    * @param {string} str
    * @param {string} [flags]
    * @param {string} [description]
+   * @param {Object} [versionOpts]
+   * @param {string} [versionOpts.helpGroup]
    * @return {this | string} `this` command for chaining, or version string if no arguments
    */
 
-  version(str, flags, description) {
+  version(str, flags, description, versionOpts) {
     if (str === undefined) return this._version;
     this._version = str;
     flags = flags || '-V, --version';
     description = description || 'output the version number';
     const versionOption = this.createOption(flags, description);
+    if (versionOpts?.helpGroup) versionOption.helpGroup(versionOpts.helpGroup);
     this._versionOptionName = versionOption.attributeName();
     this.options.push(versionOption);
     this.on('option:' + versionOption.name(), () => {
@@ -1937,6 +1949,19 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   /**
+   * Get or set the help group of the command. Used as the title in the help. e.g. 'Commands:'
+   *
+   * @param {string} [title]
+   * @return {string|Command}
+   */
+
+  helpGroup(title) {
+    if (title === undefined) return this._helpGroupTitle;
+    this._helpGroupTitle = title;
+    return this;
+  }
+
+  /**
    * Set the name of the command from script filename, such as process.argv[1],
    * or require.main.filename, or __filename.
    *
@@ -2046,16 +2071,19 @@ Expecting one of '${allowedValues.join("', '")}'`);
    *
    * @param {string | boolean} [flags]
    * @param {string} [description]
+   * @param {Object} [helpOpts]
+   * @param {string} [helpOpts.helpGroup]
    * @return {Command} `this` command for chaining
    */
 
-  helpOption(flags, description) {
+  helpOption(flags, description, helpOpts) {
     if (typeof flags === 'boolean') {
       this._hasHelpOption = flags;
       return this;
     }
     this._helpFlags = flags || this._helpFlags;
     this._helpDescription = description || this._helpDescription;
+    this._helpOptionGroup = helpOpts?.helpGroup;
 
     const helpFlags = splitOptionFlags(this._helpFlags);
     this._helpShortFlag = helpFlags.shortFlag;

--- a/lib/help.js
+++ b/lib/help.js
@@ -35,6 +35,7 @@ class Help {
         .helpOption(false);
       helpCommand.description(cmd._helpCommandDescription);
       if (helpArgs) helpCommand.arguments(helpArgs);
+      if (cmd._helpCommandGroup) helpCommand.helpGroup(cmd._helpCommandGroup);
       visibleCommands.push(helpCommand);
     }
     if (this.sortSubcommands) {
@@ -82,6 +83,7 @@ class Help {
       } else {
         helpOption = cmd.createOption(cmd._helpFlags, cmd._helpDescription);
       }
+      if (cmd._helpOptionGroup) helpOption.helpGroup(cmd._helpOptionGroup);
       visibleOptions.push(helpOption);
     }
     if (this.sortOptions) {
@@ -131,6 +133,70 @@ class Help {
       return cmd._args;
     }
     return [];
+  }
+
+  /**
+    * info.things
+    * info.visibleThings
+    * info.helpGroup(thing)
+    *
+    * @api private
+    */
+  _visibleThingGroups(cmd, helper, info) {
+    const groupMap = new Map();
+    const ensureGroup = (group) => {
+      if (!groupMap.has(group)) {
+        groupMap.set(group, []);
+      }
+    };
+
+    // Create groups from things in order things created.
+    info.things.forEach(thing => {
+      const group = info.helpGroup(thing);
+      ensureGroup(group);
+    });
+
+    // Process visible things into groups (reminder: may be sorted, may be extra help item).
+    info.visibleThings.forEach(thing => {
+      const group = info.helpGroup(thing);
+      ensureGroup(group);
+      groupMap.get(group).push(thing);
+    });
+
+    // Remove empty groups
+    groupMap.forEach((things, key) => {
+      if (things.length === 0) {
+        groupMap.delete(key);
+      }
+    });
+
+    return groupMap;
+  }
+
+  /**
+    * @param {Command} cmd
+    * @param {Help} helper
+    * @return {Map<string, Command[]>}
+    */
+  visibleCommandGroups(cmd, helper) {
+    return this._visibleThingGroups(cmd, helper, {
+      helpGroup: (cmd) => cmd.helpGroup() || 'Commands:',
+      things: cmd.commands,
+      visibleThings: helper.visibleCommands(cmd)
+    });
+  }
+
+  /**
+   * @param {Command} cmd
+   * @param {Help} helper
+   * @return {Map<string, Option[]>}
+   */
+  visibleOptionGroups(cmd, helper) {
+    return this._visibleThingGroups(cmd, helper, {
+      helpGroup: (option) => option.helpGroupTitle || 'Options:',
+      things: cmd.options,
+      visibleThings: helper.visibleOptions(cmd)
+    });
   }
 
   /**
@@ -379,12 +445,13 @@ class Help {
     }
 
     // Options
-    const optionList = helper.visibleOptions(cmd).map((option) => {
-      return formatItem(helper.optionTerm(option), helper.optionDescription(option));
+    const optionGroups = this.visibleOptionGroups(cmd, helper);
+    optionGroups.forEach((opts, groupTitle) => {
+      const optionList = opts.map((opt) => {
+        return formatItem(helper.optionTerm(opt), helper.optionDescription(opt));
+      });
+      output = output.concat([groupTitle, formatList(optionList), '']);
     });
-    if (optionList.length > 0) {
-      output = output.concat(['Options:', formatList(optionList), '']);
-    }
 
     if (this.showGlobalOptions) {
       const globalOptionList = helper.visibleGlobalOptions(cmd).map((option) => {
@@ -395,13 +462,14 @@ class Help {
       }
     }
 
-    // Commands
-    const commandList = helper.visibleCommands(cmd).map((cmd) => {
-      return formatItem(helper.subcommandTerm(cmd), helper.subcommandDescription(cmd));
+    // Command Groups
+    const commandGroups = this.visibleCommandGroups(cmd, helper);
+    commandGroups.forEach((cmds, groupTitle) => {
+      const commandList = cmds.map((cmd) => {
+        return formatItem(helper.subcommandTerm(cmd), helper.subcommandDescription(cmd));
+      });
+      output = output.concat([groupTitle, formatList(commandList), '']);
     });
-    if (commandList.length > 0) {
-      output = output.concat(['Commands:', formatList(commandList), '']);
-    }
 
     return output.join('\n');
   }

--- a/lib/help.js
+++ b/lib/help.js
@@ -136,12 +136,15 @@ class Help {
   }
 
   /**
-    * info.things
-    * info.visibleThings
-    * info.helpGroup(thing)
-    *
-    * @api private
-    */
+   * @param {Command} cmd
+   * @param {Help} helper
+   * @param {Object} info
+   * @param {Option[] | Command[]} info.things
+   * @param {Option[] | Command[]} info.visibleThings
+   * @param {function} info.helpGroup
+   *
+   * @api private
+   */
   _visibleThingGroups(cmd, helper, info) {
     const groupMap = new Map();
     const ensureGroup = (group) => {
@@ -174,10 +177,12 @@ class Help {
   }
 
   /**
-    * @param {Command} cmd
-    * @param {Help} helper
-    * @return {Map<string, Command[]>}
-    */
+   * Return map of Commands using group as key.
+   *
+   * @param {Command} cmd
+   * @param {Help} helper
+   * @return {Map<string, Command[]>}
+   */
   visibleCommandGroups(cmd, helper) {
     return this._visibleThingGroups(cmd, helper, {
       helpGroup: (cmd) => cmd.helpGroup() || 'Commands:',
@@ -187,6 +192,8 @@ class Help {
   }
 
   /**
+   * Return map of Options using group as key.
+   *
    * @param {Command} cmd
    * @param {Help} helper
    * @return {Map<string, Option[]>}

--- a/lib/option.js
+++ b/lib/option.js
@@ -222,7 +222,7 @@ class Option {
    * Get or set the help group of the command. Used as the title in the help. e.g. 'Commands:'
    *
    * @param {string} [title]
-   * @return {string|Command}
+   * @return {string|Option}
    */
 
   helpGroup(title) {

--- a/lib/option.js
+++ b/lib/option.js
@@ -35,6 +35,7 @@ class Option {
     this.argChoices = undefined;
     this.conflictsWith = [];
     this.implied = undefined;
+    this.helpGroupTitle = undefined;
   }
 
   /**
@@ -215,6 +216,18 @@ class Option {
 
   attributeName() {
     return camelcase(this.name().replace(/^no-/, ''));
+  }
+
+  /**
+   * Get or set the help group of the command. Used as the title in the help. e.g. 'Commands:'
+   *
+   * @param {string} [title]
+   * @return {string|Command}
+   */
+
+  helpGroup(title) {
+    this.helpGroupTitle = title;
+    return this;
   }
 
   /**

--- a/lib/option.js
+++ b/lib/option.js
@@ -219,7 +219,7 @@ class Option {
   }
 
   /**
-   * Get or set the help group of the command. Used as the title in the help. e.g. 'Commands:'
+   * Set the help group of the option. Used as the title in the help. e.g. 'Options:'
    *
    * @param {string} [title]
    * @return {string|Option}

--- a/tests/command.chain.test.js
+++ b/tests/command.chain.test.js
@@ -208,4 +208,10 @@ describe('Command methods that should return this for chaining', () => {
     const result = program.nameFromFilename('name');
     expect(result).toBe(program);
   });
+
+  test('when set .helpGroup() then returns this', () => {
+    const program = new Command();
+    const result = program.helpGroup('Commands:');
+    expect(result).toBe(program);
+  });
 });

--- a/tests/command.helpGroup.test.js
+++ b/tests/command.helpGroup.test.js
@@ -1,0 +1,17 @@
+const commander = require('../');
+
+// Just testing the observable Command behaviour here, actual Help behaviour tested elsewhere.
+
+test('when set helpGroup on Command then can get helpGroup', () => {
+  const cmd = new commander.Command();
+  const group = 'Example:';
+  cmd.helpGroup(group);
+  expect(cmd.helpGroup()).toEqual(group);
+});
+
+test('when use opt.helpGroup with external command then sets helpGroup on new command', () => {
+  const program = new commander.Command();
+  const group = 'Example:';
+  program.command('external', 'external description', { helpGroup: group });
+  expect(program.commands[program.commands.length - 1].helpGroup()).toEqual(group);
+});

--- a/tests/help.helpGroup.test.js
+++ b/tests/help.helpGroup.test.js
@@ -1,0 +1,66 @@
+const { Command, Option } = require('../');
+
+test('when use cmd.helpGroup then command listed in custom group', () => {
+  const program = new Command();
+  program.command('foo')
+    .description('foo description')
+    .helpGroup('Example Command:')
+    .action(() => {});
+  const helpInfo = program.helpInformation();
+  expect(helpInfo).toMatch(/Example Command:\n +foo +foo description\n\n/);
+});
+
+test('when use opt:helpGroup with external command then command listed in custom group', () => {
+  const program = new Command();
+  program.command('foo', 'foo description', { helpGroup: 'Example Command:' });
+  const helpInfo = program.helpInformation();
+  expect(helpInfo).toMatch(/Example Command:\n +foo +foo description\n\n/);
+});
+
+test('when use opt:helpGroup with addCommand then command listed in custom group', () => {
+  const program = new Command();
+  program.addCommand(new Command('foo').description('foo description').helpGroup('Example Command:'));
+  const helpInfo = program.helpInformation();
+  expect(helpInfo).toMatch(/Example Command:\n +foo +foo description\n\n/);
+});
+
+test('when hidden command with group then group not displayed', () => {
+  const program = new Command();
+  program.command('hidden', 'hidden description', { helpGroup: 'Hidden Command:', hidden: true });
+  const helpInfo = program.helpInformation();
+  expect(helpInfo).not.toMatch(/Hidden/);
+});
+
+test('when use opt:helpGroup with addHelpCommand then command listed in custom group', () => {
+  const program = new Command();
+  program.addHelpCommand('help', 'show help', { helpGroup: 'Example Command:' });
+  const helpInfo = program.helpInformation();
+  expect(helpInfo).toMatch(/Example Command:\n +help +show help\n/);
+});
+
+test('when use opt:helpGroup with helpOption then option listed in custom group', () => {
+  const program = new Command();
+  program.helpOption('-h, --help', 'show help', { helpGroup: 'Example Option:' });
+  const helpInfo = program.helpInformation();
+  expect(helpInfo).toMatch(/Example Option:\n +-h, --help +show help\n/);
+});
+
+test('when sort commands then command groups in creation order and commands sorted in group', () => {
+  const program = new Command();
+  program.configureHelp({ sortSubcommands: true });
+  program.command('z2', 'ZZ', { helpGroup: 'First Group:' });
+  program.command('a', 'AA', { helpGroup: 'Second Group:' });
+  program.command('z1', 'ZZ', { helpGroup: 'First Group:' });
+  const helpInfo = program.helpInformation();
+  expect(helpInfo).toMatch(/First Group:\n +z1 +ZZ\n +z2 +ZZ\n\nSecond Group:/);
+});
+
+test('when sort options then options groups in creation order and options sorted in group', () => {
+  const program = new Command();
+  program.configureHelp({ sortOptions: true });
+  program.addOption(new Option('-z', 'ZZ').helpGroup('First Group:'));
+  program.addOption(new Option('-a', 'AA').helpGroup('Second Group:'));
+  program.addOption(new Option('-y', 'YY').helpGroup('First Group:'));
+  const helpInfo = program.helpInformation();
+  expect(helpInfo).toMatch(/First Group:\n +-y +YY\n +-z + ZZ\n\nSecond Group:/);
+});

--- a/tests/option.chain.test.js
+++ b/tests/option.chain.test.js
@@ -42,4 +42,10 @@ describe('Option methods that should return this for chaining', () => {
     const result = option.conflicts(['a']);
     expect(result).toBe(option);
   });
+
+  test('when set .helpGroup() then returns this', () => {
+    const option = new Option('-e,--example <value>');
+    const result = option.helpGroup('Option:');
+    expect(result).toBe(option);
+  });
 });

--- a/tests/options.helpGroup.test.js
+++ b/tests/options.helpGroup.test.js
@@ -1,0 +1,10 @@
+const commander = require('../');
+
+// Just testing the observable Option behaviour here, actual Help behaviour tested elsewhere.
+
+test('when set helpGroup then stored as helpGroupTitle', () => {
+  const opt = new commander.Option('-e, --example');
+  const group = 'Example:';
+  opt.helpGroup(group);
+  expect(opt.helpGroupTitle).toEqual(group);
+});

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -106,6 +106,11 @@ export class Option {
   default(value: unknown, description?: string): this;
 
   /**
+   * Set the help group of the option. Used as the title in the help. e.g. 'Options:'
+   */
+  helpGroup(title: string): this;
+
+  /**
    * Preset to use when option used without option-argument, especially optional but also boolean and negated.
    * The custom processing (parseArg) is called.
    *
@@ -293,7 +298,7 @@ export class Command {
    *
    * You can optionally supply the  flags and description to override the defaults.
    */
-  version(str: string, flags?: string, description?: string): this;
+  version(str: string, flags?: string, description?: string, versionOpts?: { helpGroup?: string }): this;
 
   /**
    * Define a command, implemented using an action handler.
@@ -411,7 +416,7 @@ export class Command {
    *
    * @returns `this` command for chaining
    */
-  addHelpCommand(enableOrNameAndArgs?: string | boolean, description?: string): this;
+  addHelpCommand(enableOrNameAndArgs?: string | boolean, description?: string, helpOpts?: { helpGroup?: string }): this;
 
   /**
    * Add hook for life cycle event.
@@ -789,6 +794,15 @@ export class Command {
   name(): string;
 
   /**
+   * Set the help group of the command. Used as the title in the help. e.g. 'Commands:'
+   */
+  helpGroup(str: string): this;
+  /**
+   * Get the help group of the command.
+   */
+  helpGroup(): string;
+
+  /**
    * Set the name of the command from script filename, such as process.argv[1],
    * or require.main.filename, or __filename.
    *
@@ -841,7 +855,7 @@ export class Command {
    * flags and help description for your command. Pass in false
    * to disable the built-in help option.
    */
-  helpOption(flags?: string | boolean, description?: string): this;
+  helpOption(flags?: string | boolean, description?: string, helpOpts?: { helpGroup?: string }): this;
 
   /**
    * Output help information and exit.
@@ -872,6 +886,7 @@ export interface CommandOptions {
   isDefault?: boolean;
   /** @deprecated since v7, replaced by hidden */
   noHelp?: boolean;
+  helpGroup?: string;
 }
 export interface ExecutableCommandOptions extends CommandOptions {
   executableFile?: string;

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -36,12 +36,13 @@ expectType<commander.Command | null>(program.parent);
 expectType<commander.Command>(program.version('1.2.3'));
 expectType<commander.Command>(program.version('1.2.3', '-r,--revision'));
 expectType<commander.Command>(program.version('1.2.3', '-r,--revision', 'show revision information'));
+expectType<commander.Command>(program.version('1.2.3', '-r,--revision', 'show revision information', { helpGroup: 'Version Group:' }));
 
 // command (and CommandOptions)
 expectType<commander.Command>(program.command('action'));
 expectType<commander.Command>(program.command('action', { isDefault: true, hidden: true, noHelp: true }));
 expectType<commander.Command>(program.command('exec', 'exec description'));
-expectType<commander.Command>(program.command('exec', 'exec description', { isDefault: true, hidden: true, noHelp: true, executableFile: 'foo' }));
+expectType<commander.Command>(program.command('exec', 'exec description', { isDefault: true, hidden: true, noHelp: true, executableFile: 'foo', helpGroup: 'Exteneral Group:' }));
 
 // addCommand
 expectType<commander.Command>(program.addCommand(new commander.Command('abc')));
@@ -62,6 +63,7 @@ expectType<commander.Command>(program.addHelpCommand(false));
 expectType<commander.Command>(program.addHelpCommand(true));
 expectType<commander.Command>(program.addHelpCommand('compress <file>'));
 expectType<commander.Command>(program.addHelpCommand('compress <file>', 'compress target file'));
+expectType<commander.Command>(program.addHelpCommand('compress <file>', 'compress target file', { helpGroup: 'Help Group:' }));
 
 // exitOverride
 expectType<commander.Command>(program.exitOverride());
@@ -270,6 +272,10 @@ expectType<string>(program.usage());
 expectType<commander.Command>(program.name('my-name'));
 expectType<string>(program.name());
 
+// helpGroup
+expectType<commander.Command>(program.helpGroup('My Group:'));
+expectType<string>(program.helpGroup());
+
 // nameFromFilename
 expectType<commander.Command>(program.nameFromFilename(__filename));
 
@@ -297,6 +303,7 @@ expectType<string>(program.helpInformation({ error: true }));
 // helpOption
 expectType<commander.Command>(program.helpOption('-h,--help'));
 expectType<commander.Command>(program.helpOption('-h,--help', 'custom description'));
+expectType<commander.Command>(program.helpOption('-h,--help', 'custom description', { helpGroup: 'Help Group:' }));
 expectType<commander.Command>(program.helpOption(undefined, 'custom description'));
 expectType<commander.Command>(program.helpOption(false));
 
@@ -403,6 +410,9 @@ const baseOption = new commander.Option('-f,--foo', 'foo description');
 // default
 expectType<commander.Option>(baseOption.default(3));
 expectType<commander.Option>(baseOption.default(60, 'one minute'));
+
+// helpGroup
+expectType<commander.Option>(baseOption.helpGroup('Example Group:'));
 
 // preset
 expectType<commander.Option>(baseOption.preset(123));


### PR DESCRIPTION
## Problem

Some people with larger programs would like to break up their commands and options into groups in the help. There have not been a lot of requests for this, but it is something I had noticed as a possible enhancement.

See: #78 https://github.com/tj/commander.js/issues/374#issuecomment-220442296 #1897

Help groups are common in "big" programs, but big programs often have custom help systems anyway! (e.g. git, npm)

## Solution

Add `.helpGroup()` to Command and Option. Use the help groups as titles in the help.

To support built-in features and external commands, add `{helpGroup}` configuration to:
- `.version()`
- `.helpOption()`
- `.addHelpCommand()`
- external command configuration

```js
program.command('build').helpGroup('Demo Commands:').action(() => {});
program.command('serve', 'external command', { helpGroup: 'Demo Commands:' });
program.addOption(new Option('-e, --example').helpGroup('Demo Options:'));
program.version('1.2.3', '--version', 'Show version', { helpGroup: 'Demo Options:' });
program.helpOption('-s, --support', 'Show help', { helpGroup: 'Demo Options:' });
program.addHelpCommand('help [command]', 'Show help', { helpGroup: 'Demo Commands:' });
```

```console
% node pr-example.js
Usage: pr-example [options] [command]

Demo Options:
  -e, --example
  --version       Show version
  -s, --support   Show help

Demo Commands:
  build
  serve           external command
  help [command]  Show help
```

## ChangeLog

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->
