### PR TITLE
Clean up state from previous parse call when calling `parse()` / `parseAsync()`

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -10,12 +10,6 @@ const { Help } = require('./help.js');
 const { Option, splitOptionFlags, DualOptions } = require('./option.js');
 const { suggestSimilar } = require('./suggestSimilar');
 
-/**
- * TypeScript import types for JSDoc, used by Visual Studio Code IntelliSense and `npm run typescript-checkJS`
- * https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#import-types
- * @typedef { import('../typings').OptionValueSource } OptionValueSource
- */
-
 // @ts-check
 
 class Command extends EventEmitter {
@@ -797,8 +791,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   setOptionValue(key, value) {
-    this._setPersistentOptionValueWithSource(key, value);
-    return this;
+    return this.setOptionValueWithSource(key, value);
   }
 
   /**
@@ -806,7 +799,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     *
     * @param {string} key
     * @param {Object} value
-    * @param {'config'} source
+    * @param {string} [source]
     * @return {Command} `this` command for chaining
     */
 
@@ -818,7 +811,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
   /**
     * @param {string} key
     * @param {Object} value
-    * @param {'default' | 'config'} [source]
+    * @param {string} [source]
     * @api private
     */
 
@@ -831,7 +824,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
   /**
     * @param {string} key
     * @param {Object} value
-    * @param {OptionValueSource} [source]
+    * @param {string} [source]
     * @api private
     */
 
@@ -849,7 +842,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     * Expected values are default | config | env | cli | implied
     *
     * @param {string} key
-    * @return {OptionValueSource | undefined}
+    * @return {string | undefined}
     */
 
   getOptionValueSource(key) {
@@ -861,7 +854,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     * Expected values are default | config | env | cli | implied
     *
     * @param {string} key
-    * @return {OptionValueSource | undefined}
+    * @return {string | undefined}
     */
 
   getOptionValueSourceWithGlobals(key) {

--- a/lib/command.js
+++ b/lib/command.js
@@ -12,7 +12,71 @@ const { suggestSimilar } = require('./suggestSimilar');
 
 // @ts-check
 
-class Command extends EventEmitter {
+class CommandBase extends EventEmitter {
+  constructor() {
+    super();
+
+    // The proxy only treats keys not present in the instance and its prototype chain as keys for _optionValues when _storeOptionsAsProperties is set to true.
+    // Setting option values for keys present in the instance and its prototype chain is still possible by calling .setOptionValue() or .setOptionValueWithSource(),
+    // but such values will not be accessible as instance properties because the instance and its prototype chain have precedence.
+    // However, they will be accessible via .getOptionValue(), .opts() and .optsWithGlobals().
+    return new Proxy(this, {
+      get(target, key, receiver) {
+        if (target._storeOptionsAsProperties && !(key in target)) {
+          target = receiver = receiver._optionValues;
+        }
+        return Reflect.get(target, key, receiver);
+      },
+      set(target, key, value, receiver) {
+        if (target._storeOptionsAsProperties && !(key in target)) {
+          target = receiver = receiver._optionValues;
+        }
+        return Reflect.set(target, key, value, receiver);
+      },
+      has(target, key) {
+        if (target._storeOptionsAsProperties && !(key in target)) {
+          target = target._optionValues;
+        }
+        return Reflect.has(target, key);
+      },
+      deleteProperty(target, key) {
+        if (target._storeOptionsAsProperties && !(key in target)) {
+          target = target._optionValues;
+        }
+        return Reflect.deleteProperty(target, key);
+      },
+      defineProperty(target, key, descriptor) {
+        if (target._storeOptionsAsProperties && !(key in target)) {
+          target = target._optionValues;
+        }
+        return Reflect.defineProperty(target, key, descriptor);
+      },
+      getOwnPropertyDescriptor(target, key) {
+        if (target._storeOptionsAsProperties && !(key in target)) {
+          target = target._optionValues;
+        }
+        return Reflect.getOwnPropertyDescriptor(target, key);
+      },
+      ownKeys(target) {
+        const result = Reflect.ownKeys(target);
+        if (target._storeOptionsAsProperties) {
+          result.push(...Reflect.ownKeys(target._optionValues).filter(
+            key => !(result.includes(key)) // remove duplicates
+          ));
+        }
+        return result;
+      },
+      preventExtensions(target) {
+        if (target._storeOptionsAsProperties) {
+          Reflect.preventExtensions(target._optionValues);
+        }
+        return Reflect.preventExtensions(target);
+      }
+    });
+  }
+}
+
+class Command extends CommandBase {
   /**
    * Initialize a new `Command`.
    *
@@ -70,6 +134,12 @@ class Command extends EventEmitter {
     this._helpCommandDescription = 'display help for command';
     this._helpConfiguration = {};
 
+    // Because of how the proxy returned from the CommandBase constructor works in order to support options-as-properties,
+    // all instance properties have to be defined when _storeOptionsAsProperties is set to false.
+    // Ideally, that should happen as soon as in the constructor, even if it seems unnecessary because the initial values are undefined like here.
+    this._version = undefined;
+    this._versionOptionName = undefined;
+
     this._unprocessedName = name || '';
     this._persistentOptionValues = {};
     this._persistentOptionValueSources = {};
@@ -77,67 +147,6 @@ class Command extends EventEmitter {
 
     /** @type {boolean | undefined} */
     this._asyncParsing = undefined;
-
-    // Because of how the returned proxy works, ideally, no prooerties should be defined outside the cinstructor.
-    // They can still be defined outside the constructor in subclasses, but only when _storeOptionsAsProperties is set to false.
-    this._version = undefined;
-    this._versionOptionName = undefined;
-
-    // The proxy only treats keys not present in the instance and its prototype chain as keys for _optionValues when _storeOptionsAsProperties is set to true.
-    // Setting option values for keys present in the instance and its prototype chain is still possible by calling .setOptionValue() or .setOptionValueWithSource(),
-    // but such values will not be accessible as instnace properties because the instance and its prototype chain has precedence.
-    // However, they will be accessible via .getOptionValue(), .opts() and .optsWithGlobals().
-    return new Proxy(this, {
-      get(target, key, receiver) {
-        if (target._storeOptionsAsProperties && !(key in target)) {
-          target = receiver = receiver._optionValues;
-        }
-        return Reflect.get(target, key, receiver);
-      },
-      set(target, key, value, receiver) {
-        if (target._storeOptionsAsProperties && !(key in target)) {
-          target = receiver = receiver._optionValues;
-        }
-        return Reflect.set(target, key, value, receiver);
-      },
-      has(target, key) {
-        if (target._storeOptionsAsProperties && !(key in target)) {
-          target = target._optionValues;
-        }
-        return Reflect.has(target, key);
-      },
-      deleteProperty(target, key) {
-        if (target._storeOptionsAsProperties && !(key in target)) {
-          target = target._optionValues;
-        }
-        return Reflect.deleteProperty(target, key);
-      },
-      defineProperty(target, key, descriptor) {
-        if (target._storeOptionsAsProperties && !(key in target)) {
-          target = target._optionValues;
-        }
-        return Reflect.defineProperty(target, key, descriptor);
-      },
-      getOwnPropertyDescriptor(target, key) {
-        if (target._storeOptionsAsProperties && !(key in target)) {
-          target = target._optionValues;
-        }
-        return Reflect.getOwnPropertyDescriptor(target, key);
-      },
-      ownKeys(target) {
-        const result = Reflect.ownKeys(target);
-        if (target._storeOptionsAsProperties) {
-          result.push(...Reflect.ownKeys(target._optionValues));
-        }
-        return result;
-      },
-      preventExtensions(target) {
-        if (target._storeOptionsAsProperties) {
-          Reflect.preventExtensions(target._optionValues);
-        }
-        return Reflect.preventExtensions(target);
-      }
-    });
   }
 
   resetParseState() {

--- a/lib/command.js
+++ b/lib/command.js
@@ -810,7 +810,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     const set = this._asyncParsing === undefined
       ? this._setPersistentOptionValueWithSource
       : this._setNonPersistentOptionValueWithSource;
-    set(key, value, source);
+    set.call(this, key, value, source);
     return this;
   }
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -569,7 +569,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
           val = ''; // not normal, parseArg might have failed or be a mock function for testing
         }
       }
-      this.setOptionValueWithSource(name, val, valueSource);
+      this._setNonPersistentOptionValueWithSource(name, val, valueSource);
     };
 
     this.on('option:' + oname, (val) => {
@@ -799,11 +799,26 @@ Expecting one of '${allowedValues.join("', '")}'`);
     *
     * @param {string} key
     * @param {Object} value
-    * @param {string} source - expected values are default/config/env/cli/implied
+    * @param {string} source - expected values are default/config
     * @return {Command} `this` command for chaining
     */
 
   setOptionValueWithSource(key, value, source) {
+    this._setNonPersistentOptionValueWithSource(key, value, source);
+    this._persistentOptionValues[key] = value;
+    this._persistentOptionValueSources[key] = source;
+    return this;
+  }
+
+  /**
+    * @param {string} key
+    * @param {Object} value
+    * @param {string} source - expected values are default/config/env/cli/implied
+    * @return {Command} `this` command for chaining
+    * @api private
+    */
+
+  _setNonPersistentOptionValueWithSource(key, value, source) {
     if (this._storeOptionsAsProperties) {
       this[key] = value;
     } else {
@@ -811,13 +826,8 @@ Expecting one of '${allowedValues.join("', '")}'`);
     }
     this._optionValueSources[key] = source;
 
-    if (!(['cli', 'env', 'implied'].includes(source))) {
-      this._persistentOptionValues[key] = value;
-      this._persistentOptionValueSources[key] = source;
-    } else {
-      delete this._persistentOptionValues[key];
-      delete this._persistentOptionValueSources[key];
-    }
+    delete this._persistentOptionValues[key];
+    delete this._persistentOptionValueSources[key];
 
     return this;
   }
