### PR TITLE
Correctly handle `allowUnknownOption` in `.parseOptions()`

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -1445,6 +1445,8 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
     // parse options
     let activeVariadicOption = null;
+    let onlyKnownOptionsSoFar = true;
+    let reprocessedBySubcommand = false;
     while (args.length) {
       const arg = args.shift();
 
@@ -1510,29 +1512,48 @@ Expecting one of '${allowedValues.join("', '")}'`);
         }
       }
 
-      // Not a recognised option by this command.
-      // Might be a command-argument, or subcommand option, or unknown option, or help command or option.
+      // Not a recognised option by this command. Might be
+      // - a subcommand,
+      // - the help option encountered after a subcommand (considered unknown),
+      // - any other option unknown to this command,
+      // - or a command-argument.
 
-      // An unknown option means further arguments also classified as unknown so can be reprocessed by subcommands.
-      if (maybeOption(arg)) {
-        dest = unknown;
+      if (onlyKnownOptionsSoFar && !reprocessedBySubcommand) {
+        reprocessedBySubcommand = true; // reset to false later if not entering subcommand
+        const stopAtSubcommand = (
+          this._enablePositionalOptions || this._passThroughOptions
+        );
+        if (this._findCommand(arg)) {
+          if (stopAtSubcommand) {
+            operands.push(arg);
+            unknown.push(...args);
+            break;
+          }
+        } else if (arg === this._helpCommandName && this._hasImplicitHelpCommand()) {
+          if (stopAtSubcommand) {
+            operands.push(arg, ...args);
+            break;
+          }
+        } else if (this._defaultCommandName) {
+          if (stopAtSubcommand) {
+            unknown.push(arg, ...args);
+            break;
+          }
+        } else {
+          reprocessedBySubcommand = false;
+        }
       }
 
-      // If using positionalOptions, stop processing our options at subcommand.
-      if ((this._enablePositionalOptions || this._passThroughOptions) && operands.length === 0 && unknown.length === 0) {
-        if (this._findCommand(arg)) {
-          operands.push(arg);
-          if (args.length > 0) unknown.push(...args);
-          break;
-        } else if (arg === this._helpCommandName && this._hasImplicitHelpCommand()) {
-          operands.push(arg);
-          if (args.length > 0) operands.push(...args);
-          break;
-        } else if (this._defaultCommandName) {
-          unknown.push(arg);
-          if (args.length > 0) unknown.push(...args);
-          break;
-        }
+      onlyKnownOptionsSoFar = false;
+
+      // Respect the fact that the working principle of allowUnknownOption is to treat unknown options as command-arguments.
+      const treatUnknownOptionAsCommandArgument = (
+        this._allowUnknownOption && !reprocessedBySubcommand
+      );
+
+      // An unknown option means further arguments also classified as unknown so can be reprocessed by subcommands.
+      if (maybeOption(arg) && !treatUnknownOptionAsCommandArgument) {
+        dest = unknown;
       }
 
       // If using passThroughOptions, stop processing options at first command-argument.

--- a/lib/command.js
+++ b/lib/command.js
@@ -1542,16 +1542,18 @@ Expecting one of '${allowedValues.join("', '")}'`);
           reprocessedBySubcommand = false;
         }
       }
-
       onlyKnownOptionsSoFar = false;
 
       // Respect the fact that the working principle of allowUnknownOption is to treat unknown options as command-arguments.
       const treatUnknownOptionAsCommandArgument = (
         this._allowUnknownOption && !reprocessedBySubcommand
       );
+      const isUnknownOption = (
+        maybeOption(arg) && !treatUnknownOptionAsCommandArgument
+      );
 
       // An unknown option means further arguments also classified as unknown so can be reprocessed by subcommands.
-      if (maybeOption(arg) && !treatUnknownOptionAsCommandArgument) {
+      if (isUnknownOption) {
         dest = unknown;
       }
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -1514,8 +1514,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
       // Not a recognised option by this command. Might be
       // - a subcommand,
-      // - the help option encountered after a subcommand (considered unknown),
-      // - any other option unknown to this command,
+      // - an option unknown to this command,
       // - or a command-argument.
 
       if (onlyKnownOptionsSoFar && !reprocessedBySubcommand) {

--- a/tests/command.allowUnknownOption.test.js
+++ b/tests/command.allowUnknownOption.test.js
@@ -92,4 +92,12 @@ describe('allowUnknownOption', () => {
       program.parse(['node', 'test', 'sub', '-m']);
     }).not.toThrow();
   });
+
+  test('when specify unknown program option and allowUnknownOption then unknown option parsed as operand', () => {
+    const program = new commander.Command();
+    program
+      .allowUnknownOption();
+    const result = program.parseOptions(['-m']);
+    expect(result).toEqual({ operands: ['-m'], unknown: [] });
+  });
 });

--- a/tests/command.helpCommand.test.js
+++ b/tests/command.helpCommand.test.js
@@ -21,22 +21,6 @@ describe('help command listed in helpInformation', () => {
     expect(helpInformation).toMatch(/help \[command\]/);
   });
 
-  test('when program has subcommands and specify only unknown option then display help', () => {
-    const program = new commander.Command();
-    program
-      .configureHelp({ formatHelp: () => '' })
-      .exitOverride()
-      .allowUnknownOption()
-      .command('foo');
-    let caughtErr;
-    try {
-      program.parse(['--unknown'], { from: 'user' });
-    } catch (err) {
-      caughtErr = err;
-    }
-    expect(caughtErr.code).toEqual('commander.help');
-  });
-
   test('when program has subcommands and suppress help command then no help command', () => {
     const program = new commander.Command();
     program.addHelpCommand(false);


### PR DESCRIPTION
## Problem

#1945

## Solution

Implement the first solution suggested in the issue.

Unknown options are now treated as command-arguments in `.parseOptions()` as suggested by the docs.

The incorrect test has been removed.

## ChangeLog

### Fixed
- _Breaking:_ treat unknown options as command-arguments in `.parseOptions()` as suggested by the docs