### PR TITLE
Add clarifications about `passThroughOptions` handling of unknown options to docs and comments

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -981,8 +981,8 @@ program -b subcommand
 program subcommand -b
 ```
 
-By default options are recognised before and after command-arguments. To only process options that come
-before the command-arguments, use `.passThroughOptions()`. This lets you pass the  arguments and following options through to another program
+By default, options are recognised before and after command-arguments. To only process options that come
+before the command-arguments (and before any unknown options), use `.passThroughOptions()`. This lets you pass the arguments and following options through to another program
 without needing to use `--` to end the option processing.
 To use pass through options in a subcommand, the program needs to enable positional options.
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -1535,7 +1535,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
         }
       }
 
-      // If using passThroughOptions, stop processing options at first command-argument.
+      // If using passThroughOptions, stop processing options at first command-argument / unknown option.
+      // Processing after an unknown option is not possible because there is no way to know if the next argument is its option-argument and we should continue,
+      // or if it is a command-argument and we should stop.
       if (this._passThroughOptions) {
         dest.push(arg);
         if (args.length > 0) dest.push(...args);

--- a/lib/command.js
+++ b/lib/command.js
@@ -1535,9 +1535,10 @@ Expecting one of '${allowedValues.join("', '")}'`);
         }
       }
 
-      // If using passThroughOptions, stop processing options at first command-argument / unknown option.
-      // Processing after an unknown option is not possible because there is no way to know if the next argument is its option-argument and we should continue,
-      // or if it is a command-argument and we should stop.
+      // If using passThroughOptions, stop processing options at first command-argument.
+      // The processing is also stopped when an unknown option is encountered because
+      // - either allowUnknownOption is on and so the option is treated as a command-argument,
+      // - or it is off and so an error will be thrown anyway since no subcommand was found that could reprocess the option.
       if (this._passThroughOptions) {
         dest.push(arg);
         if (args.length > 0) dest.push(...args);


### PR DESCRIPTION
## Problem
#1936

## Solution
What caused my confusion turned out to be desired behavior.

This PR includes clarifications that could help avoid confusion in the future.

## ChangeLog
### Fixed
- extended documentation about `.passThroughOptions()` by a missing mention of unknown option handling