### PR TITLE
Add async custom processing support. Add `chainArgParserCalls()` for configuration. Additionally await thenable implicit and default option values and thenable default argument values

### DIFF
--- a/docs/parsing-and-hooks.md
+++ b/docs/parsing-and-hooks.md
@@ -1,23 +1,29 @@
 # Parsing life cycle and hooks
 
-The processing starts with an array of args. Each command processes and removes the options it understands, and passes the remaining args to the next subcommand.
-The final command calls the action handler.
+The processing starts with an array of args. Each command processes and removes the options it understands, and passes the remaining args to the next subcommand. The final command calls the action handler.
 
 Starting with top-level command (program):
 
-- parse options: parse recognised options (for this command) and remove from args
-- parse env: look for environment variables (for this command)
-- process implied: set any implied option values (for this command)
-- if the first arg is a subcommand
-    - call `preSubcommand` hooks
-    - pass remaining arguments to subcommand, and process same way
+* process options for this command (includes calling or chaining provided argParsers[^1])
+  * recognised options from args (and remove them)
+  * options based on environment variables
+* set implied option values (for this command)
+* await thenable option values if parsing with `parseAsync()`
+* if the first arg is a subcommand
+  * call or chain `preSubcommand` hooks[^1]
+  * pass remaining arguments to subcommand, and process same way
 
 Once reach final (leaf) command:
 
-- check for missing mandatory options
-- check for conflicting options
-- check for unknown options
-- process remaining args as command-arguments
-- call `preAction` hooks
-- call action handler
-- call `postAction` hooks
+* check for missing mandatory options
+* check for conflicting options
+* check for unknown options
+* process remaining args as command-arguments (includes calling or chaining provided argParsers[^1])
+* await thenable argument values if parsing with `parseAsync()`
+* if an action handler is provided
+  * call or chain `preAction` hooks[^1]
+  * call or chain action handler[^1]
+  * call or chain `postAction` hooks[^1]
+</details>
+
+[^1]: output a warning suggesting use of `parseAsync()` when parsing with `parse()` and a thenable is returned, unless `process.env.NODE_ENV === 'production'`

--- a/docs/parsing-and-hooks.md
+++ b/docs/parsing-and-hooks.md
@@ -5,9 +5,10 @@ The processing starts with an array of args. Each command processes and removes 
 Starting with top-level command (program):
 
 * process options for this command (includes calling or chaining provided argParsers[^1])
-  * recognised options from args (and remove them)
+  * recognised options from args
   * options based on environment variables
 * set implied option values (for this command)
+* remove recognised options from args
 * await thenable option values if parsing with `parseAsync()`
 * if the first arg is a subcommand
   * call or chain `preSubcommand` hooks[^1]

