### PR TITLE
Prevent aliases already in use and subcommands with such an alias or the name already in use from being added

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -110,14 +110,40 @@ class Command extends EventEmitter {
   }
 
   /**
-   * @param {string} name
+   * @param {string} names
+   * @param {string[]} aliases
+   * @param {Command} matchingCommand
+   * @return {string}
    * @api private
    */
 
-  _checkForConflictingCommandNames(name) {
-    if (this._findCommand(name)) {
-      throw new Error(`Cannot add command '${name}'${this._name && ` to '${this._name}'`}.
-A subcommand with the same name has already been added`);
+  _getConflictingCommandNamesMessageDetail(name, aliases, matchingCommand) {
+    const matchingCommandNames = matchingCommand._aliases.concat(
+      matchingCommand._name
+    );
+    if (matchingCommandNames.includes(name)) return 'same name';
+    const matchingAlias = aliases.find(
+      alias => matchingCommandNames.includes(alias)
+    );
+    return `alias '${matchingAlias}'`;
+  }
+
+  /**
+   * @param {string} names
+   * @param {string[]} aliases
+   * @api private
+   */
+
+  _checkForConflictingCommandNames(name, aliases = []) {
+    const names = aliases.concat(name);
+    const matchingCommand = names
+      .map(name => this._findCommand(name))
+      .filter(found => found)[0];
+    if (matchingCommand) {
+      const messageDetail = this._getConflictingCommandNamesMessageDetail(
+        name, aliases, matchingCommand
+      );
+      throw new Error(`Cannot add command '${name}'${this._name && ` to '${this._name}'`} since a command using the ${messageDetail} has already been added`);
     }
   }
 
@@ -278,7 +304,7 @@ A subcommand with the same name has already been added`);
       throw new Error(`Command passed to .addCommand() must have a name
 - specify the name in Command constructor or using .name()`);
     }
-    this._checkForConflictingCommandNames(cmd._name);
+    this._checkForConflictingCommandNames(cmd._name, cmd._aliases);
 
     opts = opts || {};
     if (opts.isDefault) this._defaultCommandName = cmd._name;
@@ -1889,7 +1915,12 @@ Expecting one of '${allowedValues.join("', '")}'`);
       command = this.commands[this.commands.length - 1];
     }
 
-    if (alias === command._name) throw new Error('Command alias can\'t be the same as its name');
+    if (alias === command._name) {
+      throw new Error('Command alias can\'t be the same as its name');
+    }
+    if (command.parent?._findCommand(alias)) {
+      throw new Error(`Cannot add alias '${alias}' for subcommand '${command._name}'${command.parent._name && ` of '${command.parent._name}'`} since a subcommand with the same name or alias has already been added`);
+    }
 
     command._aliases.push(alias);
     return this;

--- a/lib/command.js
+++ b/lib/command.js
@@ -110,6 +110,18 @@ class Command extends EventEmitter {
   }
 
   /**
+   * @param {string} name
+   * @api private
+   */
+
+  _checkForConflictingCommandNames(name) {
+    if (this._findCommand(name)) {
+      throw new Error(`Cannot add command '${name}'${this._name && ` to '${this._name}'`}.
+A subcommand with the same name has already been added`);
+    }
+  }
+
+  /**
    * Define a command.
    *
    * There are two styles of command: pay attention to where to put the description.
@@ -143,6 +155,7 @@ class Command extends EventEmitter {
     }
     opts = opts || {};
     const [, name, args] = nameAndArgs.match(/([^ ]+) *(.*)/);
+    this._checkForConflictingCommandNames(name);
 
     const cmd = this.createCommand(name);
     if (desc) {
@@ -265,6 +278,7 @@ class Command extends EventEmitter {
       throw new Error(`Command passed to .addCommand() must have a name
 - specify the name in Command constructor or using .name()`);
     }
+    this._checkForConflictingCommandNames(cmd._name);
 
     opts = opts || {};
     if (opts.isDefault) this._defaultCommandName = cmd._name;


### PR DESCRIPTION
# Pull Request

## Problem

Adding aliases that are already in use and subcommands with such an alias or the name that is already in use is allowed.

### Demo
```js
program.command('sub').action(() => console.log('first'));
program.command('sub').action(() => console.log('second'));
program.parse(['sub'], { from: 'user' }); // output will always be first
```

```js
program.command('sub').action(() => console.log('first'));
const explicit = new Command('explicit')
  .alias('sub')
  .action(() => console.log('second'));
program.addCommand(explicit);
program.parse(['sub'], { from: 'user' }); // output will always be first
```

```js
program.command('sub');
const explicit = new Command('explicit');
program.addCommand(explicit);
explicit.alias('sub'); // does not throw
```

### Original issue
- #1903

## ChangeLog

### Changed
- _Breaking:_ throw an error when trying to add a subcommand with a name or an alias that is already in use
- _Breaking:_ throw an error when trying to add an alias that is already in use to a subcommand

## Peer PRs

### …solving similar problems
- #1923