### PR TITLE
Handle falsy values in `addHelpCommand()` properly

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -365,7 +365,7 @@ class Command extends EventEmitter {
    */
 
   addHelpCommand(enableOrNameAndArgs, description) {
-    if (enableOrNameAndArgs === false) {
+    if (!enableOrNameAndArgs && enableOrNameAndArgs !== undefined) {
       this._addImplicitHelpCommand = false;
     } else {
       this._addImplicitHelpCommand = true;


### PR DESCRIPTION
Cherry-picked from #1926 for better separation of concerns.

## Problem

Only `false` is treated as falsy in `addHelpCommand()`.

## ChangeLog

### Fixed
- falsy parameter value handling in `.addHelpCommand()`