### PR TITLE
Prevent options with flags already in use from being added

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -507,6 +507,31 @@ Expecting one of '${allowedValues.join("', '")}'`);
    * @return {Command} `this` command for chaining
    */
   addOption(option) {
+    const flagString = [option.short, option.long]
+      .filter(flag => flag)
+      .join(', ');
+    const flagConflictCommonMessage = `Cannot add option ${flagString}`;
+
+    const shortConflictOption = this.options.find((other) => (
+      option.short && option.short === other.short
+    ));
+    const longConflictOption = this.options.find((other) => (
+      option.long && option.long === other.long
+    ));
+
+    if (shortConflictOption) {
+      if (shortConflictOption === longConflictOption) {
+        throw new Error(`${flagConflictCommonMessage}.
+An option with the same flags has already been added`);
+      }
+      throw new Error(`${flagConflictCommonMessage}.
+An option with flag ${shortConflictOption.short} has already been added`);
+    }
+    if (longConflictOption) {
+      throw new Error(`${flagConflictCommonMessage}.
+An option with flag ${longConflictOption.long} has already been added`);
+    }
+
     const oname = option.name();
     const name = option.attributeName();
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -515,17 +515,15 @@ Expecting one of '${allowedValues.join("', '")}'`);
     const shortConflictOption = option.short && this._findOption(option.short);
     const longConflictOption = option.long && this._findOption(option.long);
 
-    if (shortConflictOption) {
+    if (shortConflictOption || longConflictOption) {
       if (shortConflictOption === longConflictOption) {
         throw new Error(`${flagConflictCommonMessage}.
 An option with the same flags has already been added`);
       }
       throw new Error(`${flagConflictCommonMessage}.
-An option with flag ${shortConflictOption.short} has already been added`);
-    }
-    if (longConflictOption) {
-      throw new Error(`${flagConflictCommonMessage}.
-An option with flag ${longConflictOption.long} has already been added`);
+An option with flag ${
+  shortConflictOption ? shortConflictOption.short : longConflictOption.long
+} has already been added`);
     }
 
     const oname = option.name();

--- a/lib/command.js
+++ b/lib/command.js
@@ -507,8 +507,8 @@ Expecting one of '${allowedValues.join("', '")}'`);
    * @return {Command} `this` command for chaining
    */
   addOption(option) {
-    const matchingOption = (option.short && this._findOption(option.short))
-      || (option.long && this._findOption(option.long));
+    const matchingOption = (option.short && this._findOption(option.short)) ||
+      (option.long && this._findOption(option.long));
     if (matchingOption) {
       throw new Error(`Cannot add option '${option.flags}'${this._name && ` to '${this._name}'`} since an option using same flag has already been added
 - conflicts with option '${matchingOption.flags}'`);

--- a/lib/command.js
+++ b/lib/command.js
@@ -507,21 +507,11 @@ Expecting one of '${allowedValues.join("', '")}'`);
    * @return {Command} `this` command for chaining
    */
   addOption(option) {
-    const flagString = [option.short, option.long]
-      .filter(flag => flag)
-      .join(', ');
-    const flagConflictCommonMessage = `Cannot add option ${flagString}`;
-
-    const shortConflictOption = option.short && this._findOption(option.short);
-    const longConflictOption = option.long && this._findOption(option.long);
-
-    if (shortConflictOption || longConflictOption) {
-      if (shortConflictOption === longConflictOption) {
-        throw new Error(`${flagConflictCommonMessage}.
-An option with the same flags has already been added`);
-      }
-      throw new Error(`${flagConflictCommonMessage}.
-An option with flag ${shortConflictOption ? shortConflictOption.short : longConflictOption.long} has already been added`);
+    const matchingOption = (option.short && this._findOption(option.short))
+      || (option.long && this._findOption(option.long));
+    if (matchingOption) {
+      throw new Error(`Cannot add option '${option.flags}'${this._name && ` to '${this._name}'`} since an option using same flag has already been added
+- conflicts with option '${matchingOption.flags}'`);
     }
 
     const oname = option.name();

--- a/lib/command.js
+++ b/lib/command.js
@@ -521,9 +521,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
 An option with the same flags has already been added`);
       }
       throw new Error(`${flagConflictCommonMessage}.
-An option with flag ${
-  shortConflictOption ? shortConflictOption.short : longConflictOption.long
-} has already been added`);
+An option with flag ${shortConflictOption ? shortConflictOption.short : longConflictOption.long} has already been added`);
     }
 
     const oname = option.name();

--- a/lib/command.js
+++ b/lib/command.js
@@ -501,18 +501,32 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   /**
-   * Add an option.
+   * Check for option flag conflicts.
+   * Register option if no conflicts found.
+   * Throw otherwise.
    *
    * @param {Option} option
-   * @return {Command} `this` command for chaining
+   * @api private
    */
-  addOption(option) {
+
+  _registerOption(option) {
     const matchingOption = (option.short && this._findOption(option.short)) ||
       (option.long && this._findOption(option.long));
     if (matchingOption) {
       throw new Error(`Cannot add option '${option.flags}'${this._name && ` to '${this._name}'`} since an option using same flag has already been added
 - conflicts with option '${matchingOption.flags}'`);
     }
+    this.options.push(option);
+  }
+
+  /**
+   * Add an option.
+   *
+   * @param {Option} option
+   * @return {Command} `this` command for chaining
+   */
+  addOption(option) {
+    this._registerOption(option);
 
     const oname = option.name();
     const name = option.attributeName();
@@ -527,9 +541,6 @@ Expecting one of '${allowedValues.join("', '")}'`);
     } else if (option.defaultValue !== undefined) {
       this.setOptionValueWithSource(name, option.defaultValue, 'default');
     }
