### PR TITLE
Allow dynamically updating version number and version option flags and description

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -77,6 +77,9 @@ class Command extends EventEmitter {
     this._helpCommandnameAndArgs = 'help [command]';
     this._helpCommandDescription = 'display help for command';
     this._helpConfiguration = {};
+
+    this._version = undefined;
+    this._versionOptionName = undefined;
   }
 
   /**

--- a/lib/command.js
+++ b/lib/command.js
@@ -1818,16 +1818,24 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   version(str, flags, description) {
-    if (str === undefined) return this._version;
-    this._version = str;
-    flags = flags || '-V, --version';
-    description = description || 'output the version number';
-    this._versionOption = this.createOption(flags, description);
-    this.options.push(this._versionOption);
-    this.on('option:' + this._versionOption.name(), () => {
-      this._outputConfiguration.writeOut(`${str}\n`);
-      this._exit(0, 'commander.version', str);
-    });
+    if (str === undefined && flags === undefined && description === undefined) {
+      return this._version;
+    }
+    if (str !== undefined) {
+      this._version = str;
+    }
+    if (!this._versionOption) {
+      flags = flags || '-V, --version';
+      description = description || 'output the version number';
+      this._versionOption = this.createOption(flags, description);
+      this.options.push(this._versionOption);
+      this.on('option:' + this._versionOption.name(), () => {
+        this._outputConfiguration.writeOut(`${this._version}\n`);
+        this._exit(0, 'commander.version', this._version);
+      });
+    } else {
+      this._versionOption.setFlagsAndDescription(flags, description);
+    }
     return this;
   }
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -1807,7 +1807,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    *
    * You can optionally supply the  flags and description to override the defaults.
    *
-   * @param {string} str
+   * @param {string} [str]
    * @param {string} [flags]
    * @param {string} [description]
    * @return {this | string} `this` command for chaining, or version string if no arguments

--- a/lib/command.js
+++ b/lib/command.js
@@ -79,7 +79,7 @@ class Command extends EventEmitter {
     this._helpConfiguration = {};
 
     this._version = undefined;
-    this._versionOptionName = undefined;
+    this._versionOption = undefined;
   }
 
   /**
@@ -1562,10 +1562,11 @@ Expecting one of '${allowedValues.join("', '")}'`);
       // Preserve original behaviour so backwards compatible when still using properties
       const result = {};
       const len = this.options.length;
+      const versionOptionName = this._versionOption?.attributeName();
 
       for (let i = 0; i < len; i++) {
         const key = this.options[i].attributeName();
-        result[key] = key === this._versionOptionName ? this._version : this[key];
+        result[key] = key === versionOptionName ? this._version : this[key];
       }
       return result;
     }
@@ -1821,10 +1822,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
     this._version = str;
     flags = flags || '-V, --version';
     description = description || 'output the version number';
-    const versionOption = this.createOption(flags, description);
-    this._versionOptionName = versionOption.attributeName();
-    this.options.push(versionOption);
-    this.on('option:' + versionOption.name(), () => {
+    this._versionOption = this.createOption(flags, description);
+    this.options.push(this._versionOption);
+    this.on('option:' + this._versionOption.name(), () => {
       this._outputConfiguration.writeOut(`${str}\n`);
       this._exit(0, 'commander.version', str);
     });

--- a/lib/option.js
+++ b/lib/option.js
@@ -11,21 +11,8 @@ class Option {
    */
 
   constructor(flags, description) {
-    this.flags = flags;
-    this.description = description || '';
-
-    this.required = flags.includes('<'); // A value must be supplied when the option is specified.
-    this.optional = flags.includes('['); // A value is optional when the option is specified.
-    // variadic test ignores <value,...> et al which might be used to describe custom splitting of single argument
-    this.variadic = /\w\.\.\.[>\]]$/.test(flags); // The option can take multiple values.
+    this.setFlagsAndDescription(flags, description);
     this.mandatory = false; // The option must have a value after parsing, which usually means it must be specified on command line.
