### PR TITLE
Add missing check for broken passThrough

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -272,6 +272,8 @@ class Command extends EventEmitter {
 
     this.commands.push(cmd);
     cmd.parent = this;
+    this._checkForIllegalPassThroughOptions(cmd, this);
+
     return this;
   }
 
@@ -721,6 +723,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
   enablePositionalOptions(positional = true) {
     this._enablePositionalOptions = !!positional;
+    this.commands.forEach((command) => {
+      this._checkForIllegalPassThroughOptions(command, this);
+    });
     return this;
   }
 
@@ -735,10 +740,20 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
   passThroughOptions(passThrough = true) {
     this._passThroughOptions = !!passThrough;
-    if (!!this.parent && passThrough && !this.parent._enablePositionalOptions) {
-      throw new Error('passThroughOptions can not be used without turning on enablePositionalOptions for parent command(s)');
-    }
+    this._checkForIllegalPassThroughOptions(this, this.parent);
     return this;
+  }
+
+  /**
+   * @param {Command} command
+   * @param {Command | null} parent
+   * @api private
+   */
+
+  _checkForIllegalPassThroughOptions(command, parent) {
+    if (parent && command._passThroughOptions && !parent._enablePositionalOptions) {
+      throw new Error(`passThroughOptions cannot be used for '${command._name}' without turning on enablePositionalOptions for parent command${parent._name ? ` '${parent._name}'` : ''}`);
+    }
   }
 
   /**

--- a/lib/command.js
+++ b/lib/command.js
@@ -272,7 +272,7 @@ class Command extends EventEmitter {
 
     this.commands.push(cmd);
     cmd.parent = this;
-    this._checkForBrokenPassThrough(cmd, this);
+    cmd._checkForBrokenPassThrough();
 
     return this;
   }
@@ -737,19 +737,17 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
   passThroughOptions(passThrough = true) {
     this._passThroughOptions = !!passThrough;
-    this._checkForBrokenPassThrough(this, this.parent);
+    this._checkForBrokenPassThrough();
     return this;
   }
 
   /**
-   * @param {Command} command
-   * @param {Command | null} parent
    * @api private
    */
 
-  _checkForBrokenPassThrough(command, parent) {
-    if (parent && command._passThroughOptions && !parent._enablePositionalOptions) {
-      throw new Error(`passThroughOptions cannot be used for '${command._name}' without turning on enablePositionalOptions for parent command(s)`);
+  _checkForBrokenPassThrough() {
+    if (this.parent && this._passThroughOptions && !this.parent._enablePositionalOptions) {
+      throw new Error(`passThroughOptions cannot be used for '${this._name}' without turning on enablePositionalOptions for parent command(s)`);
     }
   }
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -272,7 +272,7 @@ class Command extends EventEmitter {
 
     this.commands.push(cmd);
     cmd.parent = this;
-    this._checkForIllegalPassThroughOptions(cmd, this);
+    this._checkForBrokenPassThrough(cmd, this);
 
     return this;
   }
@@ -737,7 +737,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
   passThroughOptions(passThrough = true) {
     this._passThroughOptions = !!passThrough;
-    this._checkForIllegalPassThroughOptions(this, this.parent);
+    this._checkForBrokenPassThrough(this, this.parent);
     return this;
   }
 
@@ -747,7 +747,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    * @api private
    */
 
-  _checkForIllegalPassThroughOptions(command, parent) {
+  _checkForBrokenPassThrough(command, parent) {
     if (parent && command._passThroughOptions && !parent._enablePositionalOptions) {
       throw new Error(`passThroughOptions cannot be used for '${command._name}' without turning on enablePositionalOptions for parent command${parent._name ? ` '${parent._name}'` : ''}`);
     }

--- a/lib/command.js
+++ b/lib/command.js
@@ -749,7 +749,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
   _checkForBrokenPassThrough(command, parent) {
     if (parent && command._passThroughOptions && !parent._enablePositionalOptions) {
-      throw new Error(`passThroughOptions cannot be used for '${command._name}' without turning on enablePositionalOptions for parent command${parent._name ? ` '${parent._name}'` : ''}`);
+      throw new Error(`passThroughOptions cannot be used for '${command._name}' without turning on enablePositionalOptions for parent command(s)`);
     }
   }
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -723,9 +723,6 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
   enablePositionalOptions(positional = true) {
     this._enablePositionalOptions = !!positional;
-    this.commands.forEach((command) => {
-      this._checkForIllegalPassThroughOptions(command, this);
-    });
     return this;
   }
 

--- a/tests/command.positionalOptions.test.js
+++ b/tests/command.positionalOptions.test.js
@@ -381,17 +381,6 @@ describe('illegal passThroughOptions', () => {
       program.addCommand(sub);
     }).toThrow();
   });
-
-  test('when program has subcommand with passThroughOptions and reset to non-positional then error', () => {
-    const program = new commander.Command()
-      .enablePositionalOptions();
-    program.command('sub')
-      .passThroughOptions();
-
-    expect(() => {
-      program.enablePositionalOptions(false);
-    }).toThrow();
-  });
 });
 
 // ------------------------------------------------------------------------------

