### PR TITLE
Add `.suppressWarnings()` for warnings in #1915 #1931 #1938 #1940

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -57,6 +57,7 @@ class Command extends EventEmitter {
     this._showHelpAfterError = false;
     this._showSuggestionAfterError = true;
 
+    this._suppressWarnings = false;
     // see .configureOutput() for docs
     this._outputConfiguration = {
       writeOut: (str) => process.stdout.write(str),
@@ -88,6 +89,7 @@ class Command extends EventEmitter {
    * @return {Command} `this` command for chaining
    */
   copyInheritedSettings(sourceCommand) {
+    this._suppressWarnings = sourceCommand._suppressWarnings;
     this._outputConfiguration = sourceCommand._outputConfiguration;
     this._hasHelpOption = sourceCommand._hasHelpOption;
     this._helpFlags = sourceCommand._helpFlags;
@@ -106,6 +108,19 @@ class Command extends EventEmitter {
     this._showHelpAfterError = sourceCommand._showHelpAfterError;
     this._showSuggestionAfterError = sourceCommand._showSuggestionAfterError;
 
+    return this;
+  }
+
+  /**
+   * Suppress warnings about library usage patterns that are not always wrong
+   * but are often connected with a developer mistake,
+   * or a different pattern better suited for the use case scenario is offered.
+   *
+   * @param {boolean} [suppress=true]
+   * @return {Command} `this` command for chaining
+   */
+  suppressWarnings(suppress = true) {
+    this._suppressWarnings = !!suppress;
     return this;
   }
 

--- a/tests/command.chain.test.js
+++ b/tests/command.chain.test.js
@@ -4,6 +4,12 @@ const { Command, Option, Argument } = require('../');
 // parse and parseAsync are tested in command.parse.test.js
 
 describe('Command methods that should return this for chaining', () => {
+  test('when call .suppressWarnings() then returns this', () => {
+    const program = new Command();
+    const result = program.suppressWarnings();
+    expect(result).toBe(program);
+  });
+
   test('when call .command() with description for stand-alone executable then returns this', () => {
     const program = new Command();
     const result = program.command('foo', 'foo description');

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -286,6 +286,15 @@ export class Command {
   constructor(name?: string);
 
   /**
+   * Suppress warnings about library usage patterns that are not always wrong
+   * but are often connected with a developer mistake,
+   * or a different pattern better suited for the use case scenario is offered.
+   *
+   * @return {Command} `this` command for chaining
+   */
+  suppressWarnings(suppress?: boolean): this;
+
+  /**
    * Set the program version to `str`.
    *
    * This method auto-registers the "-V, --version" flag

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -32,6 +32,10 @@ expectType<readonly commander.Command[]>(program.commands);
 expectType<readonly commander.Option[]>(program.options);
 expectType<commander.Command | null>(program.parent);
 
+// suppressWarnings
+expectType<commander.Command>(program.suppressWarnings());
+expectType<commander.Command>(program.suppressWarnings(false));
+
 // version
 expectType<commander.Command>(program.version('1.2.3'));
 expectType<commander.Command>(program.version('1.2.3', '-r,--revision'));


### PR DESCRIPTION
## Peer PRs
### Requires changes when merged with…
- #1915
- #1931
- #1938
- #1940

#### 👉 ❗ 💬 _This PR is the place for discussions about the warning model that apply to all of the PRs listed above!_

### Incompatible with…
- #1917: parse methods shall never be called on subcommands, so if warnings about such calls are added, the JSDoc and the ChangeLog entry for `.suppressWarnings()` introduced here become incorrect. The fact there is currently no well-defined meaning for such calls is one of the reasons why [#1938](https://github.com/tj/commander.js/pull/1938) and [#1940](https://github.com/tj/commander.js/pull/1940) should be preferred over [#1917](https://github.com/tj/commander.js/pull/1917)!

## Changes summary

### Proposed mistake handling model

Based on https://github.com/tj/commander.js/pull/1940#issuecomment-1675075727. Could be added to the docs.

* suspicious library usage patterns (although not always entirely wrong): assume author mistake and show a warning unless `suppressWarnings` is on – a setting added specifically so that warnings can be hidden from end users
* end user mistakes, including arguments deemed invalid by argParsers: display an error message and exit the program (by default)
* other errors originating in callbacks (argParsers, hooks, actions): `throw` the error for the author to handle – should not be seen by end user

### ChangeLog
#### Added
- `.suppressWarnings()` to suppress warnings about presumably wrong library usage

## Some explanations

### Why `.suppressWarning()` instead of an environment variable such as `NODE_ENV` (as originally proposed)?

Environment variables are used for stuff the end user should be able to control, but in our case, the tool author is the one to decide whether the warnings are to be shown.

See also: https://github.com/tj/commander.js/pull/1940#issuecomment-1675099093.