### PR TITLE
[PR with tiny fixes] Fix help command for subcommands with an executable handler and only a short help flag. Do not use undefined long help option flag in legacy code. Change initial variable values in test for better error messages. 

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -1809,7 +1809,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    *
    * You can optionally supply the  flags and description to override the defaults.
    *
-   * @param {string} [str]
+   * @param {string} str
    * @param {string} [flags]
    * @param {string} [description]
    * @return {this | string} `this` command for chaining, or version string if no arguments

--- a/lib/command.js
+++ b/lib/command.js
@@ -1101,9 +1101,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
     }
 
     // Fallback to parsing the help flag to invoke the help.
-    if (this._helpLongFlag) {
-      return this._dispatchSubcommand(subcommandName, [], [this._helpLongFlag]);
-    }
+    return this._dispatchSubcommand(subcommandName, [], [
+      this._helpLongFlag || this._helpShortFlag
+    ]);
   }
 
   /**

--- a/lib/command.js
+++ b/lib/command.js
@@ -1807,7 +1807,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    *
    * You can optionally supply the  flags and description to override the defaults.
    *
-   * @param {string} str
+   * @param {string} [str]
    * @param {string} [flags]
    * @param {string} [description]
    * @return {this | string} `this` command for chaining, or version string if no arguments

--- a/lib/command.js
+++ b/lib/command.js
@@ -1101,7 +1101,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
     }
 
     // Fallback to parsing the help flag to invoke the help.
-    return this._dispatchSubcommand(subcommandName, [], [this._helpLongFlag]);
+    if (this._helpLongFlag) {
+      return this._dispatchSubcommand(subcommandName, [], [this._helpLongFlag]);
+    }
   }
 
   /**
@@ -2034,7 +2036,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
     }
     context.write(helpInformation);
 
-    this.emit(this._helpLongFlag); // deprecated
+    if (this._helpLongFlag) {
+      this.emit(this._helpLongFlag); // deprecated
+    }
     this.emit('afterHelp', context);
     getCommandAndParents(this).forEach(command => command.emit('afterAllHelp', context));
   }

--- a/tests/command.addHelpText.test.js
+++ b/tests/command.addHelpText.test.js
@@ -181,7 +181,7 @@ describe('context checks with full parse', () => {
   });
 
   test('when help requested then context.error is false', () => {
-    let context = {};
+    let context;
     const program = new commander.Command();
     program
       .exitOverride()
@@ -193,7 +193,7 @@ describe('context checks with full parse', () => {
   });
 
   test('when help for error then context.error is true', () => {
-    let context = {};
+    let context;
     const program = new commander.Command();
     program
       .exitOverride()
@@ -206,7 +206,7 @@ describe('context checks with full parse', () => {
   });
 
   test('when help on program then context.command is program', () => {
-    let context = {};
+    let context;
     const program = new commander.Command();
     program
       .exitOverride()
@@ -218,7 +218,7 @@ describe('context checks with full parse', () => {
   });
 
   test('when help on subcommand and "before" subcommand then context.command is subcommand', () => {
-    let context = {};
+    let context;
     const program = new commander.Command();
     program
       .exitOverride();
@@ -231,7 +231,7 @@ describe('context checks with full parse', () => {
   });
 
   test('when help on subcommand and "beforeAll" on program then context.command is subcommand', () => {
-    let context = {};
+    let context;
     const program = new commander.Command();
     program
       .exitOverride()

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -293,7 +293,7 @@ export class Command {
    *
    * You can optionally supply the  flags and description to override the defaults.
    */
-  version(str?: string, flags?: string, description?: string): this;
+  version(str: string, flags?: string, description?: string): this;
 
   /**
    * Define a command, implemented using an action handler.

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -293,7 +293,7 @@ export class Command {
    *
    * You can optionally supply the  flags and description to override the defaults.
    */
-  version(str: string, flags?: string, description?: string): this;
+  version(str?: string, flags?: string, description?: string): this;
 
   /**
    * Define a command, implemented using an action handler.


### PR DESCRIPTION
Tiny fixes that don't really belong anywhere else.

## ChangeLog

### Changed
- ~do not call `preSubcommand` hooks when displaying help for a subcommand with an executable handler~
  - ~_(technically breaking, but hey, are we really going to assume someone relied on this?)_~
- ~deviating help flags specified for a subcommand with an executable handler via `.helpOption()` are now respected by the parent's help command (passed to the subcommand instead of the parent's help flag)~

### Fixed
- ~`.version()` optional parameter type~
- subcommands with an executable handler and only a short help flag are now handled correctly by the parent's help command
- stopped using undefined long help option flag in legacy code