--- a/tests/command.positionalOptions.test.js
+++ b/tests/command.positionalOptions.test.js
@@ -362,13 +362,36 @@ describe('program with action handler and positionalOptions and subcommand', () 
 
 // ------------------------------------------------------------------------------
 
-test('when program not positional and turn on passthrough in subcommand then error', () => {
-  const program = new commander.Command();
-  const sub = program.command('sub');
+describe('illegal passThroughOptions', () => {
+  test('when program not positional and turn on passThroughOptions in subcommand then error', () => {
+    const program = new commander.Command();
+    const sub = program.command('sub');
 
-  expect(() => {
-    sub.passThroughOptions();
-  }).toThrow();
+    expect(() => {
+      sub.passThroughOptions();
+    }).toThrow();
+  });
+
+  test('when program not positional and add subcommand with passThroughOptions then error', () => {
+    const program = new commander.Command();
+    const sub = new commander.Command('sub')
+      .passThroughOptions();
+
+    expect(() => {
+      program.addCommand(sub);
+    }).toThrow();
+  });
+
+  test('when program has subcommand with passThroughOptions and reset to non-positional then error', () => {
+    const program = new commander.Command()
+      .enablePositionalOptions();
+    program.command('sub')
+      .passThroughOptions();
+
+    expect(() => {
+      program.enablePositionalOptions(false);
+    }).toThrow();
+  });
 });
 
 // ------------------------------------------------------------------------------

--- a/tests/command.positionalOptions.test.js
+++ b/tests/command.positionalOptions.test.js
@@ -362,7 +362,7 @@ describe('program with action handler and positionalOptions and subcommand', () 
 
 // ------------------------------------------------------------------------------
 
-describe('illegal passThroughOptions', () => {
+describe('broken passThrough', () => {
   test('when program not positional and turn on passThroughOptions in subcommand then error', () => {
     const program = new commander.Command();
     const sub = program.command('sub');


### PR DESCRIPTION
## Problem

```js
const { Command } = require('commander');

try {
  new Command('parent')
    .command('sub')
    .passThroughOptions(); // not allowed without enablePositionalOptions for parent
} catch (err) {
  console.error(err);
}

try {
  const parent = new Command('parent');
  const sub = new Command('sub')
    .passThroughOptions();
  parent.addCommand(sub); // allowed without enablePositionalOptions for parent
} catch (err) {
  console.error(err);
}
```

<details>
<summary>A check for this case is considered unnecessary, see <a href="https://github.com/tj/commander.js/pull/1937#discussion_r1284917245">comment</a></summary>

```js
try {
  const parent = new Command('parent')
    .enablePositionalOptions();
  parent.command('sub')
    .passThroughOptions();
  parent.enablePositionalOptions(false); // allowed despite passThroughOptions for sub
} catch (err) {
  console.error(err);
}
```
</details>

## Solution

Throw errors in all demonstrated cases. Additionally make the error message more meaningful by including the command name (similar to #1923 and #1924).

## ChangeLog

### Changed
- _Breaking:_ throw when a subcommand with  `passThroughOptions` is added to a command without `enablePositionalOptions`