### PR TITLE
Warn about async calls in `.parse()`

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -12,8 +12,6 @@ const { suggestSimilar } = require('./suggestSimilar');
 
 // @ts-check
 
-const PRODUCTION = process.env.NODE_ENV === 'production';
-
 class Command extends EventEmitter {
   /**
    * Initialize a new `Command`.
@@ -909,7 +907,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
   parse(argv, parseOptions) {
     const userArgs = this._prepareUserArgs(argv, parseOptions);
     const result = this._parseCommand([], userArgs);
-    if (!PRODUCTION && isThenable(result)) {
+    if (isThenable(result)) {
       console.warn(`.parse() is incompatible with async hooks and actions.
 Use .parseAsync() instead.`);
     }

--- a/lib/command.js
+++ b/lib/command.js
@@ -12,6 +12,8 @@ const { suggestSimilar } = require('./suggestSimilar');
 
 // @ts-check
 
+const PRODUCTION = process.env.NODE_ENV === 'production';
+
 class Command extends EventEmitter {
   /**
    * Initialize a new `Command`.
@@ -906,7 +908,11 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
   parse(argv, parseOptions) {
     const userArgs = this._prepareUserArgs(argv, parseOptions);
-    this._parseCommand([], userArgs);
+    const result = this._parseCommand([], userArgs);
+    if (!PRODUCTION && isThenable(result)) {
+      console.warn(`.parse() is incompatible with async hooks and actions.
+Use .parseAsync() instead.`);
+    }
 
     return this;
   }
@@ -1188,8 +1194,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   _chainOrCall(promise, fn) {
-    // thenable
-    if (promise && promise.then && typeof promise.then === 'function') {
+    if (isThenable(promise)) {
       // already have a promise, chain callback
       return promise.then(() => fn());
     }
@@ -2191,6 +2196,16 @@ function getCommandAndParents(startCommand) {
     result.push(command);
   }
   return result;
+}
+
+/**
+ * @param {*} value
+ * @returns {boolean}
+ * @api private
+ */
+
+function isThenable(value) {
+  return typeof value?.then === 'function';
 }
 
 exports.Command = Command;


### PR DESCRIPTION
Partially fixes #1916.

Cherry-picked from #1917 for better separation of concerns and because the change is the only change introduced there that can be combined meaningfully with #1938.

I would like this PR and #1938 to supersede #1917. See [#1917 (comment)](https://github.com/tj/commander.js/pull/1917#issuecomment-1666467716) for details.

#### Why `console.warn()` and not throw from within `parse()` / `parseAsync()`?

Errors thrown from `parse()` / `parseAsync()` are expected to have originated in user-supplied code (argParsers, hooks and actions).

An alternative could be to `console.error()` and `process.exit()` with a non-zero exit code, effectively forbidding the wrong usage, but what I don't like is the discrepancy between this approach and how all other library errors are simply thrown and can be handled by the user.

## ChangeLog

### Added
- warnings about async hook and action calls made in `.parse()`

## Peer PRs

### Warnings need to be consistent with…
- #1915
- #1917
- #1931
- #1938

### Requires changes when merged with…
- #1955