--- a/lib/argument.js
+++ b/lib/argument.js
@@ -16,6 +16,8 @@ class Argument {
     this.description = description || '';
     this.variadic = false;
     this.parseArg = undefined;
+    /** @type {boolean | undefined} */
+    this.chained = undefined;
     this.defaultValue = undefined;
     this.defaultValueDescription = undefined;
     this.argChoices = undefined;
@@ -86,6 +88,18 @@ class Argument {
 
   argParser(fn) {
     this.parseArg = fn;
+    return this;
+  }
+
+  /**
+   * When set to true, next call to the function provided via .argParser() will be chained to its return value if it is thenable.
+   * When set to undefined (the default), only chain when .parseAsync() has been called.
+   *
+   * @param {boolean | undefined} [chained]
+   * @return {Argument}
+   */
+  chainArgParserCalls(chained) {
+    this.chained = chained === undefined ? undefined : !!chained;
     return this;
   }
 

--- a/lib/argument.js
+++ b/lib/argument.js
@@ -16,8 +16,7 @@ class Argument {
     this.description = description || '';
     this.variadic = false;
     this.parseArg = undefined;
-    /** @type {boolean | undefined} */
-    this.chained = undefined;
+    this.chained = true;
     this.defaultValue = undefined;
     this.defaultValueDescription = undefined;
     this.argChoices = undefined;
@@ -92,14 +91,13 @@ class Argument {
   }
 
   /**
-   * When set to `true`, next call to the function provided via `.argParser()` will be chained to its return value if it is thenable.
-   * When set to `undefined` (the default), only chain when `.parseAsync()` has been called.
+   * When set to `true` (the default), next call to the function provided via `.argParser()` will be chained to its return value if it is thenable.
    *
-   * @param {boolean | undefined} [chained]
+   * @param {boolean} [chained=true]
    * @return {Argument}
    */
-  chainArgParserCalls(chained) {
-    this.chained = chained === undefined ? undefined : !!chained;
+  chainArgParserCalls(chained = true) {
+    this.chained = !!chained;
     return this;
   }
 

--- a/lib/argument.js
+++ b/lib/argument.js
@@ -92,8 +92,8 @@ class Argument {
   }
 
   /**
-   * When set to true, next call to the function provided via .argParser() will be chained to its return value if it is thenable.
-   * When set to undefined (the default), only chain when .parseAsync() has been called.
+   * When set to `true`, next call to the function provided via `.argParser()` will be chained to its return value if it is thenable.
+   * When set to `undefined` (the default), only chain when `.parseAsync()` has been called.
    *
    * @param {boolean | undefined} [chained]
    * @return {Argument}

--- a/lib/command.js
+++ b/lib/command.js
@@ -924,7 +924,6 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
   parse(argv, parseOptions) {
     this._asyncParsing = false;
-    this._setShouldAwait();
 
     const userArgs = this._prepareUserArgs(argv, parseOptions);
     this._parseCommand([], userArgs);
@@ -953,7 +952,6 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
   async parseAsync(argv, parseOptions) {
     this._asyncParsing = true;
-    this._setShouldAwait();
 
     const userArgs = this._prepareUserArgs(argv, parseOptions);
     await this._parseCommand([], userArgs);
@@ -972,22 +970,6 @@ Expecting one of '${allowedValues.join("', '")}'`);
   await(enabled) {
     this._await = enabled === undefined ? undefined : !!enabled;
     return this;
-  }
-
-  /**
-   * If `_await` is `undefined`, inherit await behaviour or base it on whether `.parseAsync()` has been called on the top-level command.
-   *
-   * @api private
-   */
-
-  _setShouldAwait() {
-    this._shouldAwait = undefined;
-    let cmd = this;
-    do {
-      this._shouldAwait = cmd._await;
-      cmd = cmd.parent;
-    } while (this._shouldAwait === undefined && cmd);
-    this._shouldAwait ??= this._asyncParsing;
   }
 
   /**
@@ -1415,6 +1397,11 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   _parseCommand(operands, unknown) {
+    // Use explicitly set await mode,
+    // or inherit await behaviour from parent,
+    // or base it on whether .parseAsync() has been called.
+    this._shouldAwait = this._await ?? this.parent?._shouldAwait ?? this._asyncParsing;
+
     let chain;
 
     const parsed = this.parseOptions(unknown);

--- a/lib/command.js
+++ b/lib/command.js
@@ -1488,7 +1488,6 @@ Expecting one of '${allowedValues.join("', '")}'`);
         }
       };
       const processAndAwaitArguments = () => {
-        checkForUnknownOptions();
         this._processArguments();
         chain = this._chainOrCall(chain, () => this._awaitArgumentResavePromises());
       };

--- a/lib/command.js
+++ b/lib/command.js
@@ -1271,8 +1271,16 @@ Expecting one of '${allowedValues.join("', '")}'`);
       // already have a promise, chain callback
       return chain.then(fn);
     }
+
     // callback might return a promise
-    return fn(chain);
+    chain = fn(chain);
+    if (isThenable(chain) && !this._asyncParsing) {
+      chain.then(x => x, () => {}); // prevent unhandled rejection
+      process.exitCode = 1; // additionally indicates to the user that user code (parsers, hooks, action) is not the error source
+      throw new Error(`.parse() is incompatible with async argParsers, hooks and actions.
+Use .parseAsync() instead.`);
+    }
+    return chain;
   }
 
   /**

--- a/lib/command.js
+++ b/lib/command.js
@@ -517,14 +517,21 @@ Expecting one of '${allowedValues.join("', '")}'`);
     const name = option.attributeName();
 
     // store default value
-    if (option.negate) {
+    const setDefaultOptionValue = (value) => {
+      this.setOptionValueWithSource(name, value, 'default');
+      if (!PRODUCTION && !this._asyncParsing && isThenable(value)) {
+        console.warn(`.parse() is incompatible with thenable default option values.
+Use .parseAsync() instead`);
+      }
+    };
+    if (option.defaultValue !== undefined || !option.negate) {
+      setDefaultOptionValue(option.defaultValue);
+    } else {
       // --no-foo is special and defaults foo to true, unless a --foo option is already defined
       const positiveLongFlag = option.long.replace(/^--no-/, '--');
       if (!this._findOption(positiveLongFlag)) {
-        this.setOptionValueWithSource(name, option.defaultValue === undefined ? true : option.defaultValue, 'default');
+        setDefaultOptionValue(true);
       }
-    } else if (option.defaultValue !== undefined) {
-      this.setOptionValueWithSource(name, option.defaultValue, 'default');
     }
 
     // register the option

--- a/lib/command.js
+++ b/lib/command.js
@@ -807,11 +807,11 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
   setOptionValueWithSource(key, value, source) {
     if (!PRODUCTION && !this._asyncParsing && isThenable(value)) {
-        console.warn(`.parse() is incompatible with ${
-          ['cli', 'env'].includes(source)
-            ? 'async argParsers'
-            : 'thenable option values'
-        }.
+      console.warn(`.parse() is incompatible with ${
+        ['cli', 'env'].includes(source)
+          ? 'async argParsers'
+          : 'thenable option values'
+      }.
 Use .parseAsync() instead`);
     }
     if (this._storeOptionsAsProperties) {

--- a/lib/command.js
+++ b/lib/command.js
@@ -63,8 +63,6 @@ class Command extends EventEmitter {
     this._asyncParsing = undefined;
     /** @type {boolean | undefined} */
     this._await = undefined;
-    /** @type {boolean | undefined} */
-    this._shouldAwait = undefined;
 
     // see .configureOutput() for docs
     this._outputConfiguration = {
@@ -114,6 +112,7 @@ class Command extends EventEmitter {
     this._enablePositionalOptions = sourceCommand._enablePositionalOptions;
     this._showHelpAfterError = sourceCommand._showHelpAfterError;
     this._showSuggestionAfterError = sourceCommand._showSuggestionAfterError;
+    this._await = sourceCommand._await;
 
     return this;
   }
@@ -973,6 +972,14 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   /**
+   * @api private
+   */
+
+  _shouldAwait() {
+    return this._await || (this._await === undefined && this._asyncParsing);
+  }
+
+  /**
    * @return {Promise[]}
    * @api private
    */
@@ -1019,7 +1026,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   _optionalAwait(getPromises) {
-    if (this._shouldAwait) {
+    if (this._shouldAwait()) {
       const toAwait = getPromises();
       if (toAwait.length) return Promise.all(toAwait);
     }
@@ -1374,7 +1381,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   _parseArg(target, value, previous, handleError) {
-    const handleThenableError = this._shouldAwait ? handleError : undefined;
+    const handleThenableError = this._shouldAwait() ? handleError : undefined;
 
     try {
       if (this._shouldChainArgParserCalls(target)) {
@@ -1397,11 +1404,6 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   _parseCommand(operands, unknown) {
-    // Use explicitly set await mode,
-    // or inherit await behaviour from parent,
-    // or base it on whether .parseAsync() has been called.
-    this._shouldAwait = this._await ?? this.parent?._shouldAwait ?? this._asyncParsing;
-
     let chain;
 
     const parsed = this.parseOptions(unknown);

--- a/lib/command.js
+++ b/lib/command.js
@@ -953,59 +953,6 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   /**
-   * @api private
-   */
-
-  _optionalAwait(getPromises) {
-    if (this._asyncParsing) {
-      const toAwait = getPromises();
-      if (toAwait.length) return Promise.all(toAwait);
-    }
-  }
-
-  /**
-   * @api private
-   */
-
-  _awaitThenableOptions() {
-    return this._optionalAwait(() => {
-      const chainedPromises = Object.entries(this.opts())
-        .filter(([_, value]) => isThenable(value))
-        .map(([key, thenable]) => (async() => {
-          this.setOptionValueWithSource(
-            key, await thenable, this.getOptionValueSource(key)
-          );
-        })());
-
-      const notChainedNonVariadicPromises = Object.entries(
-        this._handledNotChainedNonVariadicOptionValues
-      )
-        .map(([_, values]) => values.slice(0, -1)) // only overwritten
-        .flat()
-        .filter(isThenable)
-        .map((thenable) => (async() => {
-          await thenable;
-        })());
-
-      return chainedPromises.concat(notChainedNonVariadicPromises);
-    });
-  }
-
-  /**
-   * @api private
-   */
-
-  _awaitThenableArguments() {
-    return this._optionalAwait(() => {
-      return this.processedArgs
-        .filter(isThenable)
-        .map((thenable, i) => (async() => {
-          this.processedArgs[i] = await thenable;
-        })());
-    });
-  }
-
-  /**
    * Execute a sub-command executable.
    *
    * @api private
@@ -1372,6 +1319,59 @@ Use .parseAsync() instead.`);
     } catch (err) {
       handleError(err);
     }
+  }
+
+  /**
+   * @api private
+   */
+
+  _optionalAwait(getPromises) {
+    if (this._asyncParsing) {
+      const toAwait = getPromises();
+      if (toAwait.length) return Promise.all(toAwait);
+    }
+  }
+
+  /**
+   * @api private
+   */
+
+  _awaitThenableOptions() {
+    return this._optionalAwait(() => {
+      const chainedPromises = Object.entries(this.opts())
+        .filter(([_, value]) => isThenable(value))
+        .map(([key, thenable]) => (async() => {
+          this.setOptionValueWithSource(
+            key, await thenable, this.getOptionValueSource(key)
+          );
+        })());
+
+      const notChainedNonVariadicPromises = Object.entries(
+        this._handledNotChainedNonVariadicOptionValues
+      )
+        .map(([_, values]) => values.slice(0, -1)) // only overwritten
+        .flat()
+        .filter(isThenable)
+        .map((thenable) => (async() => {
+          await thenable;
+        })());
+
+      return chainedPromises.concat(notChainedNonVariadicPromises);
+    });
+  }
+
+  /**
+   * @api private
+   */
+
+  _awaitThenableArguments() {
+    return this._optionalAwait(() => {
+      return this.processedArgs
+        .filter(isThenable)
+        .map((thenable, i) => (async() => {
+          this.processedArgs[i] = await thenable;
+        })());
+    });
   }
 
   /**

--- a/lib/command.js
+++ b/lib/command.js
@@ -285,43 +285,6 @@ class Command extends EventEmitter {
   }
 
   /**
-   * @param {Argument|Option} target
-   * @return {boolean}
-   * @api private
-   */
-
-  _shouldChainArgParserCalls(target) {
-    return target.chained || (target.chained === undefined && this._asyncParsing);
-  }
-
-  /**
-   * Internal implementation shared by ._processArguments() and option and optionEnv event listeners.
-   *
-   * @param {Argument|Option} target
-   * @param {*} value
-   * @param {*} previous
-   * @param {Function} handleError
-   * @return {*}
-   * @api private
-   */
-
-  _parseArg(target, value, previous, handleError) {
-    const handleThenableError = this._shouldAwait ? handleError : undefined;
-
-    try {
-      if (this._shouldChainArgParserCalls(target)) {
-        return this._chainOrCall(previous, (resolvedPrevious) => (
-          parseArg(target, value, resolvedPrevious, handleThenableError)
-        ));
-      }
-
-      return parseArg(target, value, previous, handleThenableError);
-    } catch (err) {
-      handleError(err);
-    }
-  }
-
-  /**
    * Factory routine to create a new unattached argument.
    *
    * See .argument() for creating an attached argument, which uses this routine to
@@ -1410,6 +1373,43 @@ Expecting one of '${allowedValues.join("', '")}'`);
       });
     }
     return result;
+  }
+
+  /**
+   * @param {Argument|Option} target
+   * @return {boolean}
+   * @api private
+   */
+
+  _shouldChainArgParserCalls(target) {
+    return target.chained || (target.chained === undefined && this._asyncParsing);
+  }
+
+  /**
+   * Internal implementation shared by ._processArguments() and option and optionEnv event listeners.
+   *
+   * @param {Argument|Option} target
+   * @param {*} value
+   * @param {*} previous
+   * @param {Function} handleError
+   * @return {*}
+   * @api private
+   */
+
+  _parseArg(target, value, previous, handleError) {
+    const handleThenableError = this._shouldAwait ? handleError : undefined;
+
+    try {
+      if (this._shouldChainArgParserCalls(target)) {
+        return this._chainOrCall(previous, (resolvedPrevious) => (
+          parseArg(target, value, resolvedPrevious, handleThenableError)
+        ));
+      }
+
+      return parseArg(target, value, previous, handleThenableError);
+    } catch (err) {
+      handleError(err);
+    }
   }
 
   /**

--- a/lib/command.js
+++ b/lib/command.js
@@ -63,6 +63,8 @@ class Command extends EventEmitter {
     this._asyncParsing = undefined;
     /** @type {boolean | undefined} */
     this._await = undefined;
+    /** @type {boolean | undefined} */
+    this._shouldAwait = undefined;
 
     // see .configureOutput() for docs
     this._outputConfiguration = {
@@ -304,7 +306,7 @@ class Command extends EventEmitter {
    */
 
   _parseArg(target, value, previous, handleError) {
-    const handleThenableError = this._shouldAwait() ? handleError : undefined;
+    const handleThenableError = this._shouldAwait ? handleError : undefined;
 
     try {
       if (this._shouldChainArgParserCalls(target)) {
@@ -959,6 +961,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
   parse(argv, parseOptions) {
     this._asyncParsing = false;
+    this._setShouldAwait();
 
     try {
       const userArgs = this._prepareUserArgs(argv, parseOptions);
@@ -967,6 +970,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
       return this;
     } finally {
       this._asyncParsing = undefined;
+      this._shouldAwait = undefined;
     }
   }
 
@@ -991,6 +995,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
   async parseAsync(argv, parseOptions) {
     this._asyncParsing = true;
+    this._setShouldAwait();
 
     try {
       const userArgs = this._prepareUserArgs(argv, parseOptions);
@@ -999,6 +1004,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
       return this;
     } finally {
       this._asyncParsing = undefined;
+      this._shouldAwait = undefined;
     }
   }
 
@@ -1021,14 +1027,10 @@ Expecting one of '${allowedValues.join("', '")}'`);
    * @api private
    */
 
-  _shouldAwait() {
-    let shouldAwait;
-    let cmd = this;
-    do {
-      shouldAwait = cmd._await ?? cmd._asyncParsing;
-      cmd = cmd.parent;
-    } while (shouldAwait === undefined);
-    return shouldAwait;
+  _setShouldAwait() {
+    for (let cmd = this; this._shouldAwait === undefined; cmd = cmd.parent) {
+      this._shouldAwait = cmd._await ?? cmd._asyncParsing;
+    }
   }
 
   /**
@@ -1078,7 +1080,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   _optionalAwait(getPromises) {
-    if (this._shouldAwait()) {
+    if (this._shouldAwait) {
       const toAwait = getPromises();
       if (toAwait.length) return Promise.all(toAwait);
     }

--- a/lib/command.js
+++ b/lib/command.js
@@ -970,18 +970,19 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   /**
-   * @return {Promise[]}
    * @api private
    */
 
-  _getOptionResavePromises() {
-    const chainedPromises = Object.entries(this.opts())
-      .filter(([_, value]) => isThenable(value))
-      .map(([key, thenable]) => (async() => {
-        this.setOptionValueWithSource(
-          key, await thenable, this.getOptionValueSource(key)
-        );
-      })());
+  _awaitThenableOptions() {
+    const chainedPromises = this._shouldAwait()
+      ? Object.entries(this.opts())
+        .filter(([_, value]) => isThenable(value))
+        .map(([key, thenable]) => (async() => {
+          this.setOptionValueWithSource(
+            key, await thenable, this.getOptionValueSource(key)
+          );
+        })())
+      : [];
 
     const notChainedNonVariadicPromises = Object.entries(
       this._handledNotChainedNonVariadicOptionValues
@@ -996,47 +997,23 @@ Expecting one of '${allowedValues.join("', '")}'`);
         await thenable;
       })());
 
-    return chainedPromises.concat(notChainedNonVariadicPromises);
-  }
-
-  /**
-   * @return {Promise[]}
-   * @api private
-   */
-
-  _getArgumentResavePromises() {
-    return this.processedArgs
-      .filter(isThenable)
-      .map((thenable, i) => (async() => {
-        this.processedArgs[i] = await thenable;
-      })());
+    const toAwait = chainedPromises.concat(notChainedNonVariadicPromises);
+    if (toAwait.length) return Promise.all(toAwait);
   }
 
   /**
    * @api private
    */
 
-  _optionalAwait(getPromises) {
+  _awaitThenableArguments() {
     if (this._shouldAwait()) {
-      const toAwait = getPromises();
+      const toAwait = this.processedArgs
+        .filter(isThenable)
+        .map((thenable, i) => (async() => {
+          this.processedArgs[i] = await thenable;
+        })());
       if (toAwait.length) return Promise.all(toAwait);
     }
-  }
-
-  /**
-   * @api private
-   */
-
-  _awaitOptionResavePromises() {
-    return this._optionalAwait(() => this._getOptionResavePromises());
-  }
-
-  /**
-   * @api private
-   */
-
-  _awaitArgumentResavePromises() {
-    return this._optionalAwait(() => this._getArgumentResavePromises());
   }
 
   /**
@@ -1370,25 +1347,31 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   _parseArgSubroutine(target, value, previous, handleError) {
+    const chained = this._shouldChainArgParserCalls(target);
+    const notChainedNonVariadicOption = !chained
+      && target instanceof Option
+      && !target.variadic;
+
     let result = target.parseArg(value, previous);
-    if (this._shouldAwait()) {
-      const chained = this._shouldChainArgParserCalls(target);
-      const nonVariadicOption = target instanceof Option && !target.variadic;
-      let handledResult = result;
-      if (isThenable(result)) {
+    let handledResult = result;
+
+    if (isThenable(result)) {
+      if (this._shouldAwait() || notChainedNonVariadicOption) {
         handledResult = result.then(x => x, handleError);
-        if (chained) {
-          result = handledResult;
-        } // Otherwise pass original thenable to next parser call
       }
-      if (!chained && nonVariadicOption) {
-        // For variadic options and arguments, it is well-justified to assume previous thenable is handled by parser, but this cannot be assumed for non-variadic options.
-        // End user might repeat an option that is not supposed to be repeated, i.e. an option whose parser ignores the second parameter, so special non-variadic option handling is necessary.
-        const name = target.attributeName();
-        this._handledNotChainedNonVariadicOptionValues[name] ??= [];
-        this._handledNotChainedNonVariadicOptionValues[name].push(handledResult);
-      }
+      if (this._shouldAwait() && chained) {
+        result = handledResult;
+      } // otherwise pass original thenable to next parser call
     }
+
+    if (notChainedNonVariadicOption) {
+      // For variadic options and arguments, it is well-justified to assume previous thenable is handled by parser, but this cannot be assumed for non-variadic options.
+      // End user might repeat an option that is not supposed to be repeated, i.e. an option whose parser ignores the second parameter, so special overwritten option handling is necessary.
+      const name = target.attributeName();
+      this._handledNotChainedNonVariadicOptionValues[name] ??= [];
+      this._handledNotChainedNonVariadicOptionValues[name].push(handledResult);
+    }
+
     return result;
   }
 
@@ -1430,7 +1413,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     const parsed = this.parseOptions(unknown);
     this._parseOptionsEnv(); // after cli, so parseArg not called on both cli and env
     this._parseOptionsImplied();
-    chain = this._chainOrCall(chain, () => this._awaitOptionResavePromises());
+    chain = this._chainOrCall(chain, () => this._awaitThenableOptions());
 
     operands = operands.concat(parsed.operands);
     unknown = parsed.unknown;
@@ -1465,7 +1448,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
       };
       const processAndAwaitArguments = () => {
         this._processArguments();
-        chain = this._chainOrCall(chain, () => this._awaitArgumentResavePromises());
+        chain = this._chainOrCall(chain, () => this._awaitThenableArguments());
       };
 
       const commandEvent = `command:${this.name()}`;

--- a/lib/command.js
+++ b/lib/command.js
@@ -57,7 +57,8 @@ class Command extends EventEmitter {
     this._showHelpAfterError = false;
     this._showSuggestionAfterError = true;
 
-    this._overwrittenOptionValues = {};
+    /** @type {Array} */
+    this._overwrittenThenableOptionValues = [];
     /** @type {boolean | undefined} */
     this._asyncParsing = undefined;
     /** @type {boolean | undefined} */
@@ -601,13 +602,14 @@ Expecting one of '${allowedValues.join("', '")}'`);
       // custom processing
       const oldValue = this.getOptionValue(name);
       if (val !== null && option.parseArg) {
-        const optionValues = this._storeOptionsAsProperties
-          ? this
-          : this._optionValues;
-        const overwrite = name in optionValues;
-        if (overwrite) {
-          this._overwrittenOptionValues[name] ??= [];
-          this._overwrittenOptionValues[name].push(this.getOptionValue(name));
+        if (thenable(oldValue)) {
+          const optionValues = this._storeOptionsAsProperties
+            ? this
+            : this._optionValues;
+          const overwrite = name in optionValues;
+          if (overwrite) {
+            this._overwrittenThenableOptionValues.push(oldValue);
+          }
         }
         val = this._parseArg(option, val, oldValue, handleError);
       } else if (val !== null && option.variadic) {
@@ -1050,7 +1052,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   _getOptionResavePromises() {
-    const promises = [];
+    const promises = this._overwrittenThenableOptionValues.map((value) => (
+      async() => { await value; }
+    )());
 
     Object.entries(this.opts()).forEach(([key, value]) => {
       if (thenable(value)) {
@@ -1060,16 +1064,6 @@ Expecting one of '${allowedValues.join("', '")}'`);
           );
         })());
       }
-    });
-
-    Object.entries(this._overwrittenOptionValues).forEach(([key, values]) => {
-      values.forEach(value => {
-        if (thenable(value)) {
-          promises.push((async() => {
-            await value;
-          })());
-        }
-      });
     });
 
     return promises;

--- a/lib/command.js
+++ b/lib/command.js
@@ -57,6 +57,9 @@ class Command extends EventEmitter {
     this._showHelpAfterError = false;
     this._showSuggestionAfterError = true;
 
+    /** @type {boolean | undefined} */
+    this._asyncParsing = undefined;
+
     // see .configureOutput() for docs
     this._outputConfiguration = {
       writeOut: (str) => process.stdout.write(str),
@@ -273,6 +276,67 @@ class Command extends EventEmitter {
     this.commands.push(cmd);
     cmd.parent = this;
     return this;
+  }
+
+  /**
+   * @param {Argument|Option} target
+   * @return {boolean}
+   * @api private
+   */
+
+  _shouldChainArgParserCalls(target) {
+    return target.chained || (target.chained === undefined && this._asyncParsing);
+  }
+
+  /**
+   * @param {Argument|Option} target
+   * @param {*} value
+   * @param {Function} handleError
+   * @api private
+   */
+
+  _catchChainError(target, value, handleError) {
+    if (this._shouldChainArgParserCalls(target) && thenable(value)) {
+      return value.then(x => x, handleError);
+    }
+
+    return value;
+  }
+
+  /**
+   * Internal implementation shared by ._processArguments() and option and optionEnv event listeners.
+   *
+   * @param {Argument|Option} target
+   * @param {*} value
+   * @param {*} previous
+   * @param {Function} handleError
+   * @return {*}
+   * @api private
+   */
+
+  _parseArg(target, value, previous, handleError) {
+    let parsedValue;
+
+    if (this._shouldChainArgParserCalls(target) && thenable(previous)) {
+      // chain thenables
+      parsedValue = previous.then(
+        (result) => {
+          result = target.parseArg(value, result);
+          // call with result and not parsedValue to not catch handleError exception repeatedly
+          result = this._catchChainError(target, result, handleError);
+          return result;
+        }
+      );
+    } else {
+      try {
+        parsedValue = target.parseArg(value, previous);
+        parsedValue = this._catchChainError(target, parsedValue, handleError);
+      } catch (err) {
+        handleError(err);
+      }
+    }
+
+    return parsedValue;
   }
 
   /**
@@ -526,6 +590,14 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
     // handler for cli and env supplied values
     const handleOptionValue = (val, invalidValueMessage, valueSource) => {
+      const handleError = (err) => {
+        if (err?.code === 'commander.invalidArgument') {
+          const message = `${invalidValueMessage} ${err.message}`;
+          this.error(message, { exitCode: err.exitCode, code: err.code });
+        }
+        throw err;
+      };
+
       // val is null for optional option used without an optional-argument.
       // val is undefined for boolean and negated option.
       if (val == null && option.presetArg !== undefined) {
@@ -535,15 +607,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
       // custom processing
       const oldValue = this.getOptionValue(name);
       if (val !== null && option.parseArg) {
-        try {
-          val = option.parseArg(val, oldValue);
-        } catch (err) {
-          if (err.code === 'commander.invalidArgument') {
-            const message = `${invalidValueMessage} ${err.message}`;
-            this.error(message, { exitCode: err.exitCode, code: err.code });
-          }
-          throw err;
-        }
+        val = this._parseArg(option, val, oldValue, handleError);
       } else if (val !== null && option.variadic) {
         val = option._concatValue(val, oldValue);
       }
@@ -905,10 +969,16 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   parse(argv, parseOptions) {
-    const userArgs = this._prepareUserArgs(argv, parseOptions);
-    this._parseCommand([], userArgs);
+    this._asyncParsing = false;
 
-    return this;
+    try {
+      const userArgs = this._prepareUserArgs(argv, parseOptions);
+      this._parseCommand([], userArgs);
+
+      return this;
+    } finally {
+      this._asyncParsing = undefined;
+    }
   }
 
   /**
@@ -931,10 +1001,16 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   async parseAsync(argv, parseOptions) {
-    const userArgs = this._prepareUserArgs(argv, parseOptions);
-    await this._parseCommand([], userArgs);
+    this._asyncParsing = true;
 
-    return this;
+    try {
+      const userArgs = this._prepareUserArgs(argv, parseOptions);
+      await this._parseCommand([], userArgs);
+
+      return this;
+    } finally {
+      this._asyncParsing = undefined;
+    }
   }
 
   /**
@@ -1134,18 +1210,18 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
   _processArguments() {
     const myParseArg = (argument, value, previous) => {
+      const handleError = (err) => {
+        if (err?.code === 'commander.invalidArgument') {
+          const message = `error: command-argument value '${value}' is invalid for argument '${argument.name()}'. ${err.message}`;
+          this.error(message, { exitCode: err.exitCode, code: err.code });
+        }
+        throw err;
+      };
+
       // Extra processing for nice error message on parsing failure.
       let parsedValue = value;
       if (value !== null && argument.parseArg) {
-        try {
-          parsedValue = argument.parseArg(value, previous);
-        } catch (err) {
-          if (err.code === 'commander.invalidArgument') {
-            const message = `error: command-argument value '${value}' is invalid for argument '${argument.name()}'. ${err.message}`;
-            this.error(message, { exitCode: err.exitCode, code: err.code });
-          }
-          throw err;
-        }
+        parsedValue = this._parseArg(argument, value, previous, handleError);
       }
       return parsedValue;
     };

--- a/lib/command.js
+++ b/lib/command.js
@@ -57,12 +57,11 @@ class Command extends EventEmitter {
     this._showHelpAfterError = false;
     this._showSuggestionAfterError = true;
 
-    /** @type {Array} */
-    this._overwrittenThenableOptionValues = [];
     /** @type {boolean | undefined} */
     this._asyncParsing = undefined;
     /** @type {boolean | undefined} */
     this._await = undefined;
+    this._handledNotChainedNonVariadicOptionValues = {};
 
     // see .configureOutput() for docs
     this._outputConfiguration = {
@@ -551,15 +550,6 @@ Expecting one of '${allowedValues.join("', '")}'`);
       // custom processing
       const oldValue = this.getOptionValue(name);
       if (val !== null && option.parseArg) {
-        if (thenable(oldValue)) {
-          const optionValues = this._storeOptionsAsProperties
-            ? this
-            : this._optionValues;
-          const overwrite = name in optionValues;
-          if (overwrite) {
-            this._overwrittenThenableOptionValues.push(oldValue);
-          }
-        }
         val = this._parseArg(option, val, oldValue, handleError);
       } else if (val !== null && option.variadic) {
         val = option._concatValue(val, oldValue);
@@ -985,21 +975,28 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   _getOptionResavePromises() {
-    const promises = this._overwrittenThenableOptionValues.map((value) => (
-      async() => { await value; }
-    )());
+    const chainedPromises = Object.entries(this.opts())
+      .filter(([_, value]) => isThenable(value))
+      .map(([key, thenable]) => (async() => {
+        this.setOptionValueWithSource(
+          key, await thenable, this.getOptionValueSource(key)
+        );
+      })());
 
-    Object.entries(this.opts()).forEach(([key, value]) => {
-      if (thenable(value)) {
-        promises.push((async() => {
-          this.setOptionValueWithSource(
-            key, await value, this.getOptionValueSource(key)
-          );
-        })());
-      }
-    });
+    const notChainedNonVariadicPromises = Object.entries(
+      this._handledNotChainedNonVariadicOptionValues
+    )
+      .map(([_, values]) => (
+        // Only await overwritten thenables so that behaviour is consistent with how not chained non-variadic arguments are handled.
+        values.slice(0, -1)
+      ))
+      .flat()
+      .filter(isThenable)
+      .map((thenable) => (async() => {
+        await thenable;
+      })());
 
-    return promises;
+    return chainedPromises.concat(notChainedNonVariadicPromises);
   }
 
   /**
@@ -1008,17 +1005,11 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   _getArgumentResavePromises() {
-    const promises = [];
-
-    this.processedArgs.forEach((value, i) => {
-      if (thenable(value)) {
-        promises.push((async() => {
-          this.processedArgs[i] = await value;
-        })());
-      }
-    });
-
-    return promises;
+    return this.processedArgs
+      .filter(isThenable)
+      .map((thenable, i) => (async() => {
+        this.processedArgs[i] = await thenable;
+      })());
   }
 
   /**
@@ -1299,7 +1290,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   _chainOrCall(chain, fn) {
-    if (thenable(chain)) {
+    if (isThenable(chain)) {
       // already have a promise, chain callback
       return chain.then(fn);
     }
@@ -1370,6 +1361,38 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   /**
+   * @param {Argument|Option} target
+   * @param {*} value
+   * @param {*} previous
+   * @param {Function} handleError
+   * @return {*}
+   * @api private
+   */
+
+  _parseArgSubroutine(target, value, previous, handleError) {
+    let result = target.parseArg(value, previous);
+    if (this._shouldAwait()) {
+      const chained = this._shouldChainArgParserCalls(target);
+      const nonVariadicOption = target instanceof Option && !target.variadic;
+      let handledResult = result;
+      if (isThenable(result)) {
+        handledResult = result.then(x => x, handleError);
+        if (chained) {
+          result = handledResult;
+        } // Otherwise pass original thenable to next parser call
+      }
+      if (!chained && nonVariadicOption) {
+        // For variadic options and arguments, it is well-justified to assume previous thenable is handled by parser, but this cannot be assumed for non-variadic options.
+        // End user might repeat an option that is not supposed to be repeated, i.e. an option whose parser ignores the second parameter, so special non-variadic option handling is necessary.
+        const name = target.attributeName();
+        this._handledNotChainedNonVariadicOptionValues[name] ??= [];
+        this._handledNotChainedNonVariadicOptionValues[name].push(handledResult);
+      }
+    }
+    return result;
+  }
+
+  /**
    * Internal implementation shared by ._processArguments() and option and optionEnv event listeners.
    *
    * @param {Argument|Option} target
@@ -1381,16 +1404,14 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   _parseArg(target, value, previous, handleError) {
-    const handleThenableError = this._shouldAwait() ? handleError : undefined;
-
     try {
       if (this._shouldChainArgParserCalls(target)) {
         return this._chainOrCall(previous, (resolvedPrevious) => (
-          parseArg(target, value, resolvedPrevious, handleThenableError)
+          this._parseArgSubroutine(target, value, resolvedPrevious, handleError)
         ));
       }
 
-      return parseArg(target, value, previous, handleThenableError);
+      return this._parseArgSubroutine(target, value, previous, handleError);
     } catch (err) {
       handleError(err);
     }
@@ -2357,25 +2378,8 @@ function getCommandAndParents(startCommand) {
  * @api private
  */
 
-function thenable(value) {
+function isThenable(value) {
   return typeof value?.then === 'function';
-}
-
-/**
- * @param {Argument|Option} target
- * @param {*} value
- * @param {*} previous
- * @param {Function} [handleThenableError]
- * @returns {*}
- * @api private
- */
-
-function parseArg(target, value, previous, handleThenableError) {
-  let result = target.parseArg(value, previous);
-  if (handleThenableError && thenable(result)) {
-    result = result.then(x => x, handleThenableError);
-  }
-  return result;
 }
 
 exports.Command = Command;

--- a/lib/command.js
+++ b/lib/command.js
@@ -530,14 +530,6 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
     // handler for cli and env supplied values
     const handleOptionValue = (val, invalidValueMessage, valueSource) => {
-      const handleError = (err) => {
-        if (err?.code === 'commander.invalidArgument') {
-          const message = `${invalidValueMessage} ${err.message}`;
-          this.error(message, { exitCode: err.exitCode, code: err.code });
-        }
-        throw err;
-      };
-
       // val is null for optional option used without an optional-argument.
       // val is undefined for boolean and negated option.
       if (val == null && option.presetArg !== undefined) {
@@ -547,7 +539,22 @@ Expecting one of '${allowedValues.join("', '")}'`);
       // custom processing
       const oldValue = this.getOptionValue(name);
       if (val !== null && option.parseArg) {
-        val = this._parseArg(option, val, oldValue, handleError);
+        const handleError = (err) => {
+          if (err?.code === 'commander.invalidArgument') {
+            const message = `${invalidValueMessage} ${err.message}`;
+            this.error(message, { exitCode: err.exitCode, code: err.code });
+          }
+          throw err;
+        };
+        const handledResultCallback = (handledResult) => {
+          if (!option.chained && !option.variadic) {
+            // For variadic options and arguments, it is well-justified to assume previous thenable is handled by parser, but this cannot be assumed for non-variadic options.
+            // End user might repeat an option that is not supposed to be repeated, i.e. an option whose parser ignores the second parameter, so special overwritten option handling is necessary.
+            this._handledNotChainedNonVariadicOptionValues[name] ??= [];
+            this._handledNotChainedNonVariadicOptionValues[name].push(handledResult);
+          }
+        };
+        val = this._parseArg(option, val, oldValue, handleError, handledResultCallback);
       } else if (val !== null && option.variadic) {
         val = option._concatValue(val, oldValue);
       }
@@ -1196,16 +1203,15 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
   _processArguments() {
     const myParseArg = (argument, value, previous) => {
-      const handleError = (err) => {
-        if (err?.code === 'commander.invalidArgument') {
-          const message = `error: command-argument value '${value}' is invalid for argument '${argument.name()}'. ${err.message}`;
-          this.error(message, { exitCode: err.exitCode, code: err.code });
-        }
-        throw err;
-      };
-
       let parsedValue = value;
       if (value !== null && argument.parseArg) {
+        const handleError = (err) => {
+          if (err?.code === 'commander.invalidArgument') {
+            const message = `error: command-argument value '${value}' is invalid for argument '${argument.name()}'. ${err.message}`;
+            this.error(message, { exitCode: err.exitCode, code: err.code });
+          }
+          throw err;
+        };
         parsedValue = this._parseArg(argument, value, previous, handleError);
       }
       return parsedValue;
@@ -1320,13 +1326,13 @@ Use .parseAsync() instead.`);
    * @param {*} value
    * @param {*} previous
    * @param {Function} handleError
-   * @return {*}
+   * @param {Function} [handledResultCallback]
+   * @returns {*}
    * @api private
    */
 
-  _parseArgSubroutine(target, value, previous, handleError) {
+  _parseArgSubroutine(target, value, previous, handleError, handledResultCallback) {
     let result = target.parseArg(value, previous);
-
     if (this._asyncParsing) {
       let handledResult = result;
       if (isThenable(result)) {
@@ -1335,16 +1341,8 @@ Use .parseAsync() instead.`);
           result = handledResult;
         } // otherwise pass original thenable to next parser call
       }
-
-      if (target instanceof Option && !target.chained && !target.variadic) {
-        // For variadic options and arguments, it is well-justified to assume previous thenable is handled by parser, but this cannot be assumed for non-variadic options.
-        // End user might repeat an option that is not supposed to be repeated, i.e. an option whose parser ignores the second parameter, so special overwritten option handling is necessary.
-        const name = target.attributeName();
-        this._handledNotChainedNonVariadicOptionValues[name] ??= [];
-        this._handledNotChainedNonVariadicOptionValues[name].push(handledResult);
-      }
+      handledResultCallback?.(handledResult);
     }
-
     return result;
   }
 
@@ -1355,19 +1353,22 @@ Use .parseAsync() instead.`);
    * @param {*} value
    * @param {*} previous
    * @param {Function} handleError
+   * @param {Function} [handledResultCallback]
    * @return {*}
    * @api private
    */
 
-  _parseArg(target, value, previous, handleError) {
+  _parseArg(target, value, previous, handleError, handledResultCallback) {
     try {
       if (target.chained) {
         return this._chainOrCall(previous, (resolvedPrevious) => (
-          this._parseArgSubroutine(target, value, resolvedPrevious, handleError)
+          this._parseArgSubroutine(
+            target, value, resolvedPrevious, handleError, handledResultCallback
+          )
         ));
       }
 
-      return this._parseArgSubroutine(target, value, previous, handleError);
+      return this._parseArgSubroutine(...arguments);
     } catch (err) {
       handleError(err);
     }

--- a/lib/command.js
+++ b/lib/command.js
@@ -926,15 +926,10 @@ Expecting one of '${allowedValues.join("', '")}'`);
     this._asyncParsing = false;
     this._setShouldAwait();
 
-    try {
-      const userArgs = this._prepareUserArgs(argv, parseOptions);
-      this._parseCommand([], userArgs);
+    const userArgs = this._prepareUserArgs(argv, parseOptions);
+    this._parseCommand([], userArgs);
 
-      return this;
-    } finally {
-      this._asyncParsing = undefined;
-      this._shouldAwait = undefined;
-    }
+    return this;
   }
 
   /**
@@ -960,15 +955,10 @@ Expecting one of '${allowedValues.join("', '")}'`);
     this._asyncParsing = true;
     this._setShouldAwait();
 
-    try {
-      const userArgs = this._prepareUserArgs(argv, parseOptions);
-      await this._parseCommand([], userArgs);
+    const userArgs = this._prepareUserArgs(argv, parseOptions);
+    await this._parseCommand([], userArgs);
 
-      return this;
-    } finally {
-      this._asyncParsing = undefined;
-      this._shouldAwait = undefined;
-    }
+    return this;
   }
 
   /**
@@ -991,9 +981,13 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   _setShouldAwait() {
-    for (let cmd = this; this._shouldAwait === undefined; cmd = cmd.parent) {
-      this._shouldAwait = cmd._await ?? cmd._asyncParsing;
-    }
+    this._shouldAwait = undefined;
+    let cmd = this;
+    do {
+      this._shouldAwait = cmd._await;
+      cmd = cmd.parent;
+    } while (this._shouldAwait === undefined && cmd);
+    this._shouldAwait ??= this._asyncParsing;
   }
 
   /**
@@ -1199,6 +1193,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
   _dispatchSubcommand(commandName, operands, unknown) {
     const subCommand = this._findCommand(commandName);
     if (!subCommand) this.help({ error: true });
+    subCommand._asyncParsing = this._asyncParsing;
 
     let hookResult;
     hookResult = this._chainOrCallSubCommandHook(hookResult, subCommand, 'preSubcommand');

--- a/lib/command.js
+++ b/lib/command.js
@@ -1256,10 +1256,8 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
     // callback might return a promise
     chain = fn(chain);
-    if (isThenable(chain) && !this._asyncParsing) {
-      chain.then(x => x, () => {}); // prevent unhandled rejection
-      process.exitCode = 1; // additionally indicates to the user that user code (parsers, hooks, action) is not the error source
-      throw new Error(`.parse() is incompatible with async argParsers, hooks and actions.
+    if (!this._asyncParsing && isThenable(chain) && process.env.NODE_ENV !== 'production') {
+      console.warn(`.parse() is incompatible with async argParsers, hooks and actions.
 Use .parseAsync() instead.`);
     }
     return chain;

--- a/lib/command.js
+++ b/lib/command.js
@@ -1188,8 +1188,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   _chainOrCall(promise, fn) {
-    // thenable
-    if (promise && promise.then && typeof promise.then === 'function') {
+    if (thenable(promise)) {
       // already have a promise, chain callback
       return promise.then(() => fn());
     }
@@ -2191,6 +2190,16 @@ function getCommandAndParents(startCommand) {
     result.push(command);
   }
   return result;
+}
+
+/**
+ * @param {*} value
+ * @returns {boolean}
+ * @api private
+ */
+
+function thenable(value) {
+  return typeof value?.then === 'function';
 }
 
 exports.Command = Command;

--- a/lib/command.js
+++ b/lib/command.js
@@ -293,23 +293,6 @@ class Command extends EventEmitter {
   }
 
   /**
-   * @param {Argument|Option} target
-   * @param {*} value
-   * @param {*} previous
-   * @param {Function} handleError
-   * @return {*}
-   * @api private
-   */
-
-  _parseArgAgnostic(target, value, previous, handleError) {
-    let result = target.parseArg(value, previous);
-    if (this._shouldChainArgParserCalls(target) && thenable(result)) {
-      result = result.then(x => x, handleError);
-    }
-    return result;
-  }
-
-  /**
    * Internal implementation shared by ._processArguments() and option and optionEnv event listeners.
    *
    * @param {Argument|Option} target
@@ -321,14 +304,16 @@ class Command extends EventEmitter {
    */
 
   _parseArg(target, value, previous, handleError) {
+    const handleThenableError = this._shouldAwait() ? handleError : undefined;
+
     try {
       if (this._shouldChainArgParserCalls(target)) {
         return this._chainOrCall(previous, (resolvedPrevious) => (
-          this._parseArgAgnostic(target, value, resolvedPrevious, handleError)
+          parseArg(target, value, resolvedPrevious, handleThenableError)
         ));
       }
 
-      return this._parseArgAgnostic(target, value, previous, handleError);
+      return parseArg(target, value, previous, handleThenableError);
     } catch (err) {
       handleError(err);
     }
@@ -1320,7 +1305,6 @@ Expecting one of '${allowedValues.join("', '")}'`);
         throw err;
       };
 
-      // Extra processing for nice error message on parsing failure.
       let parsedValue = value;
       if (value !== null && argument.parseArg) {
         parsedValue = this._parseArg(argument, value, previous, handleError);
@@ -2389,6 +2373,23 @@ function getCommandAndParents(startCommand) {
 
 function thenable(value) {
   return typeof value?.then === 'function';
+}
+
+/**
+ * @param {Argument|Option} target
+ * @param {*} value
+ * @param {*} previous
+ * @param {Function} [handleThenableError]
+ * @returns {*}
+ * @api private
+ */
+
+function parseArg(target, value, previous, handleThenableError) {
+  let result = target.parseArg(value, previous);
+  if (handleThenableError && thenable(result)) {
+    result = result.then(x => x, handleThenableError);
+  }
+  return result;
 }
 
 exports.Command = Command;

--- a/lib/command.js
+++ b/lib/command.js
@@ -1192,6 +1192,12 @@ Use .parseAsync() instead`);
           value = myParseArg(declaredArg, value, declaredArg.defaultValue);
         }
       }
