### PR TITLE
Refactor `getCommandAndParents()` into `Command._getCommandAndAncestors()` and use consistently

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -1756,13 +1756,14 @@ Expecting one of '${allowedValues.join("', '")}'`);
     if (flag.startsWith('--') && this._showSuggestionAfterError) {
       // Looping to pick up the global options too
       let candidateFlags = [];
-      for (const command of this._getCommandAndAncestors()) {
+      let command = this;
+      do {
         const moreFlags = command.createHelp().visibleOptions(command)
           .filter(option => option.long)
           .map(option => option.long);
         candidateFlags = candidateFlags.concat(moreFlags);
-        if (command._enablePositionalOptions) break;
-      }
+        command = command.parent;
+      } while (command && !command._enablePositionalOptions);
       suggestion = suggestSimilar(flag, candidateFlags);
     }
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -1378,13 +1378,13 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
   _checkForMissingMandatoryOptions() {
     // Walk up hierarchy so can call in subcommand after checking for displaying help.
-    for (let cmd = this; cmd; cmd = cmd.parent) {
+    this._getCommandAndAncestors().forEach((cmd) => {
       cmd.options.forEach((anOption) => {
         if (anOption.mandatory && (cmd.getOptionValue(anOption.attributeName()) === undefined)) {
           cmd.missingMandatoryOptionValue(anOption);
         }
       });
-    }
+    });
   }
 
   /**
@@ -1425,9 +1425,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
   _checkForConflictingOptions() {
     // Walk up hierarchy so can call in subcommand after checking for displaying help.
-    for (let cmd = this; cmd; cmd = cmd.parent) {
+    this._getCommandAndAncestors().forEach((cmd) => {
       cmd._checkForConflictingLocalOptions();
-    }
+    });
   }
 
   /**
@@ -1756,14 +1756,13 @@ Expecting one of '${allowedValues.join("', '")}'`);
     if (flag.startsWith('--') && this._showSuggestionAfterError) {
       // Looping to pick up the global options too
       let candidateFlags = [];
-      let command = this;
-      do {
+      for (const command of this._getCommandAndAncestors()) {
         const moreFlags = command.createHelp().visibleOptions(command)
           .filter(option => option.long)
           .map(option => option.long);
         candidateFlags = candidateFlags.concat(moreFlags);
-        command = command.parent;
-      } while (command && !command._enablePositionalOptions);
+        if (command._enablePositionalOptions) break;
+      }
       suggestion = suggestSimilar(flag, candidateFlags);
     }
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -110,6 +110,19 @@ class Command extends EventEmitter {
   }
 
   /**
+   * @returns {Command[]}
+   * @api private
+   */
+
+  _getCommandAndAncestors() {
+    const result = [];
+    for (let command = this; command; command = command.parent) {
+      result.push(command);
+    }
+    return result;
+  }
+
+  /**
    * Define a command.
    *
    * There are two styles of command: pay attention to where to put the description.
@@ -825,7 +838,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
   getOptionValueSourceWithGlobals(key) {
     // global overwrites local, like optsWithGlobals
     let source;
-    getCommandAndParents(this).forEach((cmd) => {
+    this._getCommandAndAncestors().forEach((cmd) => {
       if (cmd.getOptionValueSource(key) !== undefined) {
         source = cmd.getOptionValueSource(key);
       }
@@ -1208,7 +1221,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
   _chainOrCallHooks(promise, event) {
     let result = promise;
     const hooks = [];
-    getCommandAndParents(this)
+    this._getCommandAndAncestors()
       .reverse()
       .filter(cmd => cmd._lifeCycleHooks[event] !== undefined)
       .forEach(hookedCommand => {
@@ -1577,7 +1590,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
   optsWithGlobals() {
     // globals overwrite locals
-    return getCommandAndParents(this).reduce(
+    return this._getCommandAndAncestors().reduce(
       (combinedOptions, cmd) => Object.assign(combinedOptions, cmd.opts()),
       {}
     );
@@ -2022,7 +2035,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     }
     const context = this._getHelpContext(contextOptions);
 
-    getCommandAndParents(this).reverse().forEach(command => command.emit('beforeAllHelp', context));
+    this._getCommandAndAncestors().reverse().forEach(command => command.emit('beforeAllHelp', context));
     this.emit('beforeHelp', context);
 
     let helpInformation = this.helpInformation(context);
@@ -2036,7 +2049,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
     this.emit(this._helpLongFlag); // deprecated
     this.emit('afterHelp', context);
-    getCommandAndParents(this).forEach(command => command.emit('afterAllHelp', context));
+    this._getCommandAndAncestors().forEach(command => command.emit('afterAllHelp', context));
   }
 
   /**
@@ -2177,20 +2190,6 @@ function incrementNodeInspectorPort(args) {
     }
     return arg;
   });
-}
-
-/**
- * @param {Command} startCommand
- * @returns {Command[]}
- * @api private
- */
-
-function getCommandAndParents(startCommand) {
-  const result = [];
-  for (let command = startCommand; command; command = command.parent) {
-    result.push(command);
-  }
-  return result;
 }
 
 exports.Command = Command;

