### PR TITLE
Enforce correct option usage and support custom option flag and name extraction in `helpOption()`

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -365,7 +365,7 @@ class Command extends EventEmitter {
    */
 
   addHelpCommand(enableOrNameAndArgs, description) {
-    if (enableOrNameAndArgs === false) {
+    if (!enableOrNameAndArgs && enableOrNameAndArgs !== undefined) {
       this._addImplicitHelpCommand = false;
     } else {
       this._addImplicitHelpCommand = true;

--- a/lib/command.js
+++ b/lib/command.js
@@ -748,10 +748,13 @@ Expecting one of '${allowedValues.join("', '")}'`);
     */
 
   storeOptionsAsProperties(storeAsProperties = true) {
-    this._storeOptionsAsProperties = !!storeAsProperties;
     if (this.options.length) {
       throw new Error('call .storeOptionsAsProperties() before adding options');
     }
+    if (Object.keys(this._optionValues).length) {
+      throw new Error('call .storeOptionsAsProperties() before setting option values');
+    }
+    this._storeOptionsAsProperties = !!storeAsProperties;
     return this;
   }
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -1808,6 +1808,31 @@ Set version number by calling .version() instead`);
   }
 
   /**
+   * @param {string} flags
+   * @param {string} name
+   * @param {string} detail
+   * @api private
+   */
+
+  _checkForConflictingOptionNames(flags, name, detail) {
+    let reason;
+    if (name in this.opts()) {
+      reason = 'a value for option using same .opts() name has already been set';
+    } else {
+      const matchingOption = this.options.find(
+        (option) => name === option.attributeName()
+      );
+      if (matchingOption) {
+        reason = `an option using same .opts() name has already been added
+- conflicts with option '${matchingOption.flags}'`;
+      }
+    }
+    if (reason) {
+      throw new Error(`Cannot use '${flags}' as ${detail} option${this._name && ` for '${this._name}'`} since ${reason}`);
+    }
+  }
+
+  /**
    * Set the program version to `str`.
    *
    * This method auto-registers the "-V, --version" flag
@@ -1827,12 +1852,15 @@ Set version number by calling .version() instead`);
     flags = flags || '-V, --version';
     description = description || 'output the version number';
     const versionOption = this.createOption(flags, description);
-    this._versionOptionName = versionOption.attributeName();
-    this.options.push(versionOption);
     this.on('option:' + versionOption.name(), () => {
       this._outputConfiguration.writeOut(`${str}\n`);
       this._exit(0, 'commander.version', str);
     });
+
+    this._versionOptionName = versionOption.attributeName();
+    this._checkForConflictingOptionNames(flags, this._versionOptionName, 'version');
+    this.options.push(versionOption);
+
     return this;
   }
 
@@ -2070,6 +2098,7 @@ Set version number by calling .version() instead`);
     this._helpShortFlag = helpOption.short;
     this._helpLongFlag = helpOption.long;
     this._helpOptionName = helpOption.attributeName();
+    this._checkForConflictingOptionNames(flags, this._helpOptionName, 'help');
 
     return this;
   }

--- a/lib/command.js
+++ b/lib/command.js
@@ -7,7 +7,7 @@ const process = require('process');
 const { Argument, humanReadableArgName } = require('./argument.js');
 const { CommanderError } = require('./error.js');
 const { Help } = require('./help.js');
-const { Option, splitOptionFlags, DualOptions } = require('./option.js');
+const { Option, DualOptions } = require('./option.js');
 const { suggestSimilar } = require('./suggestSimilar');
 
 // @ts-check
@@ -67,16 +67,13 @@ class Command extends EventEmitter {
     };
 
     this._hidden = false;
-    this._hasHelpOption = true;
-    this._helpFlags = '-h, --help';
-    this._helpDescription = 'display help for command';
-    this._helpShortFlag = '-h';
-    this._helpLongFlag = '--help';
     this._addImplicitHelpCommand = undefined; // Deliberately undefined, not decided whether true or false
+
+    this._helpConfiguration = {};
     this._helpCommandName = 'help';
     this._helpCommandnameAndArgs = 'help [command]';
     this._helpCommandDescription = 'display help for command';
-    this._helpConfiguration = {};
+    this.helpOption('-h, --help', 'display help for command');
   }
 
   /**
@@ -89,15 +86,6 @@ class Command extends EventEmitter {
    */
   copyInheritedSettings(sourceCommand) {
     this._outputConfiguration = sourceCommand._outputConfiguration;
-    this._hasHelpOption = sourceCommand._hasHelpOption;
-    this._helpFlags = sourceCommand._helpFlags;
-    this._helpDescription = sourceCommand._helpDescription;
-    this._helpShortFlag = sourceCommand._helpShortFlag;
-    this._helpLongFlag = sourceCommand._helpLongFlag;
-    this._helpCommandName = sourceCommand._helpCommandName;
-    this._helpCommandnameAndArgs = sourceCommand._helpCommandnameAndArgs;
-    this._helpCommandDescription = sourceCommand._helpCommandDescription;
-    this._helpConfiguration = sourceCommand._helpConfiguration;
     this._exitCallback = sourceCommand._exitCallback;
     this._storeOptionsAsProperties = sourceCommand._storeOptionsAsProperties;
     this._combineFlagAndOptionalValue = sourceCommand._combineFlagAndOptionalValue;
@@ -105,6 +93,16 @@ class Command extends EventEmitter {
     this._enablePositionalOptions = sourceCommand._enablePositionalOptions;
     this._showHelpAfterError = sourceCommand._showHelpAfterError;
     this._showSuggestionAfterError = sourceCommand._showSuggestionAfterError;
+
+    this._helpConfiguration = sourceCommand._helpConfiguration;
+    this._helpCommandName = sourceCommand._helpCommandName;
+    this._helpCommandnameAndArgs = sourceCommand._helpCommandnameAndArgs;
+    this._helpCommandDescription = sourceCommand._helpCommandDescription;
+    if (sourceCommand._hasHelpOption) {
+      this.helpOption(sourceCommand._helpFlags, sourceCommand._helpDescription);
+    } else {
+      this._hasHelpOption = false;
+    }
 
     return this;
   }
@@ -793,6 +791,13 @@ Expecting one of '${allowedValues.join("', '")}'`);
     */
 
   setOptionValueWithSource(key, value, source) {
+    if (key === this._versionOptionName) {
+      throw new Error(`Tried to set value for the version option '${key}'. This is not allowed.
+Set version number by calling .version() instead`);
+    }
+    if (key === this._helpOptionName) {
+      throw new Error(`Tried to set value for the help option '${key}'. This is not allowed`);
+    }
     if (this._storeOptionsAsProperties) {
       this[key] = value;
     } else {
@@ -2054,12 +2059,14 @@ Expecting one of '${allowedValues.join("', '")}'`);
       this._hasHelpOption = flags;
       return this;
     }
-    this._helpFlags = flags || this._helpFlags;
-    this._helpDescription = description || this._helpDescription;
+    this._hasHelpOption = true;
+    this._helpFlags = flags = flags || this._helpFlags;
+    this._helpDescription = description = description || this._helpDescription;
 
-    const helpFlags = splitOptionFlags(this._helpFlags);
-    this._helpShortFlag = helpFlags.shortFlag;
-    this._helpLongFlag = helpFlags.longFlag;
+    const helpOption = this.createOption(flags, description);
+    this._helpShortFlag = helpOption.short;
+    this._helpLongFlag = helpOption.long;
+    this._helpOptionName = helpOption.attributeName();
 
     return this;
   }