+      if (!PRODUCTION && !this._asyncParsing && isThenable(value)) {
+        console.warn(`.parse() is incompatible with ${
+          declaredArg.parseArg ? 'async argParsers' : 'thenable argument values'
+        }.
+Use .parseAsync() instead`);
+      }
       processedArgs[index] = value;
     });
     this.processedArgs = processedArgs;

--- a/lib/command.js
+++ b/lib/command.js
@@ -517,20 +517,13 @@ Expecting one of '${allowedValues.join("', '")}'`);
     const name = option.attributeName();
 
     // store default value
-    const setDefaultOptionValue = (value) => {
-      this.setOptionValueWithSource(name, value, 'default');
-      if (!PRODUCTION && !this._asyncParsing && isThenable(value)) {
-        console.warn(`.parse() is incompatible with thenable default option values.
-Use .parseAsync() instead`);
-      }
-    };
     if (option.defaultValue !== undefined || !option.negate) {
-      setDefaultOptionValue(option.defaultValue);
+      this.setOptionValueWithSource(name, option.defaultValue, 'default');
     } else {
       // --no-foo is special and defaults foo to true, unless a --foo option is already defined
       const positiveLongFlag = option.long.replace(/^--no-/, '--');
       if (!this._findOption(positiveLongFlag)) {
-        setDefaultOptionValue(true);
+        this.setOptionValueWithSource(name, true, 'default');
       }
     }
 
@@ -813,6 +806,14 @@ Use .parseAsync() instead`);
     */
 
   setOptionValueWithSource(key, value, source) {
+    if (!PRODUCTION && !this._asyncParsing && isThenable(value)) {
+        console.warn(`.parse() is incompatible with ${
+          ['cli', 'env'].includes(source)
+            ? 'async argParsers'
+            : 'thenable option values'
+        }.
+Use .parseAsync() instead`);
+    }
     if (this._storeOptionsAsProperties) {
       this[key] = value;
     } else {
@@ -1305,18 +1306,15 @@ Use .parseAsync() instead`);
 
   _parseArg(target, value, previous, handleError, handledResultCallback) {
     try {
-      const result = target.chained
-        ? this._chainOrCall(previous, (resolvedPrevious) => (
+      if (target.chained) {
+        return this._chainOrCall(previous, (resolvedPrevious) => (
           this._parseArgSubroutine(
             target, value, resolvedPrevious, handleError, handledResultCallback
           )
-        ))
-        : this._parseArgSubroutine(...arguments)
-      if (!PRODUCTION && !this._asyncParsing && isThenable(result)) {
-        console.warn(`.parse() is incompatible with async argParsers.
-Use .parseAsync() instead`);
+        ));
       }
-      return result;
+
+      return this._parseArgSubroutine(...arguments);
     } catch (err) {
       handleError(err);
     }

--- a/lib/command.js
+++ b/lib/command.js
@@ -1211,7 +1211,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     chain = fn(chain);
     if (!this._asyncParsing && isThenable(chain) && process.env.NODE_ENV !== 'production') {
       console.warn(`.parse() is incompatible with async argParsers, hooks and actions.
-Use .parseAsync() instead.`);
+Use .parseAsync() instead`);
     }
     return chain;
   }

