### PR TITLE
React to wrong library usage

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -546,8 +546,6 @@ subcommand is specified ([example](./examples/defaultCommand.js)).
 
 You can add alternative names for a command with `.alias()`. ([example](./examples/alias.js))
 
-`.command()` automatically copies the inherited settings from the parent command to the newly created subcommand. This is only done during creation, any later setting changes to the parent are not inherited.
-
 For safety, `.addCommand()` does not automatically copy the inherited settings from the parent command. There is a helper routine `.copyInheritedSettings()` for copying the settings when they are wanted.
 
 ### Command-arguments

--- a/Readme.md
+++ b/Readme.md
@@ -546,6 +546,8 @@ subcommand is specified ([example](./examples/defaultCommand.js)).
 
 You can add alternative names for a command with `.alias()`. ([example](./examples/alias.js))
 
+Commands added with `.command()` automatically inherit settings for which inheritance is meaningful from the parent command, but only upon the subcommand creation. The setting changes made after calling `.command()` are not inherited.
+
 For safety, `.addCommand()` does not automatically copy the inherited settings from the parent command. There is a helper routine `.copyInheritedSettings()` for copying the settings when they are wanted.
 
 ### Command-arguments

--- a/Readme.md
+++ b/Readme.md
@@ -546,7 +546,7 @@ subcommand is specified ([example](./examples/defaultCommand.js)).
 
 You can add alternative names for a command with `.alias()`. ([example](./examples/alias.js))
 
-Commands added with `.command()` automatically inherit settings for which inheritance is meaningful from the parent command, but only upon the subcommand creation. The setting changes made after calling `.command()` are not inherited.
+`.command()` automatically copies the inherited settings from the parent command to the newly created subcommand. This is only done during creation, any later setting changes to the parent are not inherited.
 
 For safety, `.addCommand()` does not automatically copy the inherited settings from the parent command. There is a helper routine `.copyInheritedSettings()` for copying the settings when they are wanted.
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -1229,7 +1229,7 @@ Call on top-level command instead`);
     // callback might return a promise
     const result = fn();
     if (!PRODUCTION && !this._asyncParsing && isThenable(result)) {
-      console.warn(`.parse() is incompatible with async argParsers, hooks and actions.
+      console.warn(`.parse() is incompatible with async hooks and actions.
 Use .parseAsync() instead.`);
     }
     return result;

--- a/lib/command.js
+++ b/lib/command.js
@@ -12,6 +12,8 @@ const { suggestSimilar } = require('./suggestSimilar');
 
 // @ts-check
 