@@ -1686,7 +1696,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
         Object.keys(option.implied)
           .filter(impliedKey => !hasCustomOptionValue(impliedKey))
           .forEach(impliedKey => {
-            this.setOptionValueWithSource(impliedKey, option.implied[impliedKey], 'implied');
+            this._setNonPersistentOptionValueWithSource(
+              impliedKey, option.implied[impliedKey], 'implied'
+            );
           });
       });
   }

--- a/lib/command.js
+++ b/lib/command.js
@@ -10,6 +10,12 @@ const { Help } = require('./help.js');
 const { Option, splitOptionFlags, DualOptions } = require('./option.js');
 const { suggestSimilar } = require('./suggestSimilar');
 
+/**
+ * TypeScript import types for JSDoc, used by Visual Studio Code IntelliSense and `npm run typescript-checkJS`
+ * https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#import-types
+ * @typedef { import('../typings').OptionValueSource } OptionValueSource
+ */
+
 // @ts-check
 
 class Command extends EventEmitter {
@@ -791,7 +797,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   setOptionValue(key, value) {
-    return this.setOptionValueWithSource(key, value, undefined);
+    return this.setOptionValueWithSource(key, value);
   }
 
   /**
@@ -799,22 +805,34 @@ Expecting one of '${allowedValues.join("', '")}'`);
     *
     * @param {string} key
     * @param {Object} value
-    * @param {string} source - expected values are default/config
+    * @param {'config'} [source]
     * @return {Command} `this` command for chaining
     */
 
   setOptionValueWithSource(key, value, source) {
+    this._setPersistentOptionValueWithSource(key, value, source);
+    return this;
+  }
+
+  /**
+    * Store option value and where the value came from.
+    *
+    * @param {string} key
+    * @param {Object} value
+    * @param {'default' | 'config'} [source]
+    * @api private
+    */
+
+  _setPersistentOptionValueWithSource(key, value, source) {
     this._setNonPersistentOptionValueWithSource(key, value, source);
     this._persistentOptionValues[key] = value;
     this._persistentOptionValueSources[key] = source;
-    return this;
   }
 
   /**
     * @param {string} key
     * @param {Object} value
-    * @param {string} source - expected values are default/config/env/cli/implied
-    * @return {Command} `this` command for chaining
+    * @param {OptionValueSource} [source]
     * @api private
     */
 
@@ -828,8 +846,6 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
     delete this._persistentOptionValues[key];
     delete this._persistentOptionValueSources[key];
-
-    return this;
   }
 
   /**
@@ -837,7 +853,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     * Expected values are default | config | env | cli | implied
     *
     * @param {string} key
-    * @return {string}
+    * @return {OptionValueSource | undefined}
     */
 
   getOptionValueSource(key) {
@@ -849,7 +865,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     * Expected values are default | config | env | cli | implied
     *
     * @param {string} key
-    * @return {string}
+    * @return {OptionValueSource | undefined}
     */
 
   getOptionValueSourceWithGlobals(key) {

--- a/lib/command.js
+++ b/lib/command.js
@@ -1135,7 +1135,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
       if (subCommand._executableHandler) {
         this._executeSubCommand(subCommand, operands.concat(unknown));
       } else {
-        return subCommand._parseCommand(operands, unknown);
+        return subCommand._parseCommand(operands, unknown, this._asyncParsing);
       }
     });
     return hookResult;