--- a/lib/command.js
+++ b/lib/command.js
@@ -59,8 +59,6 @@ class Command extends EventEmitter {
 
     /** @type {boolean | undefined} */
     this._asyncParsing = undefined;
-    /** @type {boolean | undefined} */
-    this._await = undefined;
     this._handledNotChainedNonVariadicOptionValues = {};
 
     // see .configureOutput() for docs
@@ -111,7 +109,6 @@ class Command extends EventEmitter {
     this._enablePositionalOptions = sourceCommand._enablePositionalOptions;
     this._showHelpAfterError = sourceCommand._showHelpAfterError;
     this._showSuggestionAfterError = sourceCommand._showSuggestionAfterError;
-    this._await = sourceCommand._await;
 
     return this;
   }
@@ -949,24 +946,14 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   /**
-   * When set to `true`, thenable option and argument values will be awaited right after they are parsed and processed.
-   * When set to `undefined` (the default), inherit the behaviour from ancestor commands, or only await when `.parseAsync()` has been called.
-   * Useful for asynchronous custom processing (`parseArg`) of arguments and option-arguments.
-   *
-   * @param {boolean | undefined} [enabled]
-   * @return {Command} `this` command for chaining
-   */
-  await(enabled) {
-    this._await = enabled === undefined ? undefined : !!enabled;
-    return this;
-  }
-
-  /**
    * @api private
    */
 
-  _shouldAwait() {
-    return this._await || (this._await === undefined && this._asyncParsing);
+  _optionalAwait(getPromises) {
+    if (this._asyncParsing) {
+      const toAwait = getPromises();
+      if (toAwait.length) return Promise.all(toAwait);
+    }
   }
 
   /**
@@ -974,31 +961,27 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   _awaitThenableOptions() {
-    const chainedPromises = this._shouldAwait()
-      ? Object.entries(this.opts())
+    return this._optionalAwait(() => {
+      const chainedPromises = Object.entries(this.opts())
         .filter(([_, value]) => isThenable(value))
         .map(([key, thenable]) => (async() => {
           this.setOptionValueWithSource(
             key, await thenable, this.getOptionValueSource(key)
           );
-        })())
-      : [];
+        })());
 
-    const notChainedNonVariadicPromises = Object.entries(
-      this._handledNotChainedNonVariadicOptionValues
-    )
-      .map(([_, values]) => (
-        // Only await overwritten thenables so that behaviour is consistent with how not chained non-variadic arguments are handled.
-        values.slice(0, -1)
-      ))
-      .flat()
-      .filter(isThenable)
-      .map((thenable) => (async() => {
-        await thenable;
-      })());
+      const notChainedNonVariadicPromises = Object.entries(
+        this._handledNotChainedNonVariadicOptionValues
+      )
+        .map(([_, values]) => values.slice(0, -1)) // only overwritten
+        .flat()
+        .filter(isThenable)
+        .map((thenable) => (async() => {
+          await thenable;
+        })());
 
-    const toAwait = chainedPromises.concat(notChainedNonVariadicPromises);
-    if (toAwait.length) return Promise.all(toAwait);
+      return chainedPromises.concat(notChainedNonVariadicPromises);
+    });
   }
 
   /**
@@ -1006,14 +989,13 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   _awaitThenableArguments() {
-    if (this._shouldAwait()) {
-      const toAwait = this.processedArgs
+    return this._optionalAwait(() => {
+      return this.processedArgs
         .filter(isThenable)
         .map((thenable, i) => (async() => {
           this.processedArgs[i] = await thenable;
         })());
-      if (toAwait.length) return Promise.all(toAwait);
-    }
+    });
   }
 
   /**
@@ -1337,16 +1319,6 @@ Use .parseAsync() instead.`);
 
   /**
    * @param {Argument|Option} target
-   * @return {boolean}
-   * @api private
-   */
-
-  _shouldChainArgParserCalls(target) {
-    return target.chained || (target.chained === undefined && this._asyncParsing);
-  }
-
-  /**
-   * @param {Argument|Option} target
    * @param {*} value
    * @param {*} previous
    * @param {Function} handleError
@@ -1355,29 +1327,24 @@ Use .parseAsync() instead.`);
    */
 
   _parseArgSubroutine(target, value, previous, handleError) {
-    const chained = this._shouldChainArgParserCalls(target);
-    const notChainedNonVariadicOption = !chained &&
-      target instanceof Option &&
-      !target.variadic;
-
     let result = target.parseArg(value, previous);
-    let handledResult = result;
 
-    if (isThenable(result)) {
-      if (this._shouldAwait() || notChainedNonVariadicOption) {
+    if (this._asyncParsing) {
+      let handledResult = result;
+      if (isThenable(result)) {
         handledResult = result.then(x => x, handleError);
+        if (target.chained) {
+          result = handledResult;
+        } // otherwise pass original thenable to next parser call
       }
-      if (this._shouldAwait() && chained) {
-        result = handledResult;
-      } // otherwise pass original thenable to next parser call
-    }
 
-    if (notChainedNonVariadicOption) {
-      // For variadic options and arguments, it is well-justified to assume previous thenable is handled by parser, but this cannot be assumed for non-variadic options.
-      // End user might repeat an option that is not supposed to be repeated, i.e. an option whose parser ignores the second parameter, so special overwritten option handling is necessary.
-      const name = target.attributeName();
-      this._handledNotChainedNonVariadicOptionValues[name] ??= [];
-      this._handledNotChainedNonVariadicOptionValues[name].push(handledResult);
+      if (target instanceof Option && !target.chained && !target.variadic) {
+        // For variadic options and arguments, it is well-justified to assume previous thenable is handled by parser, but this cannot be assumed for non-variadic options.
+        // End user might repeat an option that is not supposed to be repeated, i.e. an option whose parser ignores the second parameter, so special overwritten option handling is necessary.
+        const name = target.attributeName();
+        this._handledNotChainedNonVariadicOptionValues[name] ??= [];
+        this._handledNotChainedNonVariadicOptionValues[name].push(handledResult);
+      }
     }
 
     return result;
@@ -1396,7 +1363,7 @@ Use .parseAsync() instead.`);
 
   _parseArg(target, value, previous, handleError) {
     try {
-      if (this._shouldChainArgParserCalls(target)) {
+      if (target.chained) {
         return this._chainOrCall(previous, (resolvedPrevious) => (
           this._parseArgSubroutine(target, value, resolvedPrevious, handleError)
         ));

--- a/lib/command.js
+++ b/lib/command.js
@@ -57,8 +57,11 @@ class Command extends EventEmitter {
     this._showHelpAfterError = false;
     this._showSuggestionAfterError = true;
 
+    this._overwrittenOptionValues = {};
     /** @type {boolean | undefined} */
     this._asyncParsing = undefined;
+    /** @type {boolean | undefined} */
+    this._await = undefined;
 
     // see .configureOutput() for docs
     this._outputConfiguration = {
@@ -607,6 +610,14 @@ Expecting one of '${allowedValues.join("', '")}'`);
       // custom processing
       const oldValue = this.getOptionValue(name);
       if (val !== null && option.parseArg) {
+        const optionValues = this._storeOptionsAsProperties
+          ? this
+          : this._optionValues;
+        const overwrite = name in optionValues;
+        if (overwrite) {
+          this._overwrittenOptionValues[name] ??= [];
+          this._overwrittenOptionValues[name].push(this.getOptionValue(name));
+        }
         val = this._parseArg(option, val, oldValue, handleError);
       } else if (val !== null && option.variadic) {
         val = option._concatValue(val, oldValue);
@@ -1014,6 +1025,112 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   /**
+   * When set to `true`, thenable option and argument values will be awaited right after they are parsed and processed.
+   * When set to `undefined` (the default), inherit the behaviour from ancestor commands, or only await when `.parseAsync()` has been called.
+   * Useful for asynchronous custom processing (`parseArg`) of arguments and option-arguments.
+   *
+   * @param {boolean | undefined} [enabled]
+   * @return {Command} `this` command for chaining
+   */
+  await(enabled) {
+    this._await = enabled === undefined ? undefined : !!enabled;
+    return this;
+  }
+
+  /**
+   * If `_await` is `undefined`, inherit await behaviour or base it on whether `.parseAsync()` has been called on the top-level command.
+   *
+   * @api private
+   */
+
+  _shouldAwait() {
+    let shouldAwait;
+    let cmd = this;
+    do {
+      shouldAwait = cmd._await ?? cmd._asyncParsing;
+      cmd = cmd.parent;
+    } while (shouldAwait === undefined);
+    return shouldAwait;
+  }
+
+  /**
+   * @return {Promise[]}
+   * @api private
+   */
+
+  _getOptionResavePromises() {
+    const promises = [];
+
+    Object.entries(this.opts()).forEach(([key, value]) => {
+      if (thenable(value)) {
+        promises.push((async() => {
+          this.setOptionValueWithSource(
+            key, await value, this.getOptionValueSource(key)
+          );
+        })());
+      }
+    });
+
+    Object.entries(this._overwrittenOptionValues).forEach(([key, values]) => {
+      values.forEach(value => {
+        if (thenable(value)) {
+          promises.push((async() => {
+            await value;
+          })());
+        }
+      });
+    });
+
+    return promises;
+  }
+
+  /**
+   * @return {Promise[]}
+   * @api private
+   */
+
+  _getArgumentResavePromises() {
+    const promises = [];
+
+    this.processedArgs.forEach((value, i) => {
+      if (thenable(value)) {
+        promises.push((async() => {
+          this.processedArgs[i] = await value;
+        })());
+      }
+    });
+
+    return promises;
+  }
+
+  /**
+   * @api private
+   */
+
+  _optionalAwait(getPromises) {
+    if (this._shouldAwait()) {
+      const toAwait = getPromises();
+      if (toAwait.length) return Promise.all(toAwait);
+    }
+  }
+
+  /**
+   * @api private
+   */
+
+  _awaitOptionResavePromises() {
+    return this._optionalAwait(() => this._getOptionResavePromises());
+  }
+
+  /**
+   * @api private
+   */
+
+  _awaitArgumentResavePromises() {
+    return this._optionalAwait(() => this._getArgumentResavePromises());
+  }
+
+  /**
    * Execute a sub-command executable.
    *
    * @api private
@@ -1332,81 +1449,93 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   _parseCommand(operands, unknown) {
+    let chain;
+
     const parsed = this.parseOptions(unknown);
     this._parseOptionsEnv(); // after cli, so parseArg not called on both cli and env
     this._parseOptionsImplied();
+    chain = this._chainOrCall(chain, () => this._awaitOptionResavePromises());
+
     operands = operands.concat(parsed.operands);
     unknown = parsed.unknown;
     this.args = operands.concat(unknown);
 
     if (operands && this._findCommand(operands[0])) {
-      return this._dispatchSubcommand(operands[0], operands.slice(1), unknown);
-    }
-    if (this._hasImplicitHelpCommand() && operands[0] === this._helpCommandName) {
-      return this._dispatchHelpCommand(operands[1]);
-    }
-    if (this._defaultCommandName) {
+      chain = this._chainOrCall(chain, () => this._dispatchSubcommand(
+        operands[0], operands.slice(1), unknown
+      ));
+    } else if (this._hasImplicitHelpCommand() && operands[0] === this._helpCommandName) {
+      chain = this._chainOrCall(chain, () => this._dispatchHelpCommand(operands[1]));
+    } else if (this._defaultCommandName) {
       outputHelpIfRequested(this, unknown); // Run the help for default command from parent rather than passing to default command
-      return this._dispatchSubcommand(this._defaultCommandName, operands, unknown);
-    }
-    if (this.commands.length && this.args.length === 0 && !this._actionHandler && !this._defaultCommandName) {
-      // probably missing subcommand and no handler, user needs help (and exit)
-      this.help({ error: true });
-    }
-
-    outputHelpIfRequested(this, parsed.unknown);
-    this._checkForMissingMandatoryOptions();
-    this._checkForConflictingOptions();
-
-    // We do not always call this check to avoid masking a "better" error, like unknown command.
-    const checkForUnknownOptions = () => {
-      if (parsed.unknown.length > 0) {
-        this.unknownOption(parsed.unknown[0]);
+      chain = this._chainOrCall(chain, () => this._dispatchSubcommand(
+        this._defaultCommandName, operands, unknown
+      ));
+    } else {
+      if (this.commands.length && this.args.length === 0 && !this._actionHandler && !this._defaultCommandName) {
+        // probably missing subcommand and no handler, user needs help (and exit)
+        this.help({ error: true });
       }
-    };
 
-    const commandEvent = `command:${this.name()}`;
-    if (this._actionHandler) {
-      checkForUnknownOptions();
-      this._processArguments();
+      outputHelpIfRequested(this, parsed.unknown);
+      this._checkForMissingMandatoryOptions();
+      this._checkForConflictingOptions();
 
-      let actionResult;
-      actionResult = this._chainOrCallHooks(actionResult, 'preAction');
-      actionResult = this._chainOrCall(actionResult, () => this._actionHandler(this.processedArgs));
-      if (this.parent) {
-        actionResult = this._chainOrCall(actionResult, () => {
-          this.parent.emit(commandEvent, operands, unknown); // legacy
-        });
-      }
-      actionResult = this._chainOrCallHooks(actionResult, 'postAction');
-      return actionResult;
-    }
-    if (this.parent && this.parent.listenerCount(commandEvent)) {
-      checkForUnknownOptions();
-      this._processArguments();
-      this.parent.emit(commandEvent, operands, unknown); // legacy
-    } else if (operands.length) {
-      if (this._findCommand('*')) { // legacy default command
-        return this._dispatchSubcommand('*', operands, unknown);
-      }
-      if (this.listenerCount('command:*')) {
-        // skip option check, emit event for possible misspelling suggestion
-        this.emit('command:*', operands, unknown);
-      } else if (this.commands.length) {
-        this.unknownCommand();
-      } else {
+      // We do not always call this check to avoid masking a "better" error, like unknown command.
+      const checkForUnknownOptions = () => {
+        if (parsed.unknown.length > 0) {
+          this.unknownOption(parsed.unknown[0]);
+        }
+      };
+      const processAndAwaitArguments = () => {
         checkForUnknownOptions();
         this._processArguments();
+        chain = this._chainOrCall(chain, () => this._awaitArgumentResavePromises());
+      };
+
+      const commandEvent = `command:${this.name()}`;
+      if (this._actionHandler) {
+        checkForUnknownOptions();
+        processAndAwaitArguments();
+        chain = this._chainOrCallHooks(chain, 'preAction');
+        chain = this._chainOrCall(chain, () => this._actionHandler(this.processedArgs));
+        if (this.parent) {
+          chain = this._chainOrCall(chain, () => {
+            this.parent.emit(commandEvent, operands, unknown); // legacy
+          });
+        }
+        chain = this._chainOrCallHooks(chain, 'postAction');
+      } else if (this.parent && this.parent.listenerCount(commandEvent)) {
+        checkForUnknownOptions();
+        processAndAwaitArguments();
+        chain = this._chainOrCall(chain, () => {
+          this.parent.emit(commandEvent, operands, unknown); // legacy
+        });
+      } else if (operands.length) {
+        if (this._findCommand('*')) { // legacy default command
+          return this._dispatchSubcommand('*', operands, unknown);
+        }
+        if (this.listenerCount('command:*')) {
+          // skip option check, emit event for possible misspelling suggestion
+          this.emit('command:*', operands, unknown);
+        } else if (this.commands.length) {
+          this.unknownCommand();
+        } else {
+          checkForUnknownOptions();
+          processAndAwaitArguments();
+        }
+      } else if (this.commands.length) {
+        checkForUnknownOptions();
+        // This command has subcommands and nothing hooked up at this level, so display help (and exit).
+        this.help({ error: true });
+      } else {
+        checkForUnknownOptions();
+        processAndAwaitArguments();
+        // fall through for caller to handle after calling .parse()
       }
-    } else if (this.commands.length) {
-      checkForUnknownOptions();
-      // This command has subcommands and nothing hooked up at this level, so display help (and exit).
-      this.help({ error: true });
-    } else {
-      checkForUnknownOptions();
-      this._processArguments();
-      // fall through for caller to handle after calling .parse()
     }
+
+    return chain;
   }
 
   /**

--- a/lib/command.js
+++ b/lib/command.js
@@ -12,8 +12,6 @@ const { suggestSimilar } = require('./suggestSimilar');
 
 // @ts-check
 
-const PRODUCTION = process.env.NODE_ENV === 'production';
-
 class Command extends EventEmitter {
   /**
    * Initialize a new `Command`.
@@ -806,7 +804,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     */
 
   setOptionValueWithSource(key, value, source) {
-    if (!PRODUCTION && !this._asyncParsing && isThenable(value)) {
+    if (!this._asyncParsing && isThenable(value)) {
       console.warn(`.parse() is incompatible with ${
         ['cli', 'env'].includes(source)
           ? 'async argParsers'
@@ -1192,7 +1190,7 @@ Use .parseAsync() instead`);
           value = myParseArg(declaredArg, value, declaredArg.defaultValue);
         }
       }
-      if (!PRODUCTION && !this._asyncParsing && isThenable(value)) {
+      if (!this._asyncParsing && isThenable(value)) {
         console.warn(`.parse() is incompatible with ${
           declaredArg.parseArg ? 'async argParsers' : 'thenable argument values'
         }.

--- a/lib/command.js
+++ b/lib/command.js
@@ -1348,9 +1348,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
   _parseArgSubroutine(target, value, previous, handleError) {
     const chained = this._shouldChainArgParserCalls(target);
-    const notChainedNonVariadicOption = !chained
-      && target instanceof Option
-      && !target.variadic;
+    const notChainedNonVariadicOption = !chained &&
+      target instanceof Option &&
+      !target.variadic;
 
     let result = target.parseArg(value, previous);
     let handledResult = result;

--- a/lib/command.js
+++ b/lib/command.js
@@ -294,16 +294,18 @@ class Command extends EventEmitter {
   /**
    * @param {Argument|Option} target
    * @param {*} value
+   * @param {*} previous
    * @param {Function} handleError
+   * @return {*}
    * @api private
    */
 
-  _catchChainError(target, value, handleError) {
-    if (this._shouldChainArgParserCalls(target) && thenable(value)) {
-      return value.then(x => x, handleError);
+  _parseArgAgnostic(target, value, previous, handleError) {
+    let result = target.parseArg(value, previous);
+    if (this._shouldChainArgParserCalls(target) && thenable(result)) {
+      result = result.then(x => x, handleError);
     }
-
-    return value;
+    return result;
   }
 
   /**
@@ -318,28 +320,17 @@ class Command extends EventEmitter {
    */
 
   _parseArg(target, value, previous, handleError) {
-    let parsedValue;
-
-    if (this._shouldChainArgParserCalls(target) && thenable(previous)) {
-      // chain thenables
-      parsedValue = previous.then(
-        (result) => {
-          result = target.parseArg(value, result);
-          // call with result and not parsedValue to not catch handleError exception repeatedly
-          result = this._catchChainError(target, result, handleError);
-          return result;
-        }
-      );
-    } else {
-      try {
-        parsedValue = target.parseArg(value, previous);
-        parsedValue = this._catchChainError(target, parsedValue, handleError);
-      } catch (err) {
-        handleError(err);
+    try {
+      if (this._shouldChainArgParserCalls(target)) {
+        return this._chainOrCall(previous, (resolvedPrevious) => (
+          this._parseArgAgnostic(target, value, resolvedPrevious, handleError)
+        ));
       }
-    }
 
-    return parsedValue;
+      return this._parseArgAgnostic(target, value, previous, handleError);
+    } catch (err) {
+      handleError(err);
+    }
   }
 
   /**
@@ -1374,19 +1365,19 @@ Expecting one of '${allowedValues.join("', '")}'`);
   /**
    * Once we have a promise we chain, but call synchronously until then.
    *
-   * @param {Promise|undefined} promise
+   * @param {*} chain
    * @param {Function} fn
-   * @return {Promise|undefined}
+   * @return {*}
    * @api private
    */
 
-  _chainOrCall(promise, fn) {
-    if (thenable(promise)) {
+  _chainOrCall(chain, fn) {
+    if (thenable(chain)) {
       // already have a promise, chain callback
-      return promise.then(() => fn());
+      return chain.then(fn);
     }
     // callback might return a promise
-    return fn();
+    return fn(chain);
   }
 
   /**

--- a/lib/command.js
+++ b/lib/command.js
@@ -12,6 +12,8 @@ const { suggestSimilar } = require('./suggestSimilar');
 
 // @ts-check
 
+const PRODUCTION = process.env.NODE_ENV === 'production';
+
 class Command extends EventEmitter {
   /**
    * Initialize a new `Command`.
@@ -916,10 +918,8 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   parse(argv, parseOptions) {
-    this._asyncParsing = false;
-
     const userArgs = this._prepareUserArgs(argv, parseOptions);
-    this._parseCommand([], userArgs);
+    this._parseCommand([], userArgs, false);
 
     return this;
   }
@@ -944,10 +944,8 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   async parseAsync(argv, parseOptions) {
-    this._asyncParsing = true;
-
     const userArgs = this._prepareUserArgs(argv, parseOptions);
-    await this._parseCommand([], userArgs);
+    await this._parseCommand([], userArgs, true);
 
     return this;
   }
@@ -1086,7 +1084,6 @@ Expecting one of '${allowedValues.join("', '")}'`);
   _dispatchSubcommand(commandName, operands, unknown) {
     const subCommand = this._findCommand(commandName);
     if (!subCommand) this.help({ error: true });
-    subCommand._asyncParsing = this._asyncParsing;
 
     let hookResult;
     hookResult = this._chainOrCallSubCommandHook(hookResult, subCommand, 'preSubcommand');
@@ -1094,7 +1091,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
       if (subCommand._executableHandler) {
         this._executeSubCommand(subCommand, operands.concat(unknown));
       } else {
-        return subCommand._parseCommand(operands, unknown);
+        return subCommand._parseCommand(operands, unknown, this._asyncParsing);
       }
     });
     return hookResult;
@@ -1206,14 +1203,8 @@ Expecting one of '${allowedValues.join("', '")}'`);
       // already have a promise, chain callback
       return chain.then(fn);
     }
-
     // callback might return a promise
-    chain = fn(chain);
-    if (!this._asyncParsing && isThenable(chain) && process.env.NODE_ENV !== 'production') {
-      console.warn(`.parse() is incompatible with async argParsers, hooks and actions.
-Use .parseAsync() instead`);
-    }
-    return chain;
+    return fn(chain);
   }
 
   /**
@@ -1307,15 +1298,18 @@ Use .parseAsync() instead`);
 
   _parseArg(target, value, previous, handleError, handledResultCallback) {
     try {
-      if (target.chained) {
-        return this._chainOrCall(previous, (resolvedPrevious) => (
+      const result = target.chained
+        ? this._chainOrCall(previous, (resolvedPrevious) => (
           this._parseArgSubroutine(
             target, value, resolvedPrevious, handleError, handledResultCallback
           )
-        ));
+        ))
+        : this._parseArgSubroutine(...arguments)
+      if (!PRODUCTION && !this._asyncParsing && isThenable(result)) {
+        console.warn(`.parse() is incompatible with async argParsers.
+Use .parseAsync() instead`);
       }
-
-      return this._parseArgSubroutine(...arguments);
+      return result;
     } catch (err) {
       handleError(err);
     }
@@ -1381,93 +1375,99 @@ Use .parseAsync() instead`);
    * @api private
    */
 
-  _parseCommand(operands, unknown) {
-    let chain;
+  _parseCommand(operands, unknown, async) {
+    this._asyncParsing = async;
 
-    const parsed = this.parseOptions(unknown);
-    this._parseOptionsEnv(); // after cli, so parseArg not called on both cli and env
-    this._parseOptionsImplied();
-    chain = this._chainOrCall(chain, () => this._awaitThenableOptions());
+    try {
+      let chain;
 
-    operands = operands.concat(parsed.operands);
-    unknown = parsed.unknown;
-    this.args = operands.concat(unknown);
+      const parsed = this.parseOptions(unknown);
+      this._parseOptionsEnv(); // after cli, so parseArg not called on both cli and env
+      this._parseOptionsImplied();
+      chain = this._chainOrCall(chain, () => this._awaitThenableOptions());
 
-    if (operands && this._findCommand(operands[0])) {
-      chain = this._chainOrCall(chain, () => this._dispatchSubcommand(
-        operands[0], operands.slice(1), unknown
-      ));
-    } else if (this._hasImplicitHelpCommand() && operands[0] === this._helpCommandName) {
-      chain = this._chainOrCall(chain, () => this._dispatchHelpCommand(operands[1]));
-    } else if (this._defaultCommandName) {
-      outputHelpIfRequested(this, unknown); // Run the help for default command from parent rather than passing to default command
-      chain = this._chainOrCall(chain, () => this._dispatchSubcommand(
-        this._defaultCommandName, operands, unknown
-      ));
-    } else {
-      if (this.commands.length && this.args.length === 0 && !this._actionHandler && !this._defaultCommandName) {
-        // probably missing subcommand and no handler, user needs help (and exit)
-        this.help({ error: true });
-      }
+      operands = operands.concat(parsed.operands);
+      unknown = parsed.unknown;
+      this.args = operands.concat(unknown);
 
-      outputHelpIfRequested(this, parsed.unknown);
-      this._checkForMissingMandatoryOptions();
-      this._checkForConflictingOptions();
-
-      // We do not always call this check to avoid masking a "better" error, like unknown command.
-      const checkForUnknownOptions = () => {
-        if (parsed.unknown.length > 0) {
-          this.unknownOption(parsed.unknown[0]);
+      if (operands && this._findCommand(operands[0])) {
+        chain = this._chainOrCall(chain, () => this._dispatchSubcommand(
+          operands[0], operands.slice(1), unknown
+        ));
+      } else if (this._hasImplicitHelpCommand() && operands[0] === this._helpCommandName) {
+        chain = this._chainOrCall(chain, () => this._dispatchHelpCommand(operands[1]));
+      } else if (this._defaultCommandName) {
+        outputHelpIfRequested(this, unknown); // Run the help for default command from parent rather than passing to default command
+        chain = this._chainOrCall(chain, () => this._dispatchSubcommand(
+          this._defaultCommandName, operands, unknown
+        ));
+      } else {
+        if (this.commands.length && this.args.length === 0 && !this._actionHandler && !this._defaultCommandName) {
+          // probably missing subcommand and no handler, user needs help (and exit)
+          this.help({ error: true });
         }
-      };
-      const processAndAwaitArguments = () => {
-        this._processArguments();
-        chain = this._chainOrCall(chain, () => this._awaitThenableArguments());
-      };
 
-      const commandEvent = `command:${this.name()}`;
-      if (this._actionHandler) {
-        checkForUnknownOptions();
-        processAndAwaitArguments();
-        chain = this._chainOrCallHooks(chain, 'preAction');
-        chain = this._chainOrCall(chain, () => this._actionHandler(this.processedArgs));
-        if (this.parent) {
+        outputHelpIfRequested(this, parsed.unknown);
+        this._checkForMissingMandatoryOptions();
+        this._checkForConflictingOptions();
+
+        // We do not always call this check to avoid masking a "better" error, like unknown command.
+        const checkForUnknownOptions = () => {
+          if (parsed.unknown.length > 0) {
+            this.unknownOption(parsed.unknown[0]);
+          }
+        };
+        const processAndAwaitArguments = () => {
+          this._processArguments();
+          chain = this._chainOrCall(chain, () => this._awaitThenableArguments());
+        };
+
+        const commandEvent = `command:${this.name()}`;
+        if (this._actionHandler) {
+          checkForUnknownOptions();
+          processAndAwaitArguments();
+          chain = this._chainOrCallHooks(chain, 'preAction');
+          chain = this._chainOrCall(chain, () => this._actionHandler(this.processedArgs));
+          if (this.parent) {
+            chain = this._chainOrCall(chain, () => {
+              this.parent.emit(commandEvent, operands, unknown); // legacy
+            });
+          }
+          chain = this._chainOrCallHooks(chain, 'postAction');
+        } else if (this.parent && this.parent.listenerCount(commandEvent)) {
+          checkForUnknownOptions();
+          processAndAwaitArguments();
           chain = this._chainOrCall(chain, () => {
             this.parent.emit(commandEvent, operands, unknown); // legacy
           });
-        }
-        chain = this._chainOrCallHooks(chain, 'postAction');
-      } else if (this.parent && this.parent.listenerCount(commandEvent)) {
-        checkForUnknownOptions();
-        processAndAwaitArguments();
-        chain = this._chainOrCall(chain, () => {
-          this.parent.emit(commandEvent, operands, unknown); // legacy
-        });
-      } else if (operands.length) {
-        if (this._findCommand('*')) { // legacy default command
-          return this._dispatchSubcommand('*', operands, unknown);
-        }
-        if (this.listenerCount('command:*')) {
-          // skip option check, emit event for possible misspelling suggestion
-          this.emit('command:*', operands, unknown);
+        } else if (operands.length) {
+          if (this._findCommand('*')) { // legacy default command
+            return this._dispatchSubcommand('*', operands, unknown);
+          }
+          if (this.listenerCount('command:*')) {
+            // skip option check, emit event for possible misspelling suggestion
+            this.emit('command:*', operands, unknown);
+          } else if (this.commands.length) {
+            this.unknownCommand();
+          } else {
+            checkForUnknownOptions();
+            processAndAwaitArguments();
+          }
         } else if (this.commands.length) {
-          this.unknownCommand();
+          checkForUnknownOptions();
+          // This command has subcommands and nothing hooked up at this level, so display help (and exit).
+          this.help({ error: true });
         } else {
           checkForUnknownOptions();
           processAndAwaitArguments();
+          // fall through for caller to handle after calling .parse()
         }
-      } else if (this.commands.length) {
-        checkForUnknownOptions();
-        // This command has subcommands and nothing hooked up at this level, so display help (and exit).
-        this.help({ error: true });
-      } else {
-        checkForUnknownOptions();
-        processAndAwaitArguments();
-        // fall through for caller to handle after calling .parse()
       }
-    }
 
-    return chain;
+      return chain;
+    } finally {
+      this._asyncParsing = undefined;
+    }
   }
 
   /**

--- a/lib/error.js
+++ b/lib/error.js
@@ -9,7 +9,7 @@ class CommanderError extends Error {
    * Constructs the CommanderError class
    * @param {number} exitCode suggested exit code which could be used with process.exit
    * @param {string} code an id string representing the error
-   * @param {string} message human-readable description of the error
+   * @param {string} [message] human-readable description of the error
    * @constructor
    */
   constructor(exitCode, code, message) {

--- a/lib/option.js
+++ b/lib/option.js
@@ -31,8 +31,7 @@ class Option {
     this.presetArg = undefined;
     this.envVar = undefined;
     this.parseArg = undefined;
-    /** @type {boolean | undefined} */
-    this.chained = undefined;
+    this.chained = true;
     this.hidden = false;
     this.argChoices = undefined;
     this.conflictsWith = [];
@@ -138,14 +137,13 @@ class Option {
   }
 
   /**
-   * When set to `true`, next call to the function provided via `.argParser()` will be chained to its return value if it is thenable.
-   * When set to `undefined` (the default), only chain when `.parseAsync()` has been called.
+   * When set to `true` (the default), next call to the function provided via `.argParser()` will be chained to its return value if it is thenable.
    *
-   * @param {boolean | undefined} [chained]
+   * @param {boolean} [chained=true]
    * @return {Argument}
    */
-  chainArgParserCalls(chained) {
-    this.chained = chained === undefined ? undefined : !!chained;
+  chainArgParserCalls(chained = true) {
+    this.chained = !!chained;
     return this;
   }
 

--- a/lib/option.js
+++ b/lib/option.js
@@ -138,8 +138,8 @@ class Option {
   }
 
   /**
-   * When set to true, next call to the function provided via .argParser() will be chained to its return value if it is thenable.
-   * When set to undefined (the default), only chain when .parseAsync() has been called.
+   * When set to `true`, next call to the function provided via `.argParser()` will be chained to its return value if it is thenable.
+   * When set to `undefined` (the default), only chain when `.parseAsync()` has been called.
    *
    * @param {boolean | undefined} [chained]
    * @return {Argument}

--- a/lib/option.js
+++ b/lib/option.js
@@ -31,6 +31,8 @@ class Option {
     this.presetArg = undefined;
     this.envVar = undefined;
     this.parseArg = undefined;
+    /** @type {boolean | undefined} */
+    this.chained = undefined;
     this.hidden = false;
     this.argChoices = undefined;
     this.conflictsWith = [];
@@ -132,6 +134,18 @@ class Option {
 
   argParser(fn) {
     this.parseArg = fn;
+    return this;
+  }
+
+  /**
+   * When set to true, next call to the function provided via .argParser() will be chained to its return value if it is thenable.
+   * When set to undefined (the default), only chain when .parseAsync() has been called.
+   *
+   * @param {boolean | undefined} [chained]
+   * @return {Argument}
+   */
+  chainArgParserCalls(chained) {
+    this.chained = chained === undefined ? undefined : !!chained;
     return this;
   }
 

--- a/tests/argument.chain.test.js
+++ b/tests/argument.chain.test.js
@@ -13,6 +13,12 @@ describe('Argument methods that should return this for chaining', () => {
     expect(result).toBe(argument);
   });
 
+  test('when call .chainArgParserCalls() then returns this', () => {
+    const argument = new Argument('<value>');
+    const result = argument.chainArgParserCalls();
+    expect(result).toBe(argument);
+  });
+
   test('when call .choices() then returns this', () => {
     const argument = new Argument('<value>');
     const result = argument.choices(['a']);

--- a/tests/argument.custom-processing.test.js
+++ b/tests/argument.custom-processing.test.js
@@ -206,7 +206,7 @@ test('when custom processing for argument throws plain error then not CommanderE
   expect(caughtErr).not.toBeInstanceOf(commander.CommanderError);
 });
 
-test('when custom with .chainArgParserCalls(true) then parsed to chain', async() => {
+test('when custom variadic with .chainArgParserCalls(true) then parsed to chain', async() => {
   const args = ['1', '2'];
   const resolvedValue = '12';
   const coercion = async(value, previousValue) => (

--- a/tests/argument.custom-processing.test.js
+++ b/tests/argument.custom-processing.test.js
@@ -209,17 +209,18 @@ test('when custom processing for argument throws plain error then not CommanderE
 test('when async custom variadic then parsed to chain', async() => {
   const args = ['1', '2'];
   const resolvedValue = '12';
-  const mockCoercion = jest.fn().mockImplementation(
-    async(value, previousValue) => (
-      previousValue === undefined ? value : previousValue + value
-    )
+  const coercion = async(value, previousValue) => (
+    previousValue === undefined ? value : previousValue + value
   );
+  const awaited = coercion(args[0], undefined);
+  const mockCoercion = jest.fn().mockImplementation(coercion);
 
   const program = new commander.Command();
   program
     .argument('<arg...>', 'desc', mockCoercion)
     .action(() => {});
 
-  await program.parseAsync(args, { from: 'user' });
-  expect(program.processedArgs[0]).toEqual(resolvedValue);
+  program.parseAsync(args, { from: 'user' });
+  expect(program.processedArgs[0]).toEqual(awaited);
+  await expect(program.processedArgs[0]).resolves.toEqual(resolvedValue);
 });

--- a/tests/argument.custom-processing.test.js
+++ b/tests/argument.custom-processing.test.js
@@ -205,3 +205,31 @@ test('when custom processing for argument throws plain error then not CommanderE
   expect(caughtErr).toBeInstanceOf(Error);
   expect(caughtErr).not.toBeInstanceOf(commander.CommanderError);
 });
+
+test('when custom with .chainArgParserCalls(true) then parsed to chain', async() => {
+  const args = ['1', '2'];
+  const resolvedValue = '12';
+  const coercion = async(value, previousValue) => (
+    previousValue === undefined ? value : previousValue + value
+  );
+  const awaited = coercion(args[0], undefined);
+  const mockCoercion = jest.fn().mockImplementation(coercion);
+
+  const argument = new commander.Argument('<arg...>', 'desc')
+    .argParser(mockCoercion)
+    .chainArgParserCalls(true);
+
+  let actionValue;
+
+  const program = new commander.Command();
+  program
+    .addArgument(argument)
+    .action((value) => {
+      actionValue = value;
+    });
+
+  program.parse(args, { from: 'user' });
+  expect(program.processedArgs[0]).toEqual(awaited);
+  expect(actionValue).toEqual(awaited);
+  await expect(actionValue).resolves.toEqual(resolvedValue);
+});

--- a/tests/command.argumentVariations.test.js
+++ b/tests/command.argumentVariations.test.js
@@ -9,7 +9,8 @@ test.each(getSingleArgCases('<explicit-required>'))('when add "<arg>" using %s t
     _name: 'explicit-required',
     required: true,
     variadic: false,
-    description: ''
+    description: '',
+    chained: true
   };
   expect(argument).toEqual(expectedShape);
 });
@@ -20,7 +21,8 @@ test.each(getSingleArgCases('implicit-required'))('when add "arg" using %s then 
     _name: 'implicit-required',
     required: true,
     variadic: false,
-    description: ''
+    description: '',
+    chained: true
   };
   expect(argument).toEqual(expectedShape);
 });
@@ -31,7 +33,8 @@ test.each(getSingleArgCases('[optional]'))('when add "[arg]" using %s then argum
     _name: 'optional',
     required: false,
     variadic: false,
-    description: ''
+    description: '',
+    chained: true
   };
   expect(argument).toEqual(expectedShape);
 });
@@ -42,7 +45,8 @@ test.each(getSingleArgCases('<explicit-required...>'))('when add "<arg...>" usin
     _name: 'explicit-required',
     required: true,
     variadic: true,
-    description: ''
+    description: '',
+    chained: true
   };
   expect(argument).toEqual(expectedShape);
 });
@@ -53,7 +57,8 @@ test.each(getSingleArgCases('implicit-required...'))('when add "arg..." using %s
     _name: 'implicit-required',
     required: true,
     variadic: true,
-    description: ''
+    description: '',
+    chained: true
   };
   expect(argument).toEqual(expectedShape);
 });
@@ -64,7 +69,8 @@ test.each(getSingleArgCases('[optional...]'))('when add "[arg...]" using %s then
     _name: 'optional',
     required: false,
     variadic: true,
-    description: ''
+    description: '',
+    chained: true
   };
   expect(argument).toEqual(expectedShape);
 });

--- a/tests/command.argumentVariations.test.js
+++ b/tests/command.argumentVariations.test.js
@@ -9,8 +9,7 @@ test.each(getSingleArgCases('<explicit-required>'))('when add "<arg>" using %s t
     _name: 'explicit-required',
     required: true,
     variadic: false,
-    description: '',
-    chained: undefined
+    description: ''
   };
   expect(argument).toEqual(expectedShape);
 });
@@ -21,8 +20,7 @@ test.each(getSingleArgCases('implicit-required'))('when add "arg" using %s then 
     _name: 'implicit-required',
     required: true,
     variadic: false,
-    description: '',
-    chained: undefined
+    description: ''
   };
   expect(argument).toEqual(expectedShape);
 });
@@ -33,8 +31,7 @@ test.each(getSingleArgCases('[optional]'))('when add "[arg]" using %s then argum
     _name: 'optional',
     required: false,
     variadic: false,
-    description: '',
-    chained: undefined
+    description: ''
   };
   expect(argument).toEqual(expectedShape);
 });
@@ -45,8 +42,7 @@ test.each(getSingleArgCases('<explicit-required...>'))('when add "<arg...>" usin
     _name: 'explicit-required',
     required: true,
     variadic: true,
-    description: '',
-    chained: undefined
+    description: ''
   };
   expect(argument).toEqual(expectedShape);
 });
@@ -57,8 +53,7 @@ test.each(getSingleArgCases('implicit-required...'))('when add "arg..." using %s
     _name: 'implicit-required',
     required: true,
     variadic: true,
-    description: '',
-    chained: undefined
+    description: ''
   };
   expect(argument).toEqual(expectedShape);
 });
@@ -69,8 +64,7 @@ test.each(getSingleArgCases('[optional...]'))('when add "[arg...]" using %s then
     _name: 'optional',
     required: false,
     variadic: true,
-    description: '',
-    chained: undefined
+    description: ''
   };
   expect(argument).toEqual(expectedShape);
 });

--- a/tests/command.argumentVariations.test.js
+++ b/tests/command.argumentVariations.test.js
@@ -9,7 +9,8 @@ test.each(getSingleArgCases('<explicit-required>'))('when add "<arg>" using %s t
     _name: 'explicit-required',
     required: true,
     variadic: false,
-    description: ''
+    description: '',
+    chained: undefined
   };
   expect(argument).toEqual(expectedShape);
 });