-    const optionFlags = splitOptionFlags(flags);
-    this.short = optionFlags.shortFlag;
-    this.long = optionFlags.longFlag;
-    this.negate = false;
-    if (this.long) {
-      this.negate = this.long.startsWith('--no-');
-    }
     this.defaultValue = undefined;
     this.defaultValueDescription = undefined;
     this.presetArg = undefined;
@@ -35,6 +22,51 @@ class Option {
     this.argChoices = undefined;
     this.conflictsWith = [];
     this.implied = undefined;
+  }
+
+  /**
+   * Set the option flags and description, if provided.
+   * Leave unchanged otherwise.
+   *
+   * @param {string} [flags]
+   * @param {string} [description]
+   */
+
+  setFlagsAndDescription(flags, description) {
+    this.setFlags(flags);
+    this.setDescription(description);
+  }
+
+  /**
+   * Set the option flags, if provided.
+   * Leave unchanged otherwise.
+   *
+   * @param {string} [flags]
+   */
+
+  setFlags(flags) {
+    if (flags !== undefined) {
+      this.flags = flags;
+      this.required = flags.includes('<'); // A value must be supplied when the option is specified.
+      this.optional = flags.includes('['); // A value is optional when the option is specified.
+      // variadic test ignores <value,...> et al which might be used to describe custom splitting of single argument
+      this.variadic = /\w\.\.\.[>\]]$/.test(flags); // The option can take multiple values.
+      const optionFlags = splitOptionFlags(flags);
+      this.short = optionFlags.shortFlag;
+      this.long = optionFlags.longFlag;
+      this.negate = this.long ? this.long.startsWith('--no-') : false;
+    }
+  }
+
+  /**
+   * Set the option description, if provided.
+   * Leave unchanged otherwise.
+   *
+   * @param {string} [description]
+   */
+
+  setDescription(description) {
+    this.description = description || this.description || '';
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -293,7 +293,7 @@ export class Command {
    *
    * You can optionally supply the  flags and description to override the defaults.
    */
-  version(str: string, flags?: string, description?: string): this;
+  version(str?: string, flags?: string, description?: string): this;
 
   /**
    * Define a command, implemented using an action handler.


### PR DESCRIPTION
## Problem

```js
// demo.js
const { Command } = require('commander');

const flags = '-v, --my-version';
const description = 'custom version option description';

var program = new Command();
program
  .version('1.0.0')
  .version('2.0.0', flags, description); // expectation: the version number and option's flags and description are updated
program.outputHelp(); // reality: a new option is added

var program = new Command();
program
  .version('1.0.0')
  .version('2.0.0'); // expectation: the version number is updated
program.outputHelp(); // reality: a new option is added

var program = new Command();
program
  .version('1.0.0')
  .version(program._version, flags); // expectation: the version option's flags are updated
program.outputHelp(); // reality: a new option is added

var program = new Command();
program
  .version('1.0.0')
  .version(program._version, undefined, description); // expectation: the version option's description is updated
program.outputHelp(); // reality: a new option is added

var program = new Command();
const result = program
  .version('1.0.0')
  .version(undefined, flags, description); // expectation: the version option's flags and description are updated
program.outputHelp(); // reality: the flags are not updated
console.log(result); // the version number is returned instead

// A real-world example
var program = new Command();
program.version('1.0.0');
if ('EARLY_ADOPTER' in process.env) {
  program.version('2.0.0'); // expectation: the version number is simply updated
}
program.outputHelp(); // reality: contains version option twice if early adopter
program.parse(['--version'], { from: 'user' }); // output is always '1.0.0'
```

```bash
EARLY_ADOPTER= node demo.js
```

## Solution

Rework `version()` to make all the above examples behave as expected.

Includes various improvements to the code for the version option, including the type fix from #1930. For reasoning behind those improvements, see the commit descriptions.

## ChangeLog

### Added
- support for dynamically updating version number and version option flags and description via `.version()`

### Fixed
-  (from [#1930](https://github.com/tj/commander.js/pull/1930)) `.version()` optional parameter type

## Peer PRs

### …solving similar problems
- #1929 and it's extensions (storing the help option instance in `_helpOption` instead of only the individual flags in `_helpShortFlag` and `_helpLongFlag`)