+const PRODUCTION = process.env.NODE_ENV === 'production';
+
 class Command extends EventEmitter {
   /**
    * Initialize a new `Command`.
@@ -77,6 +79,9 @@ class Command extends EventEmitter {
     this._helpCommandnameAndArgs = 'help [command]';
     this._helpCommandDescription = 'display help for command';
     this._helpConfiguration = {};
+
+    /** @type {boolean | undefined} */
+    this._asyncParsing = undefined;
   }
 
   /**
@@ -264,6 +269,10 @@ class Command extends EventEmitter {
     if (!cmd._name) {
       throw new Error(`Command passed to .addCommand() must have a name
 - specify the name in Command constructor or using .name()`);
+    }
+    if (cmd.parent) {
+      throw new Error(`'${cmd._name}' cannot be added using .addCommand()
+- it already has a parent command`);
     }
 
     opts = opts || {};
@@ -888,6 +897,28 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   /**
+   * @param {boolean} async
+   * @param {Function} userArgsCallback
+   * @param {string[]} [argv]
+   * @param {Object} [parseOptions]
+   * @param {string} [parseOptions.from]
+   * @return {Command|Promise}
+   * @api private
+   */
+
+  _parseSubroutine(async, userArgsCallback, argv, parseOptions) {
+    this._asyncParsing = async;
+    const methodName = async ? 'parseAsync' : 'parse';
+    if (!PRODUCTION && this.parent) {
+      console.warn(`Called .${methodName}() on subcommand '${this._name}'.
+Call on top-level command instead`);
+    }
+
+    const userArgs = this._prepareUserArgs(argv, parseOptions);
+    return userArgsCallback(userArgs);
+  }
+
+  /**
    * Parse `argv`, setting options and invoking commands when defined.
    *
    * The default expectation is that the arguments are from node and have the application as argv[0]
@@ -905,10 +936,10 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   parse(argv, parseOptions) {
-    const userArgs = this._prepareUserArgs(argv, parseOptions);
-    this._parseCommand([], userArgs);
-
-    return this;
+    return this._parseSubroutine(false, (userArgs) => {
+      this._parseCommand([], userArgs);
+      return this;
+    }, argv, parseOptions);
   }
 
   /**
@@ -931,10 +962,10 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   async parseAsync(argv, parseOptions) {
-    const userArgs = this._prepareUserArgs(argv, parseOptions);
-    await this._parseCommand([], userArgs);
-
-    return this;
+    return this._parseSubroutine(true, async(userArgs) => {
+      await this._parseCommand([], userArgs);
+      return this;
+    }, argv, parseOptions);
   }
 
   /**
@@ -1071,6 +1102,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
   _dispatchSubcommand(commandName, operands, unknown) {
     const subCommand = this._findCommand(commandName);
     if (!subCommand) this.help({ error: true });
+    subCommand._asyncParsing = this._asyncParsing;
 
     let hookResult;
     hookResult = this._chainOrCallSubCommandHook(hookResult, subCommand, 'preSubcommand');
@@ -1189,12 +1221,18 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
   _chainOrCall(promise, fn) {
     // thenable
-    if (promise && promise.then && typeof promise.then === 'function') {
+    if (isThenable(promise)) {
       // already have a promise, chain callback
       return promise.then(() => fn());
     }
+
     // callback might return a promise
-    return fn();
+    const result = fn();
+    if (!PRODUCTION && !this._asyncParsing && isThenable(result)) {
+      console.warn(`.parse() is incompatible with async argParsers, hooks and actions.
+Use .parseAsync() instead.`);
+    }
+    return result;
   }
 
   /**
@@ -2191,6 +2229,16 @@ function getCommandAndParents(startCommand) {
     result.push(command);
   }
   return result;
+}
+
+/**
+ * @param {*} value
+ * @returns {boolean}
+ * @api private
+ */
+
+function isThenable(value) {
+  return typeof value?.then === 'function';
 }
 
 exports.Command = Command;