--- a/lib/command.js
+++ b/lib/command.js
@@ -532,10 +532,10 @@ Expecting one of '${allowedValues.join("', '")}'`);
       // --no-foo is special and defaults foo to true, unless a --foo option is already defined
       const positiveLongFlag = option.long.replace(/^--no-/, '--');
       if (!this._findOption(positiveLongFlag)) {
-        this.setOptionValueWithSource(name, option.defaultValue === undefined ? true : option.defaultValue, 'default');
+        this._setPersistentOptionValueWithSource(name, option.defaultValue === undefined ? true : option.defaultValue, 'default');
       }
     } else if (option.defaultValue !== undefined) {
-      this.setOptionValueWithSource(name, option.defaultValue, 'default');
+      this._setPersistentOptionValueWithSource(name, option.defaultValue, 'default');
     }
 
     // register the option

--- a/lib/command.js
+++ b/lib/command.js
@@ -83,10 +83,10 @@ class Command extends EventEmitter {
     this._version = undefined;
     this._versionOptionName = undefined;
 
-    // The proxy only treats keys not present in the instance's prototype chain as keys for _optionValues when _storeOptionsAsProperties is set to true.
-    // Setting option values for keys present in the prototype chain is still possible by calling .setOptionValue() or .setOptionValueWithSource(),
-    // but such values will not be accessible as instnace properties because the prototype chain has precedence.
-    // However, they will be accessible via .getOptionValue().
+    // The proxy only treats keys not present in the instance and its prototype chain as keys for _optionValues when _storeOptionsAsProperties is set to true.
+    // Setting option values for keys present in the instance and its prototype chain is still possible by calling .setOptionValue() or .setOptionValueWithSource(),
+    // but such values will not be accessible as instnace properties because the instance and its prototype chain has precedence.
+    // However, they will be accessible via .getOptionValue(), .opts() and .optsWithGlobals().
     return new Proxy(this, {
       get(target, key, receiver) {
         if (target._storeOptionsAsProperties && !(key in target)) {
@@ -1680,7 +1680,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
       for (let i = 0; i < len; i++) {
         const key = this.options[i].attributeName();
-        result[key] = key === this._versionOptionName ? this._version : this[key];
+        result[key] = key === this._versionOptionName
+          ? this._version
+          : this._optionValues[key];
       }
       return result;
     }

--- a/lib/command.js
+++ b/lib/command.js
@@ -77,6 +77,66 @@ class Command extends EventEmitter {
 
     /** @type {boolean | undefined} */
     this._asyncParsing = undefined;
+
+    // Because of how the returned proxy works, ideally, no prooerties should be defined outside the cinstructor.
+    // They can still be defined outside the constructor in subclasses, but only when _storeOptionsAsProperties is set to false.
+    this._version = undefined;
+    this._versionOptionName = undefined;
+
+    // The proxy only treats keys not present in the instance's prototype chain as keys for _optionValues when _storeOptionsAsProperties is set to true.
+    // Setting option values for keys present in the prototype chain is still possible by calling .setOptionValue() or .setOptionValueWithSource(),
+    // but such values will not be accessible as instnace properties because the prototype chain has precedence.
+    return new Proxy(this, {
+      get(target, key, receiver) {
+        if (target._storeOptionsAsProperties && !(key in target)) {
+          target = receiver = receiver._optionValues;
+        }
+        return Reflect.get(target, key, receiver);
+      },
+      set(target, key, value, receiver) {
+        if (target._storeOptionsAsProperties && !(key in target)) {
+          target = receiver = receiver._optionValues;
+        }
+        return Reflect.set(target, property, value, receiver);
+      },
+      has(target, key) {
+        if (target._storeOptionsAsProperties && !(key in target)) {
+          target = target._optionValues;
+        }
+        return Reflect.has(target, key);
+      },
+      deleteProperty(target, key) {
+        if (target._storeOptionsAsProperties && !(key in target)) {
+          target = target._optionValues;
+        }
+        return Reflect.deleteProperty(target, key);
+      },
+      defineProperty(target, key, descriptor) {
+        if (target._storeOptionsAsProperties && !(key in target)) {
+          target = target._optionValues;
+        }
+        return Reflect.defineProperty(target, key, descriptor);
+      },
+      getOwnPropertyDescriptor(target, key) {
+        if (target._storeOptionsAsProperties && !(key in target)) {
+          target = target._optionValues;
+        }
+        return Reflect.getOwnPropertyDescriptor(target, key);
+      },
+      ownKeys(target) {
+        const result = Reflect.ownKeys(target);
+        if (target._storeOptionsAsProperties) {
+          result.push(...Reflect.ownKeys(target._optionValues));
+        }
+        return result;
+      },
+      preventExtensions(target) {
+        if (target._storeOptionsAsProperties) {
+          Reflect.preventExtensions(target._optionValues);
+        }
+        return Reflect.preventExtensions(target);
+      }
+    });
   }
 
   resetParseState() {
@@ -779,9 +839,6 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   getOptionValue(key) {
-    if (this._storeOptionsAsProperties) {
-      return this[key];
-    }
     return this._optionValues[key];
   }
 
@@ -835,11 +892,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     */
 
   _setNonPersistentOptionValueWithSource(key, value, source) {
-    if (this._storeOptionsAsProperties) {
-      this[key] = value;
-    } else {
-      this._optionValues[key] = value;
-    }
+    this._optionValues[key] = value;
     this._optionValueSources[key] = source;
   }
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -30,14 +30,6 @@ class Command extends EventEmitter {
     this._allowExcessArguments = true;
     /** @type {Argument[]} */
     this._args = [];
-    /** @type {string[]} */
-    this.args = []; // cli args with options removed
-    this.rawArgs = [];
-    this.processedArgs = []; // like .args but after custom processing and collecting variadic
-    this._scriptPath = null;
-    this._name = name || '';
-    this._optionValues = {};
-    this._optionValueSources = {}; // default, env, cli etc
     this._storeOptionsAsProperties = false;
     this._actionHandler = null;
     this._executableHandler = false;
@@ -77,6 +69,25 @@ class Command extends EventEmitter {
     this._helpCommandnameAndArgs = 'help [command]';
     this._helpCommandDescription = 'display help for command';
     this._helpConfiguration = {};
+
+    this._unprocessedName = name || '';
+    this._persistentOptionValues = {};
+    this._persistentOptionValueSources = {};
+    this.resetParseState();
+  }
+
+  resetParseState() {
+    /** @type {string[]} */
+    this.args = []; // cli args with options removed
+    this.rawArgs = [];
+    this.processedArgs = []; // like .args but after custom processing and collecting variadic
+    this._scriptPath = null;
+
+    this._name = this._unprocessedName;
+    this._optionValues = Object.assign({}, this._persistentOptionValues);
+    this._optionValueSources = Object.assign(
+      {}, this._persistentOptionValueSources
+    ); // default, env, cli etc
   }
 
   /**
@@ -799,6 +810,15 @@ Expecting one of '${allowedValues.join("', '")}'`);
       this._optionValues[key] = value;
     }
     this._optionValueSources[key] = source;
