### PR TITLE
Prevent `opts()` from exposing private object

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -1567,7 +1567,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
       return result;
     }
 
-    return this._optionValues;
+    return { ...this._optionValues };
   }
 
   /**


### PR DESCRIPTION
`opts()` now returns the private `_optionValues` object, making changes to it such as property deletion possible, but I don't think they are supposed to be possible. For example, deleting a property would lead to a weird state in which a source is defined in `_optionValueSources` for an option value that does not exist anymore.

The PR fixes this by returning a shallow clone of the object.