-
-    // register the option
-    this.options.push(option);
 
     // handler for cli and env supplied values
     const handleOptionValue = (val, invalidValueMessage, valueSource) => {
@@ -1827,7 +1838,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     description = description || 'output the version number';
     const versionOption = this.createOption(flags, description);
     this._versionOptionName = versionOption.attributeName();
-    this.options.push(versionOption);
+    this._registerOption(versionOption);
     this.on('option:' + versionOption.name(), () => {
       this._outputConfiguration.writeOut(`${str}\n`);
       this._exit(0, 'commander.version', str);

--- a/lib/command.js
+++ b/lib/command.js
@@ -512,12 +512,8 @@ Expecting one of '${allowedValues.join("', '")}'`);
       .join(', ');
     const flagConflictCommonMessage = `Cannot add option ${flagString}`;
 
-    const shortConflictOption = this.options.find((other) => (
-      option.short && option.short === other.short
-    ));
-    const longConflictOption = this.options.find((other) => (
-      option.long && option.long === other.long
-    ));
+    const shortConflictOption = option.short && this._findOption(option.short);
+    const longConflictOption = option.long && this._findOption(option.long);
 
     if (shortConflictOption) {
       if (shortConflictOption === longConflictOption) {


### PR DESCRIPTION
# Pull Request

## Problem

Adding options with flags that are already in use is allowed.

### Demo
```js
const { Command } = require('commander');

var program = new Command();
program
  .option('-a, --first')
  .option('-a, --second');
program.parse(['-a'], { from: 'user' });
console.log(program.opts()); // { first: true }

var program = new Command();
program
  .option('-V, --version [arg]', 'added via .option()')
  .version('1.0.0')
  .action(() => {
    console.log('called action handler');
    console.log('version value is', program.opts().version);
  });
program.outputHelp(); // both version option and option added via .option() are shown
program.parse(['-V', '2.0.0'], { from: 'user' }); // action handler not called
```

## ChangeLog

### Changed
- _Breaking:_ throw an error when `.addOption()` is called with an option whose flags are already in use

## Peer PRs

### …solving similar problems
- #1924
- #1931 (introduces `_registerOption()`, too – watch out for merge conflicts!)