--- a/tests/command.addHelpText.test.js
+++ b/tests/command.addHelpText.test.js
@@ -181,7 +181,7 @@ describe('context checks with full parse', () => {
   });
 
   test('when help requested then context.error is false', () => {
-    let context = {};
+    let context;
     const program = new commander.Command();
     program
       .exitOverride()
@@ -193,7 +193,7 @@ describe('context checks with full parse', () => {
   });
 
   test('when help for error then context.error is true', () => {
-    let context = {};
+    let context;
     const program = new commander.Command();
     program
       .exitOverride()
@@ -206,7 +206,7 @@ describe('context checks with full parse', () => {
   });
 
   test('when help on program then context.command is program', () => {
-    let context = {};
+    let context;
     const program = new commander.Command();
     program
       .exitOverride()
@@ -218,7 +218,7 @@ describe('context checks with full parse', () => {
   });
 
   test('when help on subcommand and "before" subcommand then context.command is subcommand', () => {
-    let context = {};
+    let context;
     const program = new commander.Command();
     program
       .exitOverride();
@@ -231,7 +231,7 @@ describe('context checks with full parse', () => {
   });
 
   test('when help on subcommand and "beforeAll" on program then context.command is subcommand', () => {
-    let context = {};
+    let context;
     const program = new commander.Command();
     program
       .exitOverride()

--- a/tests/command.copySettings.test.js
+++ b/tests/command.copySettings.test.js
@@ -44,10 +44,12 @@ describe('copyInheritedSettings property tests', () => {
 
     source.helpOption('-Z, --zz', 'ddd');
     cmd.copyInheritedSettings(source);
+    expect(cmd._hasHelpOption).toBeTruthy();
     expect(cmd._helpFlags).toBe('-Z, --zz');
     expect(cmd._helpDescription).toBe('ddd');
     expect(cmd._helpShortFlag).toBe('-Z');
     expect(cmd._helpLongFlag).toBe('--zz');
+    expect(cmd._helpOptionName).toBe('zz');
   });
 
   test('when copyInheritedSettings then copies addHelpCommand(name, description)', () => {


### PR DESCRIPTION
# Pull Request

## Problem

```js
var program = new Command();
var helpOption = program.createOption(program._helpFlags, program._helpDescription);
var helpOptionName = helpOption.attributeName();
console.log(helpOptionName); // 'help'
program.setOptionValue(helpOptionName, 123); // allowed!

var program = new Command();
program.option('--my-help');
program.helpOption('--my-help'); // allowed!

var program = new Command();
program.setOptionValue('myHelp', 123);
program.helpOption('--my-help'); // allowed!

var program = new Command();
program.version('1.0.0');
console.log(program.version()); // '1.0.0'
var versionOption = program.createOption(program._versionOptionName);
var versionOptionName = versionOption.attributeName();
console.log(versionOptionName); // 'version'
program.setOptionValue(versionOptionName, '1.0.1'); // allowed!
console.log(program.version()); // still '1.0.0'

var program = new Command();
program.option('--my-version');
program.version('1.0.0', '--my-version'); // allowed!

var program = new Command();
program.setOptionValue('myVersion', 123);
program.version('1.0.0', '--my-version'); // allowed!

var program = new Command();
program.setOptionValue('foo', 'bar');
console.log(program.getOptionValue('foo')); // 'bar'
console.log(program.opts()); // { foo: 'bar' }
program.storeOptionsAsProperties(); // allowed!
console.log(program.getOptionValue('foo')); // undefined
console.log(program.opts()); // {}
```

## Solution

Throw errors in all demonstrated cases (partially borrowed from [a5afe93](https://github.com/tj/commander.js/pull/1921/commits/a5afe935defd7f928a236a4bf237d73d79011a50) in the now-closed #1921).

Additionally, the code for the help option has been refactored to support custom option flag and name extraction mechanisms defined in subclasses. To achieve that, an `Option` instance returned from a `createOption()` call is used for extraction in `helpOption()` (the same is currently done in `version()`), which is now called in the constructor and `copyInheritedSettings()`.

The first two commits are tiny improvements to the code that have been made while working on the solution and don't really belong anywhere else.

## ChangeLog

### Changed
- _Breaking:_ throw errors when trying to set values for the help and version options
- _Breaking:_ throw error when trying to add help or version option with `.opts()` name already in use
- _Breaking:_ throw error when calling `.storeOptionsAsProperties()` after setting an option value
- _Breaking:_ use `.createOption()` in `.helpOption()` to support custom option flag and name extraction

### Fixed
- falsy parameter value handling in `.addHelpCommand()`

## Peer PRs
- #1923