### PR TITLE
Feature/async parse args experiment

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -1160,6 +1160,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
       processedArgs[index] = value;
     });
     this.processedArgs = processedArgs;
+    return this._settleArgumentPromises();
   }
 
   /**
@@ -1264,12 +1265,36 @@ Expecting one of '${allowedValues.join("', '")}'`);
   _settleOptionPromises() {
     const promises = [];
 
+    // Look through the options for promises from async parseArgs (or other sources).
     Object.entries(this.opts()).forEach(([key, value]) => {
       if (thenable(value)) {
         promises.push(value);
         // Resave value after promise resolves.
         value.then((settledValue) => {
           this.setOptionValueWithSource(key, settledValue, this.getOptionValueSource(key));
+        });
+      }
+    });
+
+    if (promises.length > 0) {
+      return Promise.all(promises);
+    }
+  }
+
+  /**
+   * @api private
+   */
+
+  _settleArgumentPromises() {
+    const promises = [];
+
+    // Variadic array is either ordinary, or a promise for an array.
+    this.processedArgs.forEach((arg, index) => {
+      if (thenable(arg)) {
+        promises.push(arg);
+        // Resave value after promise resolves.
+        arg.then((settledArg) => {
+          this.processedArgs[index] = settledArg;
         });
       }
     });

--- a/lib/command.js
+++ b/lib/command.js
@@ -1308,13 +1308,16 @@ Expecting one of '${allowedValues.join("', '")}'`);
         this.unknownOption(parsed.unknown[0]);
       }
     };
+    const settleAndProcessArguments = () => {
+      const chain = this._settleOptionPromises();
+      return this._chainOrCall(chain, () => this._processArguments());
+    };
 
+    let chain;
     const commandEvent = `command:${this.name()}`;
     if (this._actionHandler) {
       checkForUnknownOptions();
-      this._processArguments();
-
-      let chain = this._settleOptionPromises();
+      chain = settleAndProcessArguments();
       chain = this._chainOrCallHooks(chain, 'preAction');
       chain = this._chainOrCall(chain, () => this._actionHandler(this.processedArgs));
       if (this.parent) {
@@ -1323,12 +1326,10 @@ Expecting one of '${allowedValues.join("', '")}'`);
         });
       }
       chain = this._chainOrCallHooks(chain, 'postAction');