--- a/lib/command.js
+++ b/lib/command.js
@@ -937,7 +937,11 @@ Call on top-level command instead`);
 
   parse(argv, parseOptions) {
     return this._parseSubroutine(false, (userArgs) => {
-      this._parseCommand([], userArgs);
+      const result = this._parseCommand([], userArgs);
+      if (!PRODUCTION && isThenable(result)) {
+      console.warn(`.parse() is incompatible with async hooks and actions.
+Use .parseAsync() instead.`);
+      }
       return this;
     }, argv, parseOptions);
   }
@@ -1220,19 +1224,12 @@ Call on top-level command instead`);
    */
 
   _chainOrCall(promise, fn) {
-    // thenable
     if (isThenable(promise)) {
       // already have a promise, chain callback
       return promise.then(() => fn());
     }
-
     // callback might return a promise
-    const result = fn();
-    if (!PRODUCTION && !this._asyncParsing && isThenable(result)) {
-      console.warn(`.parse() is incompatible with async hooks and actions.
-Use .parseAsync() instead.`);
-    }
-    return result;
+    return fn();
   }
 
   /**

--- a/lib/command.js
+++ b/lib/command.js
@@ -271,8 +271,8 @@ class Command extends EventEmitter {
 - specify the name in Command constructor or using .name()`);
     }
     if (cmd.parent) {
-      throw new Error(`'${cmd._name}' cannot be added using .addCommand()
-- it already has a parent command`);
+      throw new Error(`Command '${cmd.name()}' passed to .addCommand() already has a parent
+- subcommands cannot be shared`);
     }
 
     opts = opts || {};

--- a/lib/command.js
+++ b/lib/command.js
@@ -12,8 +12,6 @@ const { suggestSimilar } = require('./suggestSimilar');
 
 // @ts-check
 
-const PRODUCTION = process.env.NODE_ENV === 'production';
-
 class Command extends EventEmitter {
   /**
    * Initialize a new `Command`.
@@ -905,7 +903,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
   _parseSubroutine(async, userArgsCallback, argv, parseOptions) {
     const methodName = async ? 'parseAsync' : 'parse';
-    if (!PRODUCTION && this.parent) {
+    if (this.parent) {
       console.warn(`Called .${methodName}() on subcommand '${this._name}'.
 Call on top-level command instead`);
     }
@@ -934,7 +932,7 @@ Call on top-level command instead`);
   parse(argv, parseOptions) {
     return this._parseSubroutine(false, (userArgs) => {
       const result = this._parseCommand([], userArgs);
-      if (!PRODUCTION && isThenable(result)) {
+      if (isThenable(result)) {
         console.warn(`.parse() is incompatible with async hooks and actions.
 Use .parseAsync() instead.`);
       }

--- a/lib/command.js
+++ b/lib/command.js
@@ -79,9 +79,6 @@ class Command extends EventEmitter {
     this._helpCommandnameAndArgs = 'help [command]';
     this._helpCommandDescription = 'display help for command';
     this._helpConfiguration = {};
-
-    /** @type {boolean | undefined} */
-    this._asyncParsing = undefined;
   }
 
   /**
@@ -907,7 +904,6 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   _parseSubroutine(async, userArgsCallback, argv, parseOptions) {
-    this._asyncParsing = async;
     const methodName = async ? 'parseAsync' : 'parse';
     if (!PRODUCTION && this.parent) {
       console.warn(`Called .${methodName}() on subcommand '${this._name}'.
@@ -939,7 +935,7 @@ Call on top-level command instead`);
     return this._parseSubroutine(false, (userArgs) => {
       const result = this._parseCommand([], userArgs);
       if (!PRODUCTION && isThenable(result)) {
-      console.warn(`.parse() is incompatible with async hooks and actions.
+        console.warn(`.parse() is incompatible with async hooks and actions.
 Use .parseAsync() instead.`);
       }
       return this;
@@ -1106,7 +1102,6 @@ Use .parseAsync() instead.`);
   _dispatchSubcommand(commandName, operands, unknown) {
     const subCommand = this._findCommand(commandName);
     if (!subCommand) this.help({ error: true });
-    subCommand._asyncParsing = this._asyncParsing;
 
     let hookResult;
     hookResult = this._chainOrCallSubCommandHook(hookResult, subCommand, 'preSubcommand');


### PR DESCRIPTION
___Update:___ Ideally, this PR should be superseded by #1938 and #1940. See [comment](https://github.com/tj/commander.js/pull/1917#issuecomment-1666467716) for details.

Partially fixes #1916. I think it is a good idea to react to wrong library uses even if they have not been featured in many issues.

#### Why `console.warn()` and not throw from within `parse()` / `parseAsync()`?

Errors thrown from `parse()` / `parseAsync()` are expected to have originated in user-supplied code (argParsers, hooks, actions).

An alternative could be to `console.error()` and `process.exit()` with a non-zero exit code, effectively forbidding all wrong usage, but what I don't like is the discrepancy between this approach and how all other library errors are simply thrown and can be handled by the user.

## ChangeLog

### Added
- _Breaking:_ throw an error when trying to add a subcommand that already has a parent command
- warnings about parse calls on subcommands
- warnings about async hook and action calls made in `.parse()`

## Peer PRs

### Warnings need to be consistent with…
- #1915
- #1931
- #1938
- #1940

### Parse call subroutine (`_parseSubroutine()`) needs to be consistent with…
- #1919

### Incompatible with…
- #1955: parse methods shall never be called on subcommands, so if warnings about such calls are added, the JSDoc and the ChangeLog entry for `.suppressWarnings()` introduced there become incorrect. The fact there is currently no well-defined meaning for such calls is one of the reasons why [#1938](https://github.com/tj/commander.js/pull/1938) and [#1940](https://github.com/tj/commander.js/pull/1940) should be preferred over this PR ([#1917](https://github.com/tj/commander.js/pull/1917))!