@@ -20,7 +21,8 @@ test.each(getSingleArgCases('implicit-required'))('when add "arg" using %s then 
     _name: 'implicit-required',
     required: true,
     variadic: false,
-    description: ''
+    description: '',
+    chained: undefined
   };
   expect(argument).toEqual(expectedShape);
 });
@@ -31,7 +33,8 @@ test.each(getSingleArgCases('[optional]'))('when add "[arg]" using %s then argum
     _name: 'optional',
     required: false,
     variadic: false,
-    description: ''
+    description: '',
+    chained: undefined
   };
   expect(argument).toEqual(expectedShape);
 });
@@ -42,7 +45,8 @@ test.each(getSingleArgCases('<explicit-required...>'))('when add "<arg...>" usin
     _name: 'explicit-required',
     required: true,
     variadic: true,
-    description: ''
+    description: '',
+    chained: undefined
   };
   expect(argument).toEqual(expectedShape);
 });
@@ -53,7 +57,8 @@ test.each(getSingleArgCases('implicit-required...'))('when add "arg..." using %s
     _name: 'implicit-required',
     required: true,
     variadic: true,
-    description: ''
+    description: '',
+    chained: undefined
   };
   expect(argument).toEqual(expectedShape);
 });
@@ -64,7 +69,8 @@ test.each(getSingleArgCases('[optional...]'))('when add "[arg...]" using %s then
     _name: 'optional',
     required: false,
     variadic: true,
-    description: ''
+    description: '',
+    chained: undefined
   };
   expect(argument).toEqual(expectedShape);
 });

