### PR TITLE
Prevent `opts()` from exposing private object

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -77,6 +77,24 @@ class Command extends EventEmitter {
     this._helpCommandnameAndArgs = 'help [command]';
     this._helpCommandDescription = 'display help for command';
     this._helpConfiguration = {};
+
+    this._optionValuesProxy = new Proxy(this._optionValues, {
+      set(_, key) {
+        throw new Error(`Tried to set value of option ${key} directly.
+Use .setOptionValue() or .setOptionValueWithSource() instead`);
+      },
+      deleteProperty(_, key) {
+        throw new Error(`Tried to delete value of option ${key}.
+Option value deletion is not supported`);
+      },
+      defineProperty(_, key) {
+        throw new Error(`Tried to configure value of option ${key} using
+- Object.defineProperty(),
+- or Object.defineProperties(),
+- or Reflect.defineProperty().
+Options value configuration is not supported`);
+      }
+    });
   }
 
   /**
@@ -1567,7 +1585,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
       return result;
     }
 
-    return { ...this._optionValues };
+    return this._optionValuesProxy;
   }
 
   /**

--- a/lib/command.js
+++ b/lib/command.js
@@ -589,6 +589,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
     const oname = option.name();
     const name = option.attributeName();
 
+    // register the option
+    this.options.push(option);
+
     // store default value
     if (option.negate) {
       // --no-foo is special and defaults foo to true, unless a --foo option is already defined
@@ -599,9 +602,6 @@ Expecting one of '${allowedValues.join("', '")}'`);
     } else if (option.defaultValue !== undefined) {
       this.setOptionValueWithSource(name, option.defaultValue, 'default');
     }
-
-    // register the option
-    this.options.push(option);
 
     // handler for cli and env supplied values
     const handleOptionValue = (val, invalidValueMessage, valueSource) => {
@@ -829,10 +829,18 @@ Expecting one of '${allowedValues.join("', '")}'`);
     */
 
   storeOptionsAsProperties(storeAsProperties = true) {
-    this._storeOptionsAsProperties = !!storeAsProperties;
     if (this.options.length) {
       throw new Error('call .storeOptionsAsProperties() before adding options');
     }
+    if (Object.keys(this._optionValues).length) {
+      throw new Error('call .storeOptionsAsProperties() before setting option values');
+    }
+    if (!this._storeOptionsAsProperties && storeAsProperties) {
+      this._defineVersionOptionAsProperty();
+    } else if (this._storeOptionsAsProperties && !storeAsProperties) {
+      this._deleteVersionOptionProperty();
+    }
+    this._storeOptionsAsProperties = !!storeAsProperties;
     return this;
   }
 
@@ -869,6 +877,20 @@ Expecting one of '${allowedValues.join("', '")}'`);
     */
 
   setOptionValueWithSource(key, value, source) {
+    if (this._storeOptionsAsProperties) {
+      if (key === this._versionOptionName) {
+        throw new Error(`Tried to set value of option ${key} reserved for version number.
+Set version number by calling .version() instead`);
+      }
+      const optionSupported = this.options.some(
+        option => key === option.attributeName()
+      );
+      if (!optionSupported) {
+        throw new Error(`Tried to set value of not supported option ${key}.
+This is not allowed when option values are stored as instance properties.
+Add support for option by calling .option() or .addOption() first`);
+      }
+    }
     this._optionValues[key] = value;
     this._optionValueSources[key] = source;
     return this;
@@ -1627,20 +1649,6 @@ Expecting one of '${allowedValues.join("', '")}'`);
    * @return {Object}
    */
   opts() {
-    if (this._storeOptionsAsProperties) {
-      // Preserve original behaviour so backwards compatible when still using properties
-      const result = {};
-      const len = this.options.length;
-
-      for (let i = 0; i < len; i++) {
-        const key = this.options[i].attributeName();
-        result[key] = key === this._versionOptionName
-          ? this._version
-          : this._optionValues[key];
-      }
-      return result;
-    }
-
     return this._optionValuesProxy;
   }
 
@@ -1893,13 +1901,36 @@ Expecting one of '${allowedValues.join("', '")}'`);
     flags = flags || '-V, --version';
     description = description || 'output the version number';
     const versionOption = this.createOption(flags, description);
+    if (this._storeOptionsAsProperties) this._deleteVersionOptionProperty();
     this._versionOptionName = versionOption.attributeName();
+    if (this._storeOptionsAsProperties) this._defineVersionOptionAsProperty();
     this.options.push(versionOption);
     this.on('option:' + versionOption.name(), () => {
       this._outputConfiguration.writeOut(`${str}\n`);
       this._exit(0, 'commander.version', str);
     });
     return this;
+  }
+
+  /**
+   * @api private
+   */
+  _defineVersionOptionAsProperty() {
+    return Reflect.defineProperty(this._optionValues, this._versionOptionName, {
+      get: () => this._version,
+      set: (value) => {
+        this._version = value;
+      },
+      configurable: true,
+      enumerable: true
+    });
+  }
+
+  /**
+   * @api private
+   */
+  _deleteVersionOptionProperty() {
+    return Reflect.deleteProperty(this._optionValues, this._versionOptionName);
   }
 
   /**

--- a/lib/command.js
+++ b/lib/command.js
@@ -79,15 +79,15 @@ class Command extends EventEmitter {
     this._helpConfiguration = {};
 
     this._optionValuesProxy = new Proxy(this._optionValues, {
-      set(_, key) {
-        throw new Error(`Tried to set value of option ${key} directly.
-Use .setOptionValue() or .setOptionValueWithSource() instead`);
+      set: (_, key, value) => {
+        this.setOptionValue(key, value);
+        return true;
       },
-      deleteProperty(_, key) {
+      deleteProperty: (_, key) => {
         throw new Error(`Tried to delete value of option ${key}.
 Option value deletion is not supported`);
       },
-      defineProperty(_, key) {
+      defineProperty: (_, key) => {
         throw new Error(`Tried to configure value of option ${key} using
 - Object.defineProperty(),
 - or Object.defineProperties(),

