### PR TITLE
Deprecate version retrieval

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -15,6 +15,7 @@ They are currently still available for backwards compatibility, but should not b
   - [InvalidOptionArgumentError](#invalidoptionargumenterror)
   - [Short option flag longer than a single character](#short-option-flag-longer-than-a-single-character)
   - [Import from `commander/esm.mjs`](#import-from-commanderesmmjs)
+  - [Version string retrieval](#version-string-retrieval)
 
 ## RegExp .option() parameter
 
@@ -207,3 +208,17 @@ import { Command } from 'commander';
 ```
 
 README updated in Commander v9. Deprecated from Commander v9.
+
+## Version string retrieval
+
+The version string passed to `.version()` was stored internally. The string could be accessed two ways, although neither
+was ever described in the README.
+
+```js
+program.storeOptionsAsProperties();
+program.version('1.0.0');
+console.log(program.version());
+console.log(program.opts().version); // only when using legacy storeOptionAsProperties
+``
+
+Deprecated from Commander v11.


### PR DESCRIPTION
# Pull Request

## Problem

An early implementation of `.version()` acted a bit like a getter/setter for a version property:
- https://github.com/tj/commander.js/blob/f0529b159e11b73b97e7d3238d3b2c561ffdb3f0/lib/commander.js#L584C5-L584C5

For historical interest, in that code `this._version` also got used to decide whether to guess the version when `.parse()` was called! Long gone.
- https://github.com/tj/commander.js/blob/f0529b159e11b73b97e7d3238d3b2c561ffdb3f0/lib/commander.js#L349C13-L349C21

When `.opts()` got added, the version option/property got returned as well. [sic]

Retrieving the version property has never been documented, and the JSDoc and TypeScript typings define the version string parameter as required (so do not include the getter usage).

1) I definitely don't think the version should be returned in `.opts()` (and that is only done when `.storeOptionsAsProperties()` is turned on, so already a legacy behaviour).

2) I am dubious about supporting a getter for the version. I think of `.version()` as a convenience for adding the version option, and not as a getter for a version property. Because it has never been documented, I have never used it that way myself and don't recall any mention of it in issues. However, I feel less strongly about this than (1) and don't mind keeping it if people are using it.

## Solution

Added to Deprecated documentation to make it explicit that may remove the functionality in future.

## ChangeLog

- _deprecated_ retrieve version string using `cmd.version()` with no parameters
- _deprecated_ retrieve version string using `cmd.opts().version` (and `.storeOptionsAsProperties()`)
