### PR TITLE
Throw error on `storeOptionsAsProperties()` after setting option values

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -750,10 +750,13 @@ Expecting one of '${allowedValues.join("', '")}'`);
     */
 
   storeOptionsAsProperties(storeAsProperties = true) {
-    this._storeOptionsAsProperties = !!storeAsProperties;
     if (this.options.length) {
       throw new Error('call .storeOptionsAsProperties() before adding options');
     }
+    if (Object.keys(this._optionValues).length) {
+      throw new Error('call .storeOptionsAsProperties() before setting option values');
+    }
+    this._storeOptionsAsProperties = !!storeAsProperties;
     return this;
   }
 

--- a/tests/commander.configureCommand.test.js
+++ b/tests/commander.configureCommand.test.js
@@ -84,3 +84,11 @@ test('when storeOptionsAsProperties() after adding option then throw', () => {
     program.storeOptionsAsProperties(false);
   }).toThrow();
 });
+
+test('when storeOptionsAsProperties() after setting option value then throw', () => {
+  const program = new commander.Command();
+  program.setOptionValue('foo', 'bar');
+  expect(() => {
+    program.storeOptionsAsProperties(false);
+  }).toThrow();
+});

--- a/tests/commander.configureCommand.test.js
+++ b/tests/commander.configureCommand.test.js
@@ -81,7 +81,7 @@ test('when storeOptionsAsProperties() after adding option then throw', () => {
   const program = new commander.Command();
   program.option('--port <number>', 'port number', '80');
   expect(() => {
-    program.storeOptionsAsProperties(false);
+    program.storeOptionsAsProperties();
   }).toThrow();
 });
 
@@ -89,6 +89,6 @@ test('when storeOptionsAsProperties() after setting option value then throw', ()
   const program = new commander.Command();
   program.setOptionValue('foo', 'bar');
   expect(() => {
-    program.storeOptionsAsProperties(false);
+    program.storeOptionsAsProperties();
   }).toThrow();
 });


### PR DESCRIPTION
Cherry-picked from https://github.com/tj/commander.js/pull/1926 for better separation of concerns.

Additionally, a unit test has been added to cover the error.

## Problem

```js
program.setOptionValue('foo', 'bar');
console.log(program.getOptionValue('foo')); // 'bar'
console.log(program.opts()); // { foo: 'bar' }
program.storeOptionsAsProperties(); // allowed!
console.log(program.getOptionValue('foo')); // undefined
console.log(program.opts()); // {}
```

## ChangeLog

### Changed
* _Breaking:_ throw error when calling `.storeOptionsAsProperties()` after setting an option value