### PR TITLE
Never call `preSubcommand` hooks on help command

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -1809,7 +1809,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    *
    * You can optionally supply the  flags and description to override the defaults.
    *
-   * @param {string} [str]
+   * @param {string} str
    * @param {string} [flags]
    * @param {string} [description]
    * @return {this | string} `this` command for chaining, or version string if no arguments

--- a/lib/command.js
+++ b/lib/command.js
@@ -1095,13 +1095,17 @@ Expecting one of '${allowedValues.join("', '")}'`);
     if (!subcommandName) {
       this.help();
     }
+
     const subCommand = this._findCommand(subcommandName);
-    if (subCommand && !subCommand._executableHandler) {
+    if (!subCommand) {
+      this.help({ error: true });
+    }
+    if (!subCommand._executableHandler) {
       subCommand.help();
     }
 
     // Fallback to parsing the help flag to invoke the help.
-    return this._dispatchSubcommand(subcommandName, [], [
+    this._executeSubCommand(subcommandName, [
       this._helpLongFlag || this._helpShortFlag
     ]);
   }

--- a/lib/command.js
+++ b/lib/command.js
@@ -1101,9 +1101,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
     }
 
     // Fallback to parsing the help flag to invoke the help.
-    if (this._helpLongFlag) {
-      return this._dispatchSubcommand(subcommandName, [], [this._helpLongFlag]);
-    }
+    return this._dispatchSubcommand(subcommandName, [], [
+      this._helpLongFlag || this._helpShortFlag
+    ]);
   }
 
   /**

--- a/lib/command.js
+++ b/lib/command.js
@@ -1807,7 +1807,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    *
    * You can optionally supply the  flags and description to override the defaults.
    *
-   * @param {string} str
+   * @param {string} [str]
    * @param {string} [flags]
    * @param {string} [description]
    * @return {this | string} `this` command for chaining, or version string if no arguments

--- a/lib/command.js
+++ b/lib/command.js
@@ -1101,7 +1101,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
     }
 
     // Fallback to parsing the help flag to invoke the help.
-    return this._dispatchSubcommand(subcommandName, [], [this._helpLongFlag]);
+    if (this._helpLongFlag) {
+      return this._dispatchSubcommand(subcommandName, [], [this._helpLongFlag]);
+    }
   }
 
   /**
@@ -2034,7 +2036,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
     }
     context.write(helpInformation);
 
-    this.emit(this._helpLongFlag); // deprecated
+    if (this._helpLongFlag) {
+      this.emit(this._helpLongFlag); // deprecated
+    }
     this.emit('afterHelp', context);
     getCommandAndParents(this).forEach(command => command.emit('afterAllHelp', context));
   }

--- a/tests/command.addHelpText.test.js
+++ b/tests/command.addHelpText.test.js
@@ -181,7 +181,7 @@ describe('context checks with full parse', () => {
   });
 
   test('when help requested then context.error is false', () => {
-    let context = {};
+    let context;
     const program = new commander.Command();
     program
       .exitOverride()
@@ -193,7 +193,7 @@ describe('context checks with full parse', () => {
   });
 
   test('when help for error then context.error is true', () => {
-    let context = {};
+    let context;
     const program = new commander.Command();
     program
       .exitOverride()
@@ -206,7 +206,7 @@ describe('context checks with full parse', () => {
   });
 
   test('when help on program then context.command is program', () => {
-    let context = {};
+    let context;
     const program = new commander.Command();
     program
       .exitOverride()
@@ -218,7 +218,7 @@ describe('context checks with full parse', () => {
   });
 
   test('when help on subcommand and "before" subcommand then context.command is subcommand', () => {
-    let context = {};
+    let context;
     const program = new commander.Command();
     program
       .exitOverride();
@@ -231,7 +231,7 @@ describe('context checks with full parse', () => {
   });
 
   test('when help on subcommand and "beforeAll" on program then context.command is subcommand', () => {
-    let context = {};
+    let context;
     const program = new commander.Command();
     program
       .exitOverride()

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -293,7 +293,7 @@ export class Command {
    *
    * You can optionally supply the  flags and description to override the defaults.
    */
-  version(str?: string, flags?: string, description?: string): this;
+  version(str: string, flags?: string, description?: string): this;
 
   /**
    * Define a command, implemented using an action handler.

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -293,7 +293,7 @@ export class Command {
    *
    * You can optionally supply the  flags and description to override the defaults.
    */
-  version(str: string, flags?: string, description?: string): this;
+  version(str?: string, flags?: string, description?: string): this;
 
   /**
    * Define a command, implemented using an action handler.


### PR DESCRIPTION
This PR builds upon the already approved #1930.

Diff only for the change introduced by this PR:
https://github.com/aweebit/commander.js/compare/feature/fixes...feature/help-command-no-preSubcommand
## Problem

Currently, there is an inconsistency between how `._dispatchHelpCommand()` deals with regular options and those with an executable handler, which seems to have been missed in #1864.

```js
// program.js
const { Command } = require('commander');

const program = new Command()
  .hook('preSubcommand', (_, sub) => {
    console.log(sub.name());
  });
program.command('regular');
program.command('executable', 'description');
program.parse();
```

```js
// program-executable.js
const { Command } = require('commander');

const program = new Command();
program.parse();
```

```bash
node program help regular # only help
node program help executable # 'executable' logged before help
```

## Solution

Call `._executeSubCommand()` directly in `._dispatchHelpCommand()`.

This is technically a breaking change, but hey, are we really going to assume someone relied on `preSubcommand` hooks being called before help for just one particular kind of subcommands?

## ChangeLog

### Fixed
_(or maybe Changed?)_
- do not call `preSubcommand` hooks when displaying help for an executable subcommand