+
+    if (!(['cli', 'env', 'implied'].includes(source))) {
+      this._persistentOptionValues[key] = value;
+      this._persistentOptionValueSources[key] = source;
+    } else {
+      delete this._persistentOptionValues[key];
+      delete this._persistentOptionValueSources[key];
+    }
+
     return this;
   }
 
@@ -888,6 +908,22 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   /**
+   * @param {boolean} async
+   * @param {Function} userArgsCallback
+   * @param {string[]} [argv]
+   * @param {Object} [parseOptions]
+   * @param {string} [parseOptions.from]
+   * @return {Command|Promise}
+   * @api private
+   */
+
+  _parseSubroutine(async, userArgsCallback, argv, parseOptions) {
+    this.resetParseState();
+    const userArgs = this._prepareUserArgs(argv, parseOptions);
+    return userArgsCallback(userArgs);
+  }
+
+  /**
    * Parse `argv`, setting options and invoking commands when defined.
    *
    * The default expectation is that the arguments are from node and have the application as argv[0]
@@ -905,10 +941,10 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   parse(argv, parseOptions) {
-    const userArgs = this._prepareUserArgs(argv, parseOptions);
-    this._parseCommand([], userArgs);
-
-    return this;
+    return this._parseSubroutine(false, (userArgs) => {
+      this._parseCommand([], userArgs);
+      return this;
+    }, argv, parseOptions);
   }
 
   /**
@@ -931,10 +967,10 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   async parseAsync(argv, parseOptions) {
-    const userArgs = this._prepareUserArgs(argv, parseOptions);
-    await this._parseCommand([], userArgs);
-
-    return this;
+    return this._parseSubroutine(true, async(userArgs) => {
+      await this._parseCommand([], userArgs);
+      return this;
+    }, argv, parseOptions);
   }
 
   /**
@@ -1932,7 +1968,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
   name(str) {
     if (str === undefined) return this._name;
-    this._name = str;
+    this._name = this._unprocessedName = str;
     return this;
   }
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -98,7 +98,7 @@ class Command extends EventEmitter {
         if (target._storeOptionsAsProperties && !(key in target)) {
           target = receiver = receiver._optionValues;
         }
-        return Reflect.set(target, property, value, receiver);
+        return Reflect.set(target, key, value, receiver);
       },
       has(target, key) {
         if (target._storeOptionsAsProperties && !(key in target)) {

--- a/lib/command.js
+++ b/lib/command.js
@@ -816,8 +816,6 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   /**
-    * Store option value and where the value came from.
-    *
     * @param {string} key
     * @param {Object} value
     * @param {'default' | 'config'} [source]
@@ -844,9 +842,6 @@ Expecting one of '${allowedValues.join("', '")}'`);
       this._optionValues[key] = value;
     }
     this._optionValueSources[key] = source;
-
-    delete this._persistentOptionValues[key];
-    delete this._persistentOptionValueSources[key];
   }
 
   /**

--- a/lib/command.js
+++ b/lib/command.js
@@ -86,6 +86,7 @@ class Command extends EventEmitter {
     // The proxy only treats keys not present in the instance's prototype chain as keys for _optionValues when _storeOptionsAsProperties is set to true.
     // Setting option values for keys present in the prototype chain is still possible by calling .setOptionValue() or .setOptionValueWithSource(),
     // but such values will not be accessible as instnace properties because the prototype chain has precedence.
+    // However, they will be accessible via .getOptionValue().
     return new Proxy(this, {
       get(target, key, receiver) {
         if (target._storeOptionsAsProperties && !(key in target)) {

--- a/lib/command.js
+++ b/lib/command.js
@@ -797,7 +797,8 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   setOptionValue(key, value) {
-    return this.setOptionValueWithSource(key, value);
+    this._setPersistentOptionValueWithSource(key, value);
+    return this;
   }
 
   /**
@@ -805,7 +806,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     *
     * @param {string} key
     * @param {Object} value
-    * @param {'config'} [source]
+    * @param {'config'} source
     * @return {Command} `this` command for chaining
     */
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -74,6 +74,9 @@ class Command extends EventEmitter {
     this._persistentOptionValues = {};
     this._persistentOptionValueSources = {};
     this.resetParseState();
+
+    /** @type {boolean | undefined} */
+    this._asyncParsing = undefined;
   }
 
   resetParseState() {
@@ -804,7 +807,10 @@ Expecting one of '${allowedValues.join("', '")}'`);
     */
 
   setOptionValueWithSource(key, value, source) {
-    this._setPersistentOptionValueWithSource(key, value, source);
+    const set = this._asyncParsing === undefined
+      ? this._setPersistentOptionValueWithSource
+      : this._setNonPersistentOptionValueWithSource;
+    set(key, value, source);
     return this;
   }
 
@@ -1307,81 +1313,87 @@ Expecting one of '${allowedValues.join("', '")}'`);
    * @api private
    */
 