--- a/lib/help.js
+++ b/lib/help.js
@@ -101,10 +101,10 @@ class Help {
     if (!this.showGlobalOptions) return [];
 
     const globalOptions = [];
-    for (let parentCmd = cmd.parent; parentCmd; parentCmd = parentCmd.parent) {
-      const visibleOptions = parentCmd.options.filter((option) => !option.hidden);
+    cmd._getCommandAndAncestors().slice(1).forEach((ancestorCmd) => {
+      const visibleOptions = ancestorCmd.options.filter((option) => !option.hidden);
       globalOptions.push(...visibleOptions);
-    }
+    });
     if (this.sortOptions) {
       globalOptions.sort(this.compareOptions);
     }
@@ -240,11 +240,11 @@ class Help {
     if (cmd._aliases[0]) {
       cmdName = cmdName + '|' + cmd._aliases[0];
     }
-    let parentCmdNames = '';
-    for (let parentCmd = cmd.parent; parentCmd; parentCmd = parentCmd.parent) {
-      parentCmdNames = parentCmd.name() + ' ' + parentCmdNames;
-    }
-    return parentCmdNames + cmdName + ' ' + cmd.usage();
+    let ancestorCmdNames = '';
+    cmd._getCommandAndAncestors().slice(1).forEach((ancestorCmd) => {
+      ancestorCmdNames = ancestorCmd.name() + ' ' + ancestorCmdNames;
+    });
+    return ancestorCmdNames + cmdName + ' ' + cmd.usage();
   }
 
   /**

--- a/lib/help.js
+++ b/lib/help.js
@@ -101,10 +101,10 @@ class Help {
     if (!this.showGlobalOptions) return [];
 
     const globalOptions = [];
-    cmd._getCommandAndAncestors().slice(1).forEach((ancestorCmd) => {
+    for (let ancestorCmd = cmd.parent; ancestorCmd; ancestorCmd = ancestorCmd.parent) {
       const visibleOptions = ancestorCmd.options.filter((option) => !option.hidden);
       globalOptions.push(...visibleOptions);
-    });
+    }
     if (this.sortOptions) {
       globalOptions.sort(this.compareOptions);
     }
@@ -241,9 +241,9 @@ class Help {
       cmdName = cmdName + '|' + cmd._aliases[0];
     }
     let ancestorCmdNames = '';
-    cmd._getCommandAndAncestors().slice(1).forEach((ancestorCmd) => {
+    for (let ancestorCmd = cmd.parent; ancestorCmd; ancestorCmd = ancestorCmd.parent) {
       ancestorCmdNames = ancestorCmd.name() + ' ' + ancestorCmdNames;
-    });
+    }
     return ancestorCmdNames + cmdName + ' ' + cmd.usage();
   }
 


### PR DESCRIPTION
Cherry-picked from #1938.

A purely cosmetic PR Introducing no functional changes or changes visible to the user.

Replaces `getCommandAndParents()` with `Command._getCommandAndAncestors()`
- …because an instance method is where the function logically belongs.
- Renamed because "ancestors" is more precise than "parents".

Also changes the code to make use of the function whenever appropriate. (I thought it was a good idea after introducing `currentParent` replacing `parent` in #1938. I ended up getting rid of it and simply upgrading the `parent` semantics, but who knows what changes to the parent resolution could be made in the future. It is better to keep the code for getting the ancestors in one place.)