--- a/tests/command.await.test.js
+++ b/tests/command.await.test.js
@@ -80,7 +80,7 @@ describe('await arguments', () => {
     await testWithArguments(program, args, resolvedValues, awaited);
   });
 
-  test('when variadic argument with chained asynchronous custom processing then .processedArgs and action arguments resolved from chain', async() => {
+  test('when variadic argument with asynchronous custom processing then .processedArgs and action arguments resolved from chain', async() => {
     const args = ['1', '2'];
     const resolvedValues = ['12'];
     const coercion = (value, previousValue) => {
@@ -92,13 +92,9 @@ describe('await arguments', () => {
     const awaited = [(await chainedAwaited(coercion, args)).thenable];
     const mockCoercion = jest.fn().mockImplementation(coercion);
 
-    const argument = new commander.Argument('<arg...>', 'desc')
-      .argParser(mockCoercion)
-      .chainArgParserCalls();
-
     const program = new commander.Command();
     program
-      .addArgument(argument);
+      .argument('<arg...>', 'desc', mockCoercion);
 
     await testWithArguments(program, args, resolvedValues, awaited);
   });
@@ -178,7 +174,7 @@ describe('await options', () => {
     expect(program.getOptionValueSource('b')).toEqual('implied');
   });
 
-  test('when non-variadic repeated option with chained asynchronous custom processing then .opts() resolved from chain', async() => {
+  test('when non-variadic repeated option with asynchronous custom processing then .opts() resolved from chain', async() => {
     const args = ['-a', '1', '-a', '2'];
     const resolvedValues = { a: '12' };
     const coercion = (value, previousValue) => {
@@ -194,19 +190,15 @@ describe('await options', () => {
     };
     const mockCoercion = jest.fn().mockImplementation(coercion);
 
-    const option = new commander.Option('-a [arg]', 'desc')
-      .argParser(mockCoercion)
-      .chainArgParserCalls();
-
     const program = new commander.Command();
     program
-      .addOption(option);
+      .option('-a [arg]', 'desc', mockCoercion);
 
     await testWithOptions(program, args, resolvedValues, awaited);
     expect(program.getOptionValueSource('a')).toEqual('cli');
   });
 
-  test('when variadic option with chained asynchronous custom processing then .opts() resolved from chain', async() => {
+  test('when variadic option with asynchronous custom processing then .opts() resolved from chain', async() => {
     const args = ['-a', '1', '2'];
     const resolvedValues = { a: '12' };
     const coercion = (value, previousValue) => {
@@ -222,13 +214,9 @@ describe('await options', () => {
     };
     const mockCoercion = jest.fn().mockImplementation(coercion);
 
-    const option = new commander.Option('-a <arg...>', 'desc')
-      .argParser(mockCoercion)
-      .chainArgParserCalls();
-
     const program = new commander.Command();
     program
-      .addOption(option);
+      .option('-a <arg...>', 'desc', mockCoercion);
 
     await testWithOptions(program, args, resolvedValues, awaited);
     expect(program.getOptionValueSource('a')).toEqual('cli');

--- a/tests/command.await.test.js
+++ b/tests/command.await.test.js
@@ -1,0 +1,267 @@
+/* eslint 'jest/expect-expect': [
+  'warn',
+  {
+    assertFunctionNames: ['expect', 'testWithArguments', 'testWithOptions']
+  }
+] */
+
+const commander = require('../');
+
+const makeThenable = (function() {
+  const cache = new Map();
+  return (value) => {
+    if (cache.has(value)) {
+      return cache.get(value);
+    }
+    const thenable = {
+      then: (fn) => makeThenable(fn(value))
+    };
+    cache.set(value, thenable);
+    return thenable;
+  };
+})();
+
+const chainedAwaited = async(coercion, args) => (
+  args.reduce(async(promise, v) => {
+    const { thenable } = await promise;
+    return { thenable: makeThenable(coercion(v, await thenable)) };
+  }, { thenable: makeThenable(undefined) })
+);
+
+describe('await arguments', () => {
+  async function testWithArguments(program, args, resolvedValues, awaited) {
+    let actionValues;
+    program
+      .action((...args) => {
+        actionValues = args.slice(0, resolvedValues.length);
+      });
+
+    const result = program.parseAsync(args, { from: 'user' });
+    awaited.forEach((value, i) => {
+      expect(program.processedArgs[i]).toBe(value);
+    });
+    await result;
+    expect(program.processedArgs).toEqual(resolvedValues);
+    expect(actionValues).toEqual(resolvedValues);
+  }
+
+  test('when arguments with custom processing then .processedArgs and action arguments resolved from callback', async() => {
+    const args = ['1', '2'];
+    const resolvedValues = [3, 4];
+    const awaited = [
+      makeThenable(resolvedValues[0]),
+      resolvedValues[1]
+    ];
+    const mockCoercions = awaited.map(
+      value => jest.fn().mockImplementation(() => value)
+    );
+
+    const program = new commander.Command();
+    program
+      .argument('<arg>', 'desc', mockCoercions[0])
+      .argument('[arg]', 'desc', mockCoercions[1]);
+
+    await testWithArguments(program, args, resolvedValues, awaited);
+  });
+
+  test('when arguments not specified with default values then .processedArgs and action arguments resolved from default values', async() => {
+    const args = [];
+    const resolvedValues = [1, 2];
+    const awaited = [
+      makeThenable(resolvedValues[0]),
+      resolvedValues[1]
+    ];
+
+    const program = new commander.Command();
+    program
+      .argument('[arg]', 'desc', awaited[0])
+      .argument('[arg]', 'desc', awaited[1]);
+
+    await testWithArguments(program, args, resolvedValues, awaited);
+  });
+
+  test('when variadic argument with chained asynchronous custom processing then .processedArgs and action arguments resolved from chain', async() => {
+    const args = ['1', '2'];
+    const resolvedValues = ['12'];
+    const coercion = (value, previousValue) => {
+      const coerced = previousValue === undefined
+        ? value
+        : previousValue + value;
+      return makeThenable(coerced);
+    };
+    const awaited = [(await chainedAwaited(coercion, args)).thenable];
+    const mockCoercion = jest.fn().mockImplementation(coercion);
+
+    const argument = new commander.Argument('<arg...>', 'desc')
+      .argParser(mockCoercion)
+      .chainArgParserCalls();
+
+    const program = new commander.Command();
+    program
+      .addArgument(argument);
+
+    await testWithArguments(program, args, resolvedValues, awaited);
+  });
+});
+
+describe('await options', () => {
+  async function testWithOptions(program, args, resolvedValues, awaited) {
+    program
+      .action(() => {});
+
+    const result = program.parseAsync(args, { from: 'user' });
+    Object.entries(awaited).forEach(([key, value]) => {
+      expect(program.opts()[key]).toBe(value);
+    });
+    await result;
+    expect(program.opts()).toEqual(resolvedValues);
+  }
+
+  test('when options with custom processing then .opts() resolved from callback', async() => {
+    const args = ['-a', '1', '-b', '2'];
+    const resolvedValues = { a: 3, b: 4 };
+    const awaited = {
+      a: makeThenable(resolvedValues.a),
+      b: resolvedValues.b
+    };
+    const mockCoercions = Object.entries(awaited).reduce((acc, [key, value]) => {
+      acc[key] = jest.fn().mockImplementation(() => value);
+      return acc;
+    }, {});
+
+    const program = new commander.Command();
+    program
+      .option('-a <arg>', 'desc', mockCoercions.a)
+      .option('-b [arg]', 'desc', mockCoercions.b);
+
+    await testWithOptions(program, args, resolvedValues, awaited);
+    expect(program.getOptionValueSource('a')).toEqual('cli');
+    expect(program.getOptionValueSource('b')).toEqual('cli');
+  });
+
+  test('when options not specified with default values then .opts() resolved from default values', async() => {
+    const args = [];
+    const resolvedValues = { a: 1, b: 2 };
+    const awaited = {
+      a: makeThenable(resolvedValues.a),
+      b: resolvedValues.b
+    };
+
+    const program = new commander.Command();
+    program
+      .option('-a <arg>', 'desc', awaited.a)
+      .option('-b [arg]', 'desc', awaited.b);
+
+    await testWithOptions(program, args, resolvedValues, awaited);
+    expect(program.getOptionValueSource('a')).toEqual('default');
+    expect(program.getOptionValueSource('b')).toEqual('default');
+  });
+
+  test('when implied option values then .opts() resolved from implied values', async() => {
+    const args = ['-c'];
+    const resolvedValues = { a: 1, b: 2, c: true };
+    const awaited = {
+      a: makeThenable(resolvedValues.a),
+      b: resolvedValues.b,
+      c: true
+    };
+
+    const option = new commander.Option('-c').implies(awaited);
+    const program = new commander.Command();
+    program
+      .option('-a <arg>')
+      .option('-b [arg]')
+      .addOption(option);
+
+    await testWithOptions(program, args, resolvedValues, awaited);
+    expect(program.getOptionValueSource('a')).toEqual('implied');
+    expect(program.getOptionValueSource('b')).toEqual('implied');
+  });
+
+  test('when non-variadic repeated option with chained asynchronous custom processing then .opts() resolved from chain', async() => {
+    const args = ['-a', '1', '-a', '2'];
+    const resolvedValues = { a: '12' };
+    const coercion = (value, previousValue) => {
+      const coerced = previousValue === undefined
+        ? value
+        : previousValue + value;
+      return makeThenable(coerced);
+    };
+    const awaited = {
+      a: (await chainedAwaited(
+        coercion, args.filter((_, i) => i % 2))
+      ).thenable
+    };
+    const mockCoercion = jest.fn().mockImplementation(coercion);
+
+    const option = new commander.Option('-a [arg]', 'desc')
+      .argParser(mockCoercion)
+      .chainArgParserCalls();
+
+    const program = new commander.Command();
+    program
+      .addOption(option);
+
+    await testWithOptions(program, args, resolvedValues, awaited);
+    expect(program.getOptionValueSource('a')).toEqual('cli');
+  });
+
+  test('when variadic option with chained asynchronous custom processing then .opts() resolved from chain', async() => {
+    const args = ['-a', '1', '2'];
+    const resolvedValues = { a: '12' };
+    const coercion = (value, previousValue) => {
+      const coerced = previousValue === undefined
+        ? value
+        : previousValue + value;
+      return makeThenable(coerced);
+    };
+    const awaited = {
+      a: (await chainedAwaited(
+        coercion, args.slice(1))
+      ).thenable
+    };
+    const mockCoercion = jest.fn().mockImplementation(coercion);
+
+    const option = new commander.Option('-a <arg...>', 'desc')
+      .argParser(mockCoercion)
+      .chainArgParserCalls();
+
+    const program = new commander.Command();
+    program
+      .addOption(option);
+
+    await testWithOptions(program, args, resolvedValues, awaited);
+    expect(program.getOptionValueSource('a')).toEqual('cli');
+  });
+
+  test('when subcommand and options with custom processing then global .opts() resolved from callback before local option-argument parser is called', async() => {
+    const arr = [];
+
+    const coercion = (value) => {
+      return new Promise((resolve) => {
+        setImmediate(() => {
+          arr.push(value);
+          resolve(value);
+        });
+      });
+    };
+    const mockCoercion = jest.fn().mockImplementation(coercion);
+
+    const syncCoercion = (value) => {
+      arr.push(value);
+      return value;
+    };
+    const mockSyncCoercion = jest.fn().mockImplementation(syncCoercion);
+
+    const program = new commander.Command();
+    program
+      .option('-a <arg>', 'desc', mockCoercion)
+      .command('subcommand')
+      .option('-b <arg>', 'desc', mockSyncCoercion)
+      .action(() => {});
+
+    const args = ['-a', '1', 'subcommand', '-b', '2'];
+    await program.parseAsync(args, { from: 'user' });
+    expect(arr).toEqual(['1', '2']);
+  });
+});

--- a/tests/command.chain.test.js
+++ b/tests/command.chain.test.js
@@ -166,12 +166,6 @@ describe('Command methods that should return this for chaining', () => {
     expect(result).toBe(program);
   });
 
-  test('when call .await() then returns this', () => {
-    const program = new Command();
-    const result = program.await();
-    expect(result).toBe(program);
-  });
-
   test('when call .hook() then returns this', () => {
     const program = new Command();
     const result = program.hook('preAction', () => {});

--- a/tests/command.chain.test.js
+++ b/tests/command.chain.test.js
@@ -166,6 +166,12 @@ describe('Command methods that should return this for chaining', () => {
     expect(result).toBe(program);
   });
 
+  test('when call .await() then returns this', () => {
+    const program = new Command();
+    const result = program.await();
+    expect(result).toBe(program);
+  });
+
   test('when call .hook() then returns this', () => {
     const program = new Command();
     const result = program.hook('preAction', () => {});

--- a/tests/command.parse.test.js
+++ b/tests/command.parse.test.js
@@ -95,7 +95,7 @@ describe('return type', () => {
           return value;
         }
 
-        const error = new Error();
+        const error = {}; // not Error so that unhandled promise rejections are properly reported
         errors.push(error);
         const promise = Promise.reject(error);
         promises.push(promise);
@@ -179,7 +179,7 @@ describe('return type', () => {
       caught = value;
     }
 
-    expect(errors[0]).toBe(caught);
+    expect(caught).toBe(errors[0]);
     expect(mockCoercion).toHaveBeenCalledTimes(3);
   });
 });

--- a/tests/option.chain.test.js
+++ b/tests/option.chain.test.js
@@ -13,6 +13,12 @@ describe('Option methods that should return this for chaining', () => {
     expect(result).toBe(option);
   });
 
+  test('when call .chainArgParserCalls() then returns this', () => {
+    const option = new Option('-e,--example <value>');
+    const result = option.chainArgParserCalls();
+    expect(result).toBe(option);
+  });
+
   test('when call .makeOptionMandatory() then returns this', () => {
     const option = new Option('-e,--example <value>');
     const result = option.makeOptionMandatory();

--- a/tests/options.custom-processing.test.js
+++ b/tests/options.custom-processing.test.js
@@ -139,3 +139,49 @@ test('when commaSeparatedList x,y,z then value is [x, y, z]', () => {
   program.parse(['node', 'test', '--list', 'x,y,z']);
   expect(program.opts().list).toEqual(['x', 'y', 'z']);
 });
+
+test('when custom non-variadic repeated with .chainArgParserCalls(true) then parsed to chain', async() => {
+  const args = ['-a', '1', '-a', '2'];
+  const resolvedValue = '12';
+  const coercion = async(value, previousValue) => (
+    previousValue === undefined ? value : previousValue + value
+  );
+  const awaited = coercion(args[1], undefined);
+  const mockCoercion = jest.fn().mockImplementation(coercion);
+
+  const option = new commander.Option('-a <arg...>', 'desc')
+    .argParser(mockCoercion)
+    .chainArgParserCalls(true);
+
+  const program = new commander.Command();
+  program
+    .addOption(option)
+    .action(() => {});
+
+  program.parse(args, { from: 'user' });
+  expect(program.opts()).toEqual({ a: awaited });
+  await expect(program.opts().a).resolves.toEqual(resolvedValue);
+});
+
+test('when custom variadic with .chainArgParserCalls(true) then parsed to chain', async() => {
+  const args = ['-a', '1', '2'];
+  const resolvedValue = '12';
+  const coercion = async(value, previousValue) => (
+    previousValue === undefined ? value : previousValue + value
+  );
+  const awaited = coercion(args[1], undefined);
+  const mockCoercion = jest.fn().mockImplementation(coercion);
+
+  const option = new commander.Option('-a <arg...>', 'desc')
+    .argParser(mockCoercion)
+    .chainArgParserCalls(true);
+
+  const program = new commander.Command();
+  program
+    .addOption(option)
+    .action(() => {});
+
+  program.parse(args, { from: 'user' });
+  expect(program.opts()).toEqual({ a: awaited });
+  await expect(program.opts().a).resolves.toEqual(resolvedValue);
+});

--- a/tests/options.custom-processing.test.js
+++ b/tests/options.custom-processing.test.js
@@ -143,35 +143,37 @@ test('when commaSeparatedList x,y,z then value is [x, y, z]', () => {
 test('when async custom non-variadic repeated then parsed to chain', async() => {
   const args = ['-a', '1', '-a', '2'];
   const resolvedValue = '12';
-  const mockCoercion = jest.fn().mockImplementation(
-    async(value, previousValue) => (
-      previousValue === undefined ? value : previousValue + value
-    )
+  const coercion = async(value, previousValue) => (
+    previousValue === undefined ? value : previousValue + value
   );
+  const awaited = coercion(args[1], undefined);
+  const mockCoercion = jest.fn().mockImplementation(coercion);
 
   const program = new commander.Command();
   program
     .option('-a <arg...>', 'desc', mockCoercion)
     .action(() => {});
 
-  await program.parseAsync(args, { from: 'user' });
-  expect(program.opts().a).toEqual(resolvedValue);
+  program.parseAsync(args, { from: 'user' });
+  expect(program.opts()).toEqual({ a: awaited });
+  await expect(program.opts().a).resolves.toEqual(resolvedValue);
 });
 
 test('when async custom variadic then parsed to chain', async() => {
   const args = ['-a', '1', '2'];
   const resolvedValue = '12';
-  const mockCoercion = jest.fn().mockImplementation(
-    async(value, previousValue) => (
-      previousValue === undefined ? value : previousValue + value
-    )
+  const coercion = async(value, previousValue) => (
+    previousValue === undefined ? value : previousValue + value
   );
+  const awaited = coercion(args[1], undefined);
+  const mockCoercion = jest.fn().mockImplementation(coercion);
 
   const program = new commander.Command();
   program
     .option('-a <arg...>', 'desc', mockCoercion)
     .action(() => {});
 
-  await program.parseAsync(args, { from: 'user' });
-  expect(program.opts().a).toEqual(resolvedValue);
+  program.parseAsync(args, { from: 'user' });
+  expect(program.opts()).toEqual({ a: awaited });
+  await expect(program.opts().a).resolves.toEqual(resolvedValue);
 });

--- a/tests/options.custom-processing.test.js
+++ b/tests/options.custom-processing.test.js
@@ -140,48 +140,38 @@ test('when commaSeparatedList x,y,z then value is [x, y, z]', () => {
   expect(program.opts().list).toEqual(['x', 'y', 'z']);
 });
 
-test('when custom non-variadic repeated with .chainArgParserCalls(true) then parsed to chain', async() => {
+test('when async custom non-variadic repeated then parsed to chain', async() => {
   const args = ['-a', '1', '-a', '2'];
   const resolvedValue = '12';
-  const coercion = async(value, previousValue) => (
-    previousValue === undefined ? value : previousValue + value
+  const mockCoercion = jest.fn().mockImplementation(
+    async(value, previousValue) => (
+      previousValue === undefined ? value : previousValue + value
+    )
   );
-  const awaited = coercion(args[1], undefined);
-  const mockCoercion = jest.fn().mockImplementation(coercion);
-
-  const option = new commander.Option('-a <arg...>', 'desc')
-    .argParser(mockCoercion)
-    .chainArgParserCalls(true);
 
   const program = new commander.Command();
   program
-    .addOption(option)
+    .option('-a <arg...>', 'desc', mockCoercion)
     .action(() => {});
 
-  program.parse(args, { from: 'user' });
-  expect(program.opts()).toEqual({ a: awaited });
-  await expect(program.opts().a).resolves.toEqual(resolvedValue);
+  await program.parseAsync(args, { from: 'user' });
+  expect(program.opts().a).toEqual(resolvedValue);
 });
 
-test('when custom variadic with .chainArgParserCalls(true) then parsed to chain', async() => {
+test('when async custom variadic then parsed to chain', async() => {
   const args = ['-a', '1', '2'];
   const resolvedValue = '12';
-  const coercion = async(value, previousValue) => (
-    previousValue === undefined ? value : previousValue + value
+  const mockCoercion = jest.fn().mockImplementation(
+    async(value, previousValue) => (
+      previousValue === undefined ? value : previousValue + value
+    )
   );
-  const awaited = coercion(args[1], undefined);
-  const mockCoercion = jest.fn().mockImplementation(coercion);
-
-  const option = new commander.Option('-a <arg...>', 'desc')
-    .argParser(mockCoercion)
-    .chainArgParserCalls(true);
 
   const program = new commander.Command();
   program
-    .addOption(option)
+    .option('-a <arg...>', 'desc', mockCoercion)
     .action(() => {});
 
-  program.parse(args, { from: 'user' });
-  expect(program.opts()).toEqual({ a: awaited });
-  await expect(program.opts().a).resolves.toEqual(resolvedValue);
+  await program.parseAsync(args, { from: 'user' });
+  expect(program.opts().a).toEqual(resolvedValue);
 });

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -66,10 +66,9 @@ export class Argument {
   argParser<T>(fn: (value: string, previous: T) => T): this;
 
   /**
-   * When set to `true`, next call to the function provided via `.argParser()` will be chained to its return value if it is thenable.
-   * When set to `undefined` (the default), only chain when `.parseAsync()` has been called.
+   * When set to `true` (the default), next call to the function provided via `.argParser()` will be chained to its return value if it is thenable.
    */
-  chainArgParserCalls(chained?: boolean | undefined): this;
+  chainArgParserCalls(chained?: boolean): this;
 
   /**
    * Only allow argument value to be one of choices.
@@ -166,10 +165,9 @@ export class Option {
   argParser<T>(fn: (value: string, previous: T) => T): this;
 
   /**
-   * When set to `true`, next call to the function provided via `.argParser()` will be chained to its return value if it is thenable.
-   * When set to `undefined` (the default), only chain when `.parseAsync()` has been called.
+   * When set to `true` (the default), next call to the function provided via `.argParser()` will be chained to its return value if it is thenable.
    */
-  chainArgParserCalls(chained?: boolean | undefined): this;
+  chainArgParserCalls(chained?: boolean): this;
 
   /**
    * Whether the option is mandatory and must have a value after parsing.
@@ -703,13 +701,6 @@ export class Command {
    * @returns Promise
    */
   parseAsync(argv?: readonly string[], options?: ParseOptions): Promise<this>;
-
-  /**
-   * When set to `true`, thenable option and argument values will be awaited right after they are parsed and processed.
-   * When set to `undefined` (the default), inherit the behaviour from ancestor commands, or only await when `.parseAsync()` has been called.
-   * Useful for asynchronous custom processing (`parseArg`) of arguments and option-arguments.
-   */
-  await(enabled?: boolean | undefined): this;
 
   /**
    * Parse options from `argv` removing known options,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -66,6 +66,12 @@ export class Argument {
   argParser<T>(fn: (value: string, previous: T) => T): this;
 
   /**
+   * When set to true, next call to the function provided via .argParser() will be chained to its return value if it is thenable.
+   * When set to undefined (the default), only chain when .parseAsync() has been called.
+   */
+  chainArgParserCalls(chained?: boolean | undefined): this;
+
+  /**
    * Only allow argument value to be one of choices.
    */
   choices(values: readonly string[]): this;
@@ -158,6 +164,12 @@ export class Option {
    * Set the custom handler for processing CLI option arguments into option values.
    */
   argParser<T>(fn: (value: string, previous: T) => T): this;
+
+  /**
+   * When set to true, next call to the function provided via .argParser() will be chained to its return value if it is thenable.
+   * When set to undefined (the default), only chain when .parseAsync() has been called.
+   */
+  chainArgParserCalls(chained?: boolean | undefined): this;
 
   /**
    * Whether the option is mandatory and must have a value after parsing.

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -705,6 +705,13 @@ export class Command {
   parseAsync(argv?: readonly string[], options?: ParseOptions): Promise<this>;
 
   /**
+   * When set to `true`, thenable option and argument values will be awaited right after they are parsed and processed.
+   * When set to `undefined` (the default), inherit the behaviour from ancestor commands, or only await when `.parseAsync()` has been called.
+   * Useful for asynchronous custom processing (`parseArg`) of arguments and option-arguments.
+   */
+  await(enabled?: boolean | undefined): this;
+
+  /**
    * Parse options from `argv` removing known options,
    * and return argv split into operands and unknown arguments.
    *

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -66,8 +66,8 @@ export class Argument {
   argParser<T>(fn: (value: string, previous: T) => T): this;
 
   /**
-   * When set to true, next call to the function provided via .argParser() will be chained to its return value if it is thenable.
-   * When set to undefined (the default), only chain when .parseAsync() has been called.
+   * When set to `true`, next call to the function provided via `.argParser()` will be chained to its return value if it is thenable.
+   * When set to `undefined` (the default), only chain when `.parseAsync()` has been called.
    */
   chainArgParserCalls(chained?: boolean | undefined): this;
 
@@ -166,8 +166,8 @@ export class Option {
   argParser<T>(fn: (value: string, previous: T) => T): this;
 
   /**
-   * When set to true, next call to the function provided via .argParser() will be chained to its return value if it is thenable.
-   * When set to undefined (the default), only chain when .parseAsync() has been called.
+   * When set to `true`, next call to the function provided via `.argParser()` will be chained to its return value if it is thenable.
+   * When set to `undefined` (the default), only chain when `.parseAsync()` has been called.
    */
   chainArgParserCalls(chained?: boolean | undefined): this;
 

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -214,6 +214,12 @@ expectType<Promise<commander.Command>>(program.parseAsync(['node', 'script.js'],
 expectType<Promise<commander.Command>>(program.parseAsync(['--option'], { from: 'user' }));
 expectType<Promise<commander.Command>>(program.parseAsync(['node', 'script.js'] as const));
 
+// await
+expectType<commander.Command>(program.await());
+expectType<commander.Command>(program.await(true));
+expectType<commander.Command>(program.await(false));
+expectType<commander.Command>(program.await(undefined));
+
 // parseOptions (and ParseOptionsResult)
 expectType<{ operands: string[]; unknown: string[] }>(program.parseOptions(['node', 'script.js', 'hello']));
 

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -214,12 +214,6 @@ expectType<Promise<commander.Command>>(program.parseAsync(['node', 'script.js'],
 expectType<Promise<commander.Command>>(program.parseAsync(['--option'], { from: 'user' }));
 expectType<Promise<commander.Command>>(program.parseAsync(['node', 'script.js'] as const));
 
-// await
-expectType<commander.Command>(program.await());
-expectType<commander.Command>(program.await(true));
-expectType<commander.Command>(program.await(false));
-expectType<commander.Command>(program.await(undefined));
-
 // parseOptions (and ParseOptionsResult)
 expectType<{ operands: string[]; unknown: string[] }>(program.parseOptions(['node', 'script.js', 'hello']));
 
@@ -428,7 +422,6 @@ expectType<commander.Option>(baseOption.argParser((value: string, previous: stri
 expectType<commander.Option>(baseOption.chainArgParserCalls());
 expectType<commander.Option>(baseOption.chainArgParserCalls(true));
 expectType<commander.Option>(baseOption.chainArgParserCalls(false));
-expectType<commander.Option>(baseOption.chainArgParserCalls(undefined));
 
 // makeOptionMandatory
 expectType<commander.Option>(baseOption.makeOptionMandatory());
@@ -482,7 +475,6 @@ expectType<commander.Argument>(baseArgument.argParser((value: string, previous: 
 expectType<commander.Argument>(baseArgument.chainArgParserCalls());
 expectType<commander.Argument>(baseArgument.chainArgParserCalls(true));
 expectType<commander.Argument>(baseArgument.chainArgParserCalls(false));
-expectType<commander.Argument>(baseArgument.chainArgParserCalls(undefined));
 
 // choices
 expectType<commander.Argument>(baseArgument.choices(['a', 'b']));

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -418,6 +418,12 @@ expectType<string>(baseOption.fullDescription());
 expectType<commander.Option>(baseOption.argParser((value: string) => parseInt(value)));
 expectType<commander.Option>(baseOption.argParser((value: string, previous: string[]) => { return previous.concat(value); }));
 
+// chainArgParserCalls
+expectType<commander.Option>(baseOption.chainArgParserCalls());
+expectType<commander.Option>(baseOption.chainArgParserCalls(true));
+expectType<commander.Option>(baseOption.chainArgParserCalls(false));
+expectType<commander.Option>(baseOption.chainArgParserCalls(undefined));
+
 // makeOptionMandatory
 expectType<commander.Option>(baseOption.makeOptionMandatory());
 expectType<commander.Option>(baseOption.makeOptionMandatory(true));
@@ -465,6 +471,12 @@ expectType<commander.Argument>(baseArgument.default(60, 'one minute'));
 // argParser
 expectType<commander.Argument>(baseArgument.argParser((value: string) => parseInt(value)));
 expectType<commander.Argument>(baseArgument.argParser((value: string, previous: string[]) => { return previous.concat(value); }));
+
+// chainArgParserCalls
+expectType<commander.Argument>(baseArgument.chainArgParserCalls());
+expectType<commander.Argument>(baseArgument.chainArgParserCalls(true));
+expectType<commander.Argument>(baseArgument.chainArgParserCalls(false));
+expectType<commander.Argument>(baseArgument.chainArgParserCalls(undefined));
 
 // choices
 expectType<commander.Argument>(baseArgument.choices(['a', 'b']));


### PR DESCRIPTION
This is a rework of #1902 not relying on the hook infrastructure and not introducing `postArguments` hooks, i.e. all simplifications from [this comment](https://github.com/tj/commander.js/pull/1902#issuecomment-1647767306) have been implemented.

## Changes summary

### ChangeLog

#### Added
- `Option.chainArgParserCalls()` and `Argument.chainArgParserCalls()` to control whether to chain `parseArg` calls
- warnings about thenable option and argument values in `.parse()` calls, including default and implied values and ones returned from async argParsers, with a suggestion to use `.parseAsync()` instead (shown unless `process.env.NODE_ENV === 'production'`)

#### Changed
- _Breaking:_ chain `parseArg` calls by default when `.parseAsync()` is called
- _Breaking:_ await thenable option and argument values when `.parseAsync()` is called

### Configuration details

#### `Option.chainArgParserCalls()` / `Argument.chainArgParserCalls()`
- When set to `true` (the default), next call to the function provided via `.argParser()` will be chained to its return value if it is thenable.

### New life cycle description

The processing starts with an array of args. Each command processes and removes the options it understands, and passes the remaining args to the next subcommand. The final command calls the action handler.

Starting with top-level command (program):

* _process options for this command (includes calling or chaining provided argParsers[^1])_
  * _recognised options from args_
  * _options based on environment variables_
* set implied option values (for this command)
* _remove recognised options from args_
* _await thenable option values if parsing with `parseAsync()`_
* if the first arg is a subcommand
  * call _or chain_ `preSubcommand` hooks[^1]
  * pass remaining arguments to subcommand, and process same way

Once reach final (leaf) command:

* check for missing mandatory options
* check for conflicting options
* check for unknown options
* process remaining args as command-arguments _(includes calling or chaining provided argParsers[^1])_
* _await thenable argument values if parsing with `parseAsync()`_
* _if an action handler is provided_
  * call _or chain_ `preAction` hooks[^1]
  * call _or chain_ action handler[^1]
  * call _or chain_ `postAction` hooks[^1]
</details>

[^1]: _output a warning suggesting use of `parseAsync()` when parsing with `parse()` and a thenable is returned, unless `process.env.NODE_ENV === 'production'`_

## Some explanations

<h3 id="why-enable-for-parse-async-by-default">Why enable chaining and awaiting for <code>parseAsync()</code> by default?</h3>

A good question, especially because this introduces breaking changes. The decision is motivated by the fact it is most logical for the following code snippets to produce the same results:

```js
program
  .option('--fail', 'desc', () => {
    throw 'exception';
  })
  .argument('[args...]', 'desc', (value, previous) => (
    previous === undefined ? value : previous + value
  ))
  .action(processed => {
    console.log(processed);
  });

program.parse(['1', '2'], { from: 'user' });

try {
  program.parse(['--fail'], { from: 'user' });
} catch (err) {
  console.log('caught', err);
}
```

```js
program
  .option('--fail', 'desc', async() => {
    throw 'exception';
  })
  .argument('[args...]', 'desc', async(value, previous) => (
    previous === undefined ? value : previous + value
  ))
  .action(processed => {
    console.log(processed);
  });

await program.parseAsync(['1', '2'], { from: 'user' });

try {
  await program.parseAsync(['--fail'], { from: 'user' });
} catch (err) {
  console.log('caught', err);
}
```

Without chaining, a promise resolving to `'[object Promise]2'` is logged from inside the action instead of `12` when running the second snippet.

Without awaiting, an unhandled promise rejection is reported instead of logging `caught exception` when running the second snippet.

### Why not enable chaining and awaiting for `parse()`?

- To make the changes as "non-breaking" as possible (although they will be breaking anyway).

  There might be production code like the one in the original example in #1900 somewhere. By not enabling awaiting for `parse()` by default, we make sure this code still works after the upgrade.

- Chaining and awaiting in `parse()` introduces the risk of unhandled promise rejections, so they should not be enabled unless the user explicitly requests it.

### Why is `chainArgParserCalls()` necessary?

- The need for the default `true` mode is motivated [here](https://github.com/tj/commander.js/pull/1902#issuecomment-1626863946) and in the [Why enable chaining and awaiting for `parseAsync()` by default?](#user-content-why-enable-for-parse-async-by-default) section.
- The need for the `false` mode is motivated [here](https://github.com/tj/commander.js/pull/1902#issuecomment-1623993097).

### Why store and await overwritten option values?

An end user might repeat an option even if it is not supposed to be repeated, i.e. if the parser ignores the old value supplied to it in the second parameter. If `chainArgParserCalls(false)` had been called on the option, this can result in unhandled promise rejections if overwritten option values are not awaited.

### Why pass `handleError` to `_parseArg()` and not just the error message for invalid argument errors?

It seems to be more or less an arbitrary design decision to give invalid argument errors thrown from option-argument and command-argument parsers the same `.code` values (`'commander.invalidArgument'`). They could just as well be different, or there could theoretically be other specially handled errors specific only to option-argument parsers or only to command-argument parsers, so it just does not seem right for `_parseArg()` to take over the error handling.

### Why use the word "await" and not "settle"?

To settle a promise means to fulfill or to reject it. That happens internally in the promise callback, an observer can only _await_ the promise.

## Peer PRs

### …solving similar problems
- #1917 (introduces warnings for async hook and action calls in `parse()` in addition to the warnings for async argParser calls introduced here)

### Warnings need to be consistent with…
- #1917
- #1931
- #1938
- #1940

### Requires changes when merged with…
- #1955

## See also
- #1913 ([differences](https://github.com/tj/commander.js/pull/1915#issuecomment-1655478510))