### PR TITLE
Fix tests (Node.js v18.17.0)

### DIFF
--- a/tests/command.default.test.js
+++ b/tests/command.default.test.js
@@ -3,7 +3,12 @@ const commander = require('../');
 const path = require('path');
 const util = require('util');
 
-const execFileAsync = util.promisify(childProcess.execFile);
+const execFileAsync = function(...args) {
+  if (args.length < 3) args.push({});
+  args[2].env ??= { ...process.env };
+  delete args[2].env.FORCE_COLOR;
+  return util.promisify(childProcess.execFile).apply(this, args);
+};
 
 describe('default executable command', () => {
   // Calling node explicitly so pm works without file suffix cross-platform.

--- a/tests/command.executableSubcommand.inspect.test.js
+++ b/tests/command.executableSubcommand.inspect.test.js
@@ -2,7 +2,12 @@ const childProcess = require('child_process');
 const path = require('path');
 const util = require('util');
 
-const execFileAsync = util.promisify(childProcess.execFile);
+const execFileAsync = function(...args) {
+  if (args.length < 3) args.push({});
+  args[2].env ??= { ...process.env };
+  delete args[2].env.FORCE_COLOR;
+  return util.promisify(childProcess.execFile).apply(this, args);
+};
 
 // Test the special handling for --inspect to increment fixed debug port numbers.
 // If we reuse port we can get conflicts because port not released fast enough.

--- a/tests/command.executableSubcommand.lookup.test.js
+++ b/tests/command.executableSubcommand.lookup.test.js
@@ -1,7 +1,12 @@
 const childProcess = require('child_process');
 const path = require('path');
 const util = require('util');
-const execFileAsync = util.promisify(childProcess.execFile);
+const execFileAsync = function(...args) {
+  if (args.length < 3) args.push({});
+  args[2].env ??= { ...process.env };
+  delete args[2].env.FORCE_COLOR;
+  return util.promisify(childProcess.execFile).apply(this, args);
+};
 
 // Calling node explicitly so pm works without file suffix cross-platform.
 // This file does end-to-end tests actually spawning program.

--- a/tests/command.parseOptions.test.js
+++ b/tests/command.parseOptions.test.js
@@ -3,7 +3,12 @@ const commander = require('../');
 const path = require('path');
 const util = require('util');
 
-const execFileAsync = util.promisify(childProcess.execFile);
+const execFileAsync = function(...args) {
+  if (args.length < 3) args.push({});
+  args[2].env ??= { ...process.env };
+  delete args[2].env.FORCE_COLOR;
+  return util.promisify(childProcess.execFile).apply(this, args);
+};
 
 // Combination of parse and parseOptions tests which are are more about details
 // than high level behaviours which are tested elsewhere.


### PR DESCRIPTION
Tests of `node` child processes stopped working on Windows after upgrading to Node.js v18.17.0. The reason turned out to be the fact Jest allows an internally set value of the [`FORCE_COLOR`](https://nodejs.org/api/cli.html#force_color1-2-3) environment variable to leak through to tests, see jestjs/jest#14391. This results in colored output of the child processes, and so comparisons of the output with expected values fail.

 This PR is a quick fix unsetting the variable for the child processes.