### PR TITLE
Make `copyInheritedSettings()` recursive

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -546,7 +546,7 @@ subcommand is specified ([example](./examples/defaultCommand.js)).
 
 You can add alternative names for a command with `.alias()`. ([example](./examples/alias.js))
 
-For safety, `.addCommand()` does not automatically copy the inherited settings from the parent command. There is a helper routine `.copyInheritedSettings()` for copying the settings when they are wanted.
+For safety, `.addCommand()` does not automatically copy the inherited settings from the parent command. There is a helper routine `.copyInheritedSettings()` for copying the settings when they are wanted. The copying is done recursively, so the settings are inherited by the entire subcommand hierarchy.
 
 ### Command-arguments
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -106,6 +106,10 @@ class Command extends EventEmitter {
     this._showHelpAfterError = sourceCommand._showHelpAfterError;
     this._showSuggestionAfterError = sourceCommand._showSuggestionAfterError;
 
+    this.commands.forEach(command => {
+      command.copyInheritedSettings(this);
+    });
+
     return this;
   }
 

--- a/tests/command.copySettings.test.js
+++ b/tests/command.copySettings.test.js
@@ -18,6 +18,28 @@ test('when add subcommand with .command() then calls copyInheritedSettings from 
   expect(copySettingMock).toHaveBeenCalledWith(program);
 });
 
+test('when copyInheritedSettings on command with subcommand hierarchy then copies recursively', () => {
+  const source = new commander.Command();
+  const cmd = new commander.Command();
+
+  const descendants = Array.from({ length: 4 }, (_, i) => (
+    new commander.Command(String(i))
+  ));
+  const parents = [cmd, cmd, descendants[0], descendants[1]];
+  descendants.forEach((descendant, i) => {
+    descendant.copyInheritedSettings = jest.fn().mockImplementation(
+      descendant.copyInheritedSettings
+    );
+    parents[i].addCommand(descendant);
+  });
+
+  cmd.copyInheritedSettings(source);
+  descendants.forEach((descendant, i) => {
+    const copySettingMock = descendant.copyInheritedSettings;
+    expect(copySettingMock).toHaveBeenCalledWith(parents[i]);
+  });
+});
+
 describe('copyInheritedSettings property tests', () => {
   test('when copyInheritedSettings then copies outputConfiguration(config)', () => {
     const source = new commander.Command();


### PR DESCRIPTION
# Pull Request

## Problem

Pretty much all the inherited settings are such that it is only really meaningful for them to have the same values across the entire command hierarchy. However, `copyInheritedSettings()` only copies them at one level instead of doing it recursively. Because of that, the intended usage pattern is currently that the user adds subsubcommands only after the subcommand was added to its parent if the parent's inherited settings are meddled with (as clarified [here](https://github.com/tj/commander.js/pull/1915#issuecomment-1652787454)).

### Demo

```js
const sub = new Command('sub');
const subsub = sub.command('subsub');

program
  .showHelpAfterError()
  .addCommand(sub);
sub.copyInheritedSettings(program);

console.log(sub._showHelpAfterError); // true
console.log(subsub._showHelpAfterError); // false
```

## Solution

Make `copyInheritedSettings()` recursive.

## ChangeLog

### Changed
- _Breaking:_ make `.copyInheritedSettings()` recursive (settings are now inherited by the entire command hierarchy)