-  _parseCommand(operands, unknown) {
-    const parsed = this.parseOptions(unknown);
-    this._parseOptionsEnv(); // after cli, so parseArg not called on both cli and env
-    this._parseOptionsImplied();
-    operands = operands.concat(parsed.operands);
-    unknown = parsed.unknown;
-    this.args = operands.concat(unknown);
+  _parseCommand(operands, unknown, async) {
+    this._asyncParsing = async;
 
-    if (operands && this._findCommand(operands[0])) {
-      return this._dispatchSubcommand(operands[0], operands.slice(1), unknown);
-    }
-    if (this._hasImplicitHelpCommand() && operands[0] === this._helpCommandName) {
-      return this._dispatchHelpCommand(operands[1]);
-    }
-    if (this._defaultCommandName) {
-      outputHelpIfRequested(this, unknown); // Run the help for default command from parent rather than passing to default command
-      return this._dispatchSubcommand(this._defaultCommandName, operands, unknown);
-    }
-    if (this.commands.length && this.args.length === 0 && !this._actionHandler && !this._defaultCommandName) {
-      // probably missing subcommand and no handler, user needs help (and exit)
-      this.help({ error: true });
-    }
+    try {
+      const parsed = this.parseOptions(unknown);
+      this._parseOptionsEnv(); // after cli, so parseArg not called on both cli and env
+      this._parseOptionsImplied();
+      operands = operands.concat(parsed.operands);
+      unknown = parsed.unknown;
+      this.args = operands.concat(unknown);
 
-    outputHelpIfRequested(this, parsed.unknown);
-    this._checkForMissingMandatoryOptions();
-    this._checkForConflictingOptions();
-
-    // We do not always call this check to avoid masking a "better" error, like unknown command.
-    const checkForUnknownOptions = () => {
-      if (parsed.unknown.length > 0) {
-        this.unknownOption(parsed.unknown[0]);
+      if (operands && this._findCommand(operands[0])) {
+        return this._dispatchSubcommand(operands[0], operands.slice(1), unknown);
       }
-    };
-
-    const commandEvent = `command:${this.name()}`;
-    if (this._actionHandler) {
-      checkForUnknownOptions();
-      this._processArguments();
-
-      let actionResult;
-      actionResult = this._chainOrCallHooks(actionResult, 'preAction');
-      actionResult = this._chainOrCall(actionResult, () => this._actionHandler(this.processedArgs));
-      if (this.parent) {
-        actionResult = this._chainOrCall(actionResult, () => {
-          this.parent.emit(commandEvent, operands, unknown); // legacy
-        });
+      if (this._hasImplicitHelpCommand() && operands[0] === this._helpCommandName) {
+        return this._dispatchHelpCommand(operands[1]);
       }
-      actionResult = this._chainOrCallHooks(actionResult, 'postAction');
-      return actionResult;
-    }
-    if (this.parent && this.parent.listenerCount(commandEvent)) {
-      checkForUnknownOptions();
-      this._processArguments();
-      this.parent.emit(commandEvent, operands, unknown); // legacy
-    } else if (operands.length) {
-      if (this._findCommand('*')) { // legacy default command
-        return this._dispatchSubcommand('*', operands, unknown);
+      if (this._defaultCommandName) {
+        outputHelpIfRequested(this, unknown); // Run the help for default command from parent rather than passing to default command
+        return this._dispatchSubcommand(this._defaultCommandName, operands, unknown);
       }
-      if (this.listenerCount('command:*')) {
-        // skip option check, emit event for possible misspelling suggestion
-        this.emit('command:*', operands, unknown);
+      if (this.commands.length && this.args.length === 0 && !this._actionHandler && !this._defaultCommandName) {
+        // probably missing subcommand and no handler, user needs help (and exit)
+        this.help({ error: true });
+      }
+
+      outputHelpIfRequested(this, parsed.unknown);
+      this._checkForMissingMandatoryOptions();
+      this._checkForConflictingOptions();
+
+      // We do not always call this check to avoid masking a "better" error, like unknown command.
+      const checkForUnknownOptions = () => {
+        if (parsed.unknown.length > 0) {
+          this.unknownOption(parsed.unknown[0]);
+        }
+      };
+
+      const commandEvent = `command:${this.name()}`;
+      if (this._actionHandler) {
+        checkForUnknownOptions();
+        this._processArguments();
+
+        let actionResult;
+        actionResult = this._chainOrCallHooks(actionResult, 'preAction');
+        actionResult = this._chainOrCall(actionResult, () => this._actionHandler(this.processedArgs));
+        if (this.parent) {
+          actionResult = this._chainOrCall(actionResult, () => {
+            this.parent.emit(commandEvent, operands, unknown); // legacy
+          });
+        }
+        actionResult = this._chainOrCallHooks(actionResult, 'postAction');
+        return actionResult;
+      }
+      if (this.parent && this.parent.listenerCount(commandEvent)) {
+        checkForUnknownOptions();
+        this._processArguments();
+        this.parent.emit(commandEvent, operands, unknown); // legacy
+      } else if (operands.length) {
+        if (this._findCommand('*')) { // legacy default command
+          return this._dispatchSubcommand('*', operands, unknown);
+        }
+        if (this.listenerCount('command:*')) {
+          // skip option check, emit event for possible misspelling suggestion
+          this.emit('command:*', operands, unknown);
+        } else if (this.commands.length) {
+          this.unknownCommand();
+        } else {
+          checkForUnknownOptions();
+          this._processArguments();
+        }
       } else if (this.commands.length) {
-        this.unknownCommand();
+        checkForUnknownOptions();
+        // This command has subcommands and nothing hooked up at this level, so display help (and exit).
+        this.help({ error: true });
       } else {
         checkForUnknownOptions();
         this._processArguments();
+        // fall through for caller to handle after calling .parse()
       }
-    } else if (this.commands.length) {
-      checkForUnknownOptions();
-      // This command has subcommands and nothing hooked up at this level, so display help (and exit).
-      this.help({ error: true });
-    } else {
-      checkForUnknownOptions();
-      this._processArguments();
-      // fall through for caller to handle after calling .parse()
+    } finally {
+      this._asyncParsing = undefined;
     }
   }
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -1128,6 +1128,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
   _dispatchSubcommand(commandName, operands, unknown) {
     const subCommand = this._findCommand(commandName);
     if (!subCommand) this.help({ error: true });
+    subCommand.resetParseState();
 
     let hookResult;
     hookResult = this._chainOrCallSubCommandHook(hookResult, subCommand, 'preSubcommand');

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -595,7 +595,7 @@ export class Command {
   /**
    * Store option value and where the value came from.
    */
-  setOptionValueWithSource(key: string, value: unknown, source?: 'config'): this;
+  setOptionValueWithSource(key: string, value: unknown, source: 'config'): this;
 
   /**
    * Get source of option value.

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -272,7 +272,6 @@ export interface OutputConfiguration {
 
 export type AddHelpTextPosition = 'beforeAll' | 'before' | 'after' | 'afterAll';
 export type HookEvent = 'preSubcommand' | 'preAction' | 'postAction';
-export type OptionValueSource = 'default' | 'config' | 'env' | 'cli' | 'implied';
 
 export type OptionValues = Record<string, any>;
 
@@ -595,17 +594,17 @@ export class Command {
   /**
    * Store option value and where the value came from.
    */
-  setOptionValueWithSource(key: string, value: unknown, source: 'config'): this;
+  setOptionValueWithSource(key: string, value: unknown, source?: string | undefined): this;
 
   /**
    * Get source of option value.
    */
-  getOptionValueSource(key: string): OptionValueSource | undefined;
+  getOptionValueSource(key: string): string | undefined;
 
   /**
     * Get source of option value. See also .optsWithGlobals().
    */
-  getOptionValueSourceWithGlobals(key: string): OptionValueSource | undefined;
+  getOptionValueSourceWithGlobals(key: string): string | undefined;
 
   /**
    * Alter parsing of short flags with optional values.

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -595,7 +595,7 @@ export class Command {
   /**
    * Store option value and where the value came from.
    */
-  setOptionValueWithSource(key: string, value: unknown, source: OptionValueSource): this;
+  setOptionValueWithSource(key: string, value: unknown, source?: 'config'): this;
 
   /**
    * Get source of option value.

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -170,7 +170,6 @@ expectType<commander.Command>(program.setOptionValue('example', 'value'));
 expectType<commander.Command>(program.setOptionValue('example', true));
 
 // setOptionValueWithSource
-expectType<commander.Command>(program.setOptionValueWithSource('example', []));
 expectType<commander.Command>(program.setOptionValueWithSource('example', [], 'config'));
 
 // getOptionValueSource

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -173,10 +173,10 @@ expectType<commander.Command>(program.setOptionValue('example', true));
 expectType<commander.Command>(program.setOptionValueWithSource('example', [], 'config'));
 
 // getOptionValueSource
-expectType<commander.OptionValueSource | undefined>(program.getOptionValueSource('example'));
+expectType<string | undefined>(program.getOptionValueSource('example'));
 
 // getOptionValueSourceWithGlobals
-expectType<commander.OptionValueSource | undefined>(program.getOptionValueSourceWithGlobals('example'));
+expectType<string | undefined>(program.getOptionValueSourceWithGlobals('example'));
 
 // combineFlagAndOptionalValue
 expectType<commander.Command>(program.combineFlagAndOptionalValue());

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -170,7 +170,8 @@ expectType<commander.Command>(program.setOptionValue('example', 'value'));
 expectType<commander.Command>(program.setOptionValue('example', true));
 
 // setOptionValueWithSource
-expectType<commander.Command>(program.setOptionValueWithSource('example', [], 'cli'));
+expectType<commander.Command>(program.setOptionValueWithSource('example', []));
+expectType<commander.Command>(program.setOptionValueWithSource('example', [], 'config'));
 
 // getOptionValueSource
 expectType<commander.OptionValueSource | undefined>(program.getOptionValueSource('example'));


### PR DESCRIPTION
The better solution for #438 #1565 #1819 #1829 #1916 suggested in #1916.

<details>
<summary>Outdated</summary>

While implementing it, I noticed that the type restriction for the `source` parameter of the public `setOptionValueWithSource()` method are too loose. The only really supported source value seems to be `'config'` as of now, so I changed the type to this single value. This has the benefit of preventing messing up the internal logic by supplying option values with the source being one of `'default'`, `'cli'`, `'env'` and `'implied'` (at least when using TypeScript, might also want to add a real check in code).
</details>

## ChangeLog

### Changed
- _Breaking:_ previous `parse()` / `parseAsync()` call state is cleaned up in the beginning of a new call (enables command reuse for testing, REPL etc.)

### Fixed
- option value source type (set to `string | undefined` to enable custom source use)

## Peer PRs

### Merge this PR after…
- #1915 (`_asyncParsing` is used in this PR instead of simply adding a boolean variable indicating whether the command is currently being parsed because it is assumed the PRs are merged together. If they are not, use a boolean variable instead)

### Parse call subroutine (`_parseSubroutine()`) needs to be consistent with…
- #1917