### PR TITLE
Add documentation for implicitly constructed commands' setting inheritance

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -546,6 +546,8 @@ subcommand is specified ([example](./examples/defaultCommand.js)).
 
 You can add alternative names for a command with `.alias()`. ([example](./examples/alias.js))
 
+Commands added with `.command()` automatically inherit settings for which inheritance is meaningful from the parent command, but only upon the subcommand creation. The setting changes made after calling `.command()` are not inherited.
+
 For safety, `.addCommand()` does not automatically copy the inherited settings from the parent command. There is a helper routine `.copyInheritedSettings()` for copying the settings when they are wanted.
 
 ### Command-arguments

--- a/Readme.md
+++ b/Readme.md
@@ -546,7 +546,7 @@ subcommand is specified ([example](./examples/defaultCommand.js)).
 
 You can add alternative names for a command with `.alias()`. ([example](./examples/alias.js))
 
-Commands added with `.command()` automatically inherit settings for which inheritance is meaningful from the parent command, but only upon the subcommand creation. The setting changes made after calling `.command()` are not inherited.
+`.command()` automatically copies the inherited settings from the parent command to the newly created subcommand. This is only done during creation, any later setting changes to the parent are not inherited.
 
 For safety, `.addCommand()` does not automatically copy the inherited settings from the parent command. There is a helper routine `.copyInheritedSettings()` for copying the settings when they are wanted.
 


### PR DESCRIPTION
Partially fixes #1916.

Cherry-picked from #1917 because the docs extension discussion is [already finalized](https://github.com/tj/commander.js/pull/1917#discussion_r1278270441) and the change is independent from the other changes introduced there, so it can be merged even now.

## ChangeLog

### Added
- documentation for implicitly constructed commands' setting inheritance