--- a/lib/command.js
+++ b/lib/command.js
@@ -1567,7 +1567,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
       return result;
     }
 
-    return this._optionValues;
+    return { ...this._optionValues };
   }
 
   /**

--- a/lib/command.js
+++ b/lib/command.js
@@ -95,6 +95,67 @@ Option value deletion is not supported`);
 Options value configuration is not supported`);
       }
     });
+
+    // Because of how the returned proxy works, ideally, no prooerties should be defined outside the cinstructor.
+    // They can still be defined outside the constructor in subclasses, but only when _storeOptionsAsProperties is set to false.
+    this._version = undefined;
+    this._versionOptionName = undefined;
+
+    // The proxy only treats keys not present in the instance and its prototype chain as keys for _optionValues when _storeOptionsAsProperties is set to true.
+    // Setting option values for keys present in the instance and its prototype chain is still possible by calling .setOptionValue() or .setOptionValueWithSource(),
+    // but such values will not be accessible as instnace properties because the instance and its prototype chain has precedence.
+    // However, they will be accessible via .getOptionValue(), .opts() and .optsWithGlobals().
+    return new Proxy(this, {
+      get(target, key, receiver) {
+        if (target._storeOptionsAsProperties && !(key in target)) {
+          target = receiver = receiver._optionValuesProxy;
+        }
+        return Reflect.get(target, key, receiver);
+      },
+      set(target, key, value, receiver) {
+        if (target._storeOptionsAsProperties && !(key in target)) {
+          target = receiver = receiver._optionValuesProxy;
+        }
+        return Reflect.set(target, key, value, receiver);
+      },
+      has(target, key) {
+        if (target._storeOptionsAsProperties && !(key in target)) {
+          target = target._optionValuesProxy;
+        }
+        return Reflect.has(target, key);
+      },
+      deleteProperty(target, key) {
+        if (target._storeOptionsAsProperties && !(key in target)) {
+          target = target._optionValuesProxy;
+        }
+        return Reflect.deleteProperty(target, key);
+      },
+      defineProperty(target, key, descriptor) {
+        if (target._storeOptionsAsProperties && !(key in target)) {
+          target = target._optionValuesProxy;
+        }
+        return Reflect.defineProperty(target, key, descriptor);
+      },
+      getOwnPropertyDescriptor(target, key) {
+        if (target._storeOptionsAsProperties && !(key in target)) {
+          target = target._optionValuesProxy;
+        }
+        return Reflect.getOwnPropertyDescriptor(target, key);
+      },
+      ownKeys(target) {
+        const result = Reflect.ownKeys(target);
+        if (target._storeOptionsAsProperties) {
+          result.push(...Reflect.ownKeys(target._optionValuesProxy));
+        }
+        return result;
+      },
+      preventExtensions(target) {
+        if (target._storeOptionsAsProperties) {
+          Reflect.preventExtensions(target._optionValuesProxy);
+        }
+        return Reflect.preventExtensions(target);
+      }
+    });
   }
 
   /**
@@ -783,9 +844,6 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   getOptionValue(key) {
-    if (this._storeOptionsAsProperties) {
-      return this[key];
-    }
     return this._optionValues[key];
   }
 
@@ -811,11 +869,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     */
 
   setOptionValueWithSource(key, value, source) {
-    if (this._storeOptionsAsProperties) {
-      this[key] = value;
-    } else {
-      this._optionValues[key] = value;
-    }
+    this._optionValues[key] = value;
     this._optionValueSources[key] = source;
     return this;
   }
@@ -1580,7 +1634,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
       for (let i = 0; i < len; i++) {
         const key = this.options[i].attributeName();
-        result[key] = key === this._versionOptionName ? this._version : this[key];
+        result[key] = key === this._versionOptionName
+          ? this._version
+          : this._optionValues[key];
       }
       return result;
     }


### PR DESCRIPTION
`opts()` now returns the private `_optionValues` object, making changes to it such as property deletion possible, but I don't think they are supposed to be possible. For example, deleting a property would lead to a weird state in which a source is defined in `_optionValueSources` for an option value that does not exist anymore.

The PR fixes this by returning a shallow clone of the object.

(#1920 is the same and has only been closed because of a branch rename.)