### PR TITLE
Add missing support for command-arguments to commands added with `.addCommand()`

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -21,6 +21,15 @@ class Command extends EventEmitter {
 
   constructor(name) {
     super();
+    const nameMatchResult = name?.match(/([^ ]+) *(.*)/);
+    /** @type {string} */
+    this._name = nameMatchResult?.[1] ?? '';
+    /** @type {Argument[]} */
+    this._args = [];
+    if (nameMatchResult?.[2]) {
+      this.arguments(nameMatchResult[2]);
+    }
+
     /** @type {Command[]} */
     this.commands = [];
     /** @type {Option[]} */
@@ -28,14 +37,11 @@ class Command extends EventEmitter {
     this.parent = null;
     this._allowUnknownOption = false;
     this._allowExcessArguments = true;
-    /** @type {Argument[]} */
-    this._args = [];
     /** @type {string[]} */
     this.args = []; // cli args with options removed
     this.rawArgs = [];
     this.processedArgs = []; // like .args but after custom processing and collecting variadic
     this._scriptPath = null;
-    this._name = name || '';
     this._optionValues = {};
     this._optionValueSources = {}; // default, env, cli etc
     this._storeOptionsAsProperties = false;
@@ -142,9 +148,8 @@ class Command extends EventEmitter {
       desc = null;
     }
     opts = opts || {};
-    const [, name, args] = nameAndArgs.match(/([^ ]+) *(.*)/);
 
-    const cmd = this.createCommand(name);
+    const cmd = this.createCommand(nameAndArgs);
     if (desc) {
       cmd.description(desc);
       cmd._executableHandler = true;
@@ -152,7 +157,7 @@ class Command extends EventEmitter {
     if (opts.isDefault) this._defaultCommandName = cmd._name;
     cmd._hidden = !!(opts.noHelp || opts.hidden); // noHelp is deprecated old name for hidden
     cmd._executableFile = opts.executableFile || null; // Custom name for executable file, set missing to null to match constructor
-    if (args) cmd.arguments(args);
+
     this.commands.push(cmd);
     cmd.parent = this;
     cmd.copyInheritedSettings(this);


### PR DESCRIPTION
## Problem

```js
const { Command } = require('commander');

{
  const program = new Command();
  program.command('sub <arg>').action(arg => console.log(arg));
  program.parse(['sub', 'arg'], { from: 'user' }); // arg
}

{
  const program = new Command();
  const sub = new Command('sub <arg>').action(arg => console.log(arg));
  program.addCommand(sub);
  program.parse(['sub', 'arg'], { from: 'user' }); // error: unknown command 'sub'
}
```

## Solution

Move declared command-argument parsing from `.command()` to constructor.

## ChangeLog

### Fixed
- added missing support for command-arguments to commands added with `.addCommand()`