-      return chain;
-    }
-    if (this.parent && this.parent.listenerCount(commandEvent)) {
+    } else if (this.parent && this.parent.listenerCount(commandEvent)) {
       checkForUnknownOptions();
-      this._processArguments();
-      this.parent.emit(commandEvent, operands, unknown); // legacy
+      chain = settleAndProcessArguments();
+      chain = this._chainOrCall(chain, () => { this.parent.emit(commandEvent, operands, unknown); }); // Legacy
     } else if (operands.length) {
       if (this._findCommand('*')) { // legacy default command
         return this._dispatchSubcommand('*', operands, unknown);
@@ -1340,7 +1341,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
         this.unknownCommand();
       } else {
         checkForUnknownOptions();
-        this._processArguments();
+        chain = settleAndProcessArguments();
       }
     } else if (this.commands.length) {
       checkForUnknownOptions();
@@ -1348,9 +1349,10 @@ Expecting one of '${allowedValues.join("', '")}'`);
       this.help({ error: true });
     } else {
       checkForUnknownOptions();
-      this._processArguments();
+      chain = settleAndProcessArguments();
       // fall through for caller to handle after calling .parse()
     }
+    return chain;
   }
 
   /**

--- a/lib/command.js
+++ b/lib/command.js
@@ -1277,18 +1277,14 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   _settleOptionPromises() {
-    const promises = [];
-
     // Look through the options for promises from async parseArgs (or other sources).
-    Object.entries(this.opts()).forEach(([key, value]) => {
-      if (thenable(value)) {
-        // Resave value after promise resolves.
-        const promise = value.then((settledValue) => {
-          this.setOptionValueWithSource(key, settledValue, this.getOptionValueSource(key));
+    const promises = Object.entries(this.opts())
+      .filter(([key, maybePromise]) => thenable(maybePromise))
+      .map(([key, promise]) => {
+        return promise.then(value => {
+          this.setOptionValueWithSource(key, value, this.getOptionValueSource(key));
         });
-        promises.push(promise);
-      }
-    });
+      });
 
     if (promises.length > 0) {
       return Promise.all(promises);
@@ -1300,18 +1296,14 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   _settleArgumentPromises() {
-    const promises = [];
-
-    // Variadic array is either ordinary, or a promise for an array.
-    this.processedArgs.forEach((arg, index) => {
-      if (thenable(arg)) {
-        // Resave value after promise resolves.
-        const promise = arg.then((settledArg) => {
-          this.processedArgs[index] = settledArg;
+    // Look through the arguments for promises from async parseArgs (or other sources).
+    const promises = this.processedArgs
+      .filter(thenable)
+      .map((promise, index) => {
+        return promise.then(value => {
+          this.processedArgs[index] = value;
         });
-        promises.push(promise);
-      }
-    });
+      });
 
     if (promises.length > 0) {
       return Promise.all(promises);

--- a/lib/command.js
+++ b/lib/command.js
@@ -1267,6 +1267,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     Object.entries(this.opts()).forEach(([key, value]) => {
       if (thenable(value)) {
         promises.push(value);
+        // Resave value after promise resolves.
         value.then((settledValue) => {
           this.setOptionValueWithSource(key, settledValue, this.getOptionValueSource(key));
         });

--- a/lib/command.js
+++ b/lib/command.js
@@ -1279,11 +1279,11 @@ Expecting one of '${allowedValues.join("', '")}'`);
     // Look through the options for promises from async parseArgs (or other sources).
     Object.entries(this.opts()).forEach(([key, value]) => {
       if (thenable(value)) {
-        promises.push(value);
         // Resave value after promise resolves.
-        value.then((settledValue) => {
+        const promise = value.then((settledValue) => {
           this.setOptionValueWithSource(key, settledValue, this.getOptionValueSource(key));
         });
+        promises.push(promise);
       }
     });
 
@@ -1302,11 +1302,11 @@ Expecting one of '${allowedValues.join("', '")}'`);
     // Variadic array is either ordinary, or a promise for an array.
     this.processedArgs.forEach((arg, index) => {
       if (thenable(arg)) {
-        promises.push(arg);
         // Resave value after promise resolves.
-        arg.then((settledArg) => {
+        const promise = arg.then((settledArg) => {
           this.processedArgs[index] = settledArg;
         });
+        promises.push(promise);
       }
     });
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -1265,7 +1265,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
       }
     }
 
-    if (thenable(result)) result.catch(refineError);
+    if (thenable(result)) result = result.then(null, refineError); // Using then() to do a catch since we only tested for then()).
     return result;
   }
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -1188,8 +1188,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   _chainOrCall(promise, fn) {
-    // thenable
-    if (promise && promise.then && typeof promise.then === 'function') {
+    if (thenable(promise)) {
       // already have a promise, chain callback
       return promise.then(() => fn());
     }
@@ -1250,6 +1249,26 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   /**
+   * @api private
+   */
+  _settleOptionPromises() {
+    const promises = [];
+
+    Object.entries(this.opts()).forEach(([key, value]) => {
+      if (thenable(value)) {
+        promises.push(value);
+        value.then((settledValue) => {
+          this.setOptionValueWithSource(key, settledValue, this.getOptionValueSource(key));
+        });
+      }
+    });
+
+    if (promises.length > 0) {
+      return Promise.all(promises);
+    }
+  }
+
+  /**
    * Process arguments in context of this command.
    * Returns action result, in case it is a promise.
    *
@@ -1296,6 +1315,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
       this._processArguments();
 
       let actionResult;
+      actionResult = this._chainOrCall(actionResult, () => this._settleOptionPromises());
       actionResult = this._chainOrCallHooks(actionResult, 'preAction');
       actionResult = this._chainOrCall(actionResult, () => this._actionHandler(this.processedArgs));
       if (this.parent) {
@@ -2191,6 +2211,16 @@ function getCommandAndParents(startCommand) {
     result.push(command);
   }
   return result;
+}
+
+/**
+ * @param {Object} obj
+ * @returns {boolean}
+ * @api private
+ */
+
+function thenable(obj) {
+  return (obj && obj.then && typeof obj.then === 'function');
 }
 
 exports.Command = Command;

--- a/lib/command.js
+++ b/lib/command.js
@@ -535,15 +535,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
       // custom processing
       const oldValue = this.getOptionValue(name);
       if (val !== null && option.parseArg) {
-        try {
-          val = option.parseArg(val, oldValue);
-        } catch (err) {
-          if (err.code === 'commander.invalidArgument') {
-            const message = `${invalidValueMessage} ${err.message}`;
-            this.error(message, { exitCode: err.exitCode, code: err.code });
-          }
-          throw err;
-        }
+        val = this._parseArgWithMessage(invalidValueMessage, () => option.parseArg(val, oldValue));
       } else if (val !== null && option.variadic) {
         val = option._concatValue(val, oldValue);
       }
@@ -1134,18 +1126,10 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
   _processArguments() {
     const myParseArg = (argument, value, previous) => {
-      // Extra processing for nice error message on parsing failure.
       let parsedValue = value;
       if (value !== null && argument.parseArg) {
-        try {
-          parsedValue = argument.parseArg(value, previous);
-        } catch (err) {
-          if (err.code === 'commander.invalidArgument') {
-            const message = `error: command-argument value '${value}' is invalid for argument '${argument.name()}'. ${err.message}`;
-            this.error(message, { exitCode: err.exitCode, code: err.code });
-          }
-          throw err;
-        }
+        const errorMessage = `error: command-argument value '${value}' is invalid for argument '${argument.name()}'.`;
+        parsedValue = this._parseArgWithMessage(errorMessage, () => argument.parseArg(value, previous));
       }
       return parsedValue;
     };
@@ -1251,6 +1235,32 @@ Expecting one of '${allowedValues.join("', '")}'`);
   /**
    * @api private
    */
+
+  _parseArgWithMessage(invalidArgumentMessage, parseArgFn) {
+    const refineError = (err) => {
+      if (err.code === 'commander.invalidArgument') {
+        const message = `${invalidArgumentMessage} ${err.message}`;
+        this.error(message, { exitCode: err.exitCode, code: err.code });
+      }
+      throw err;
+    };
+
+    let result;
+    try {
+      result = parseArgFn();
+      if (thenable(result)) {
+        result.catch(refineError);
+      }
+    } catch (err) {
+      refineError(err);
+    }
+    return result;
+  }
+
+  /**
+   * @api private
+   */
+
   _settleOptionPromises() {
     const promises = [];
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -1256,16 +1256,19 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
     let result;
     if (thenable(previous)) {
-      result = previous.then(resolvedPrevious => target.parseArg(value, resolvedPrevious));
+      result = previous.then(resolvedPrevious => {
+        let innerResult = target.parseArg(value, resolvedPrevious);
+        if (thenable(innerResult)) innerResult = innerResult.then(null, refineError); // .catch
+        return innerResult;
+      });
     } else {
       try {
         result = target.parseArg(value, previous);
+        if (thenable(result)) result = result.then(null, refineError); // .catch
       } catch (err) {
         refineError(err);
       }
     }
-
-    if (thenable(result)) result = result.then(null, refineError); // Using then() to do a catch since we only tested for then()).
     return result;
   }
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -2263,7 +2263,7 @@ function getCommandAndParents(startCommand) {
  */
 
 function thenable(obj) {
-  return (obj && obj.then && typeof obj.then === 'function');
+  return !!(obj && obj.then && typeof obj.then === 'function');
 }
 
 exports.Command = Command;

--- a/lib/command.js
+++ b/lib/command.js
@@ -535,7 +535,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
       // custom processing
       const oldValue = this.getOptionValue(name);
       if (val !== null && option.parseArg) {
-        val = this._parseArgWithMessage(invalidValueMessage, () => option.parseArg(val, oldValue));
+        val = this._parseArg(option, val, oldValue, invalidValueMessage);
       } else if (val !== null && option.variadic) {
         val = option._concatValue(val, oldValue);
       }
@@ -1129,7 +1129,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
       let parsedValue = value;
       if (value !== null && argument.parseArg) {
         const errorMessage = `error: command-argument value '${value}' is invalid for argument '${argument.name()}'.`;
-        parsedValue = this._parseArgWithMessage(errorMessage, () => argument.parseArg(value, previous));
+        parsedValue = this._parseArg(argument, value, previous, errorMessage);
       }
       return parsedValue;
     };
@@ -1234,10 +1234,18 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   /**
+   * Call parseArgs with extra handling:
+   * - custom error message if parseArgs throws 'commander.invalidArgument'
+   * - if the previous value is a promise, chain the call to resolve the promise before parsing
+   *
+   * @param {Option | Argument} target
+   * @param {string} value
+   * @param {Promise<any> | any} previous
+   * @param {string} invalidArgumentMessage
    * @api private
    */
 
-  _parseArgWithMessage(invalidArgumentMessage, parseArgFn) {
+  _parseArg(target, value, previous, invalidArgumentMessage) {
     const refineError = (err) => {
       if (err.code === 'commander.invalidArgument') {
         const message = `${invalidArgumentMessage} ${err.message}`;
@@ -1247,14 +1255,17 @@ Expecting one of '${allowedValues.join("', '")}'`);
     };
 
     let result;
-    try {
-      result = parseArgFn();
-      if (thenable(result)) {
-        result.catch(refineError);
+    if (thenable(previous)) {
+      result = previous.then(resolvedPrevious => target.parseArg(value, resolvedPrevious));
+    } else {
+      try {
+        result = target.parseArg(value, previous);
+      } catch (err) {
+        refineError(err);
       }
-    } catch (err) {
-      refineError(err);
     }
+
+    if (thenable(result)) result.catch(refineError);
     return result;
   }
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -1072,16 +1072,16 @@ Expecting one of '${allowedValues.join("', '")}'`);
     const subCommand = this._findCommand(commandName);
     if (!subCommand) this.help({ error: true });
 
-    let hookResult;
-    hookResult = this._chainOrCallSubCommandHook(hookResult, subCommand, 'preSubcommand');
-    hookResult = this._chainOrCall(hookResult, () => {
+    let chain = this._settleOptionPromises();
+    chain = this._chainOrCallSubCommandHook(chain, subCommand, 'preSubcommand');
+    chain = this._chainOrCall(chain, () => {
       if (subCommand._executableHandler) {
         this._executeSubCommand(subCommand, operands.concat(unknown));
       } else {
         return subCommand._parseCommand(operands, unknown);
       }
     });
-    return hookResult;
+    return chain;
   }
 
   /**
@@ -1314,17 +1314,16 @@ Expecting one of '${allowedValues.join("', '")}'`);
       checkForUnknownOptions();
       this._processArguments();
 
-      let actionResult;
-      actionResult = this._chainOrCall(actionResult, () => this._settleOptionPromises());
-      actionResult = this._chainOrCallHooks(actionResult, 'preAction');
-      actionResult = this._chainOrCall(actionResult, () => this._actionHandler(this.processedArgs));
+      let chain = this._settleOptionPromises();
+      chain = this._chainOrCallHooks(chain, 'preAction');
+      chain = this._chainOrCall(chain, () => this._actionHandler(this.processedArgs));
       if (this.parent) {
-        actionResult = this._chainOrCall(actionResult, () => {
+        chain = this._chainOrCall(chain, () => {
           this.parent.emit(commandEvent, operands, unknown); // legacy
         });
       }
-      actionResult = this._chainOrCallHooks(actionResult, 'postAction');
-      return actionResult;
+      chain = this._chainOrCallHooks(chain, 'postAction');
+      return chain;
     }
     if (this.parent && this.parent.listenerCount(commandEvent)) {
       checkForUnknownOptions();


### PR DESCRIPTION
This is an experiment based on concepts in #1902 to support async Option.parseArgs and Arguments.parseArgs. Blindly store the return value from async calls  to parseArgs as usual (although actually a pending promise), and then settle the promises in a batch before proceeding to next stage of parsing. In particular, settle the promises before calling user hooks or action handler so client code is unlikely to see the promises.

Simplified approach compared to #1902, here:
- no configuration
- built-in support rather than using hooks
- <strike>handling previous value promises from repeated calls to parseArgs left to client</strike>

---
Reminder to add co-author credit if proceed with this PR.
```
Co-authored-by: Wee Bit <aweebit64@gmail.com>
```