### PR TITLE
Add support for executable subcommands with help flags differing from those of the parent command

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -1809,7 +1809,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    *
    * You can optionally supply the  flags and description to override the defaults.
    *
-   * @param {string} [str]
+   * @param {string} str
    * @param {string} [flags]
    * @param {string} [description]
    * @return {this | string} `this` command for chaining, or version string if no arguments

--- a/lib/command.js
+++ b/lib/command.js
@@ -156,6 +156,7 @@ class Command extends EventEmitter {
     this.commands.push(cmd);
     cmd.parent = this;
     cmd.copyInheritedSettings(this);
+    if (opts.helpFlags) cmd.helpOption(opts.helpFlags);
 
     if (desc) return this;
     return cmd;
@@ -1096,13 +1097,16 @@ Expecting one of '${allowedValues.join("', '")}'`);
       this.help();
     }
     const subCommand = this._findCommand(subcommandName);
-    if (subCommand && !subCommand._executableHandler) {
+    if (!subCommand) {
+      this.help({ error: true });
+    }
+    if (!subCommand._executableHandler) {
       subCommand.help();
     }
 
     // Fallback to parsing the help flag to invoke the help.
     return this._dispatchSubcommand(subcommandName, [], [
-      this._helpLongFlag || this._helpShortFlag
+      subCommand._helpLongFlag || subCommand._helpShortFlag
     ]);
   }
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -1101,9 +1101,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
     }
 
     // Fallback to parsing the help flag to invoke the help.
-    if (this._helpLongFlag) {
-      return this._dispatchSubcommand(subcommandName, [], [this._helpLongFlag]);
-    }
+    return this._dispatchSubcommand(subcommandName, [], [
+      this._helpLongFlag || this._helpShortFlag
+    ]);
   }
 
   /**

--- a/lib/command.js
+++ b/lib/command.js
@@ -1807,7 +1807,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    *
    * You can optionally supply the  flags and description to override the defaults.
    *
-   * @param {string} str
+   * @param {string} [str]
    * @param {string} [flags]
    * @param {string} [description]
    * @return {this | string} `this` command for chaining, or version string if no arguments

--- a/lib/command.js
+++ b/lib/command.js
@@ -1101,7 +1101,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
     }
 
     // Fallback to parsing the help flag to invoke the help.
-    return this._dispatchSubcommand(subcommandName, [], [this._helpLongFlag]);
+    if (this._helpLongFlag) {
+      return this._dispatchSubcommand(subcommandName, [], [this._helpLongFlag]);
+    }
   }
 
   /**
@@ -2034,7 +2036,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
     }
     context.write(helpInformation);
 
-    this.emit(this._helpLongFlag); // deprecated
+    if (this._helpLongFlag) {
+      this.emit(this._helpLongFlag); // deprecated
+    }
     this.emit('afterHelp', context);
     getCommandAndParents(this).forEach(command => command.emit('afterAllHelp', context));
   }

--- a/tests/command.addHelpText.test.js
+++ b/tests/command.addHelpText.test.js
@@ -181,7 +181,7 @@ describe('context checks with full parse', () => {
   });
 
   test('when help requested then context.error is false', () => {
-    let context = {};
+    let context;
     const program = new commander.Command();
     program
       .exitOverride()
@@ -193,7 +193,7 @@ describe('context checks with full parse', () => {
   });
 
   test('when help for error then context.error is true', () => {
-    let context = {};
+    let context;
     const program = new commander.Command();
     program
       .exitOverride()
@@ -206,7 +206,7 @@ describe('context checks with full parse', () => {
   });
 
   test('when help on program then context.command is program', () => {
-    let context = {};
+    let context;
     const program = new commander.Command();
     program
       .exitOverride()
@@ -218,7 +218,7 @@ describe('context checks with full parse', () => {
   });
 
   test('when help on subcommand and "before" subcommand then context.command is subcommand', () => {
-    let context = {};
+    let context;
     const program = new commander.Command();
     program
       .exitOverride();
@@ -231,7 +231,7 @@ describe('context checks with full parse', () => {
   });
 
   test('when help on subcommand and "beforeAll" on program then context.command is subcommand', () => {
-    let context = {};
+    let context;
     const program = new commander.Command();
     program
       .exitOverride()

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -293,7 +293,7 @@ export class Command {
    *
    * You can optionally supply the  flags and description to override the defaults.
    */
-  version(str?: string, flags?: string, description?: string): this;
+  version(str: string, flags?: string, description?: string): this;
 
   /**
    * Define a command, implemented using an action handler.

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -293,7 +293,7 @@ export class Command {
    *
    * You can optionally supply the  flags and description to override the defaults.
    */
-  version(str: string, flags?: string, description?: string): this;
+  version(str?: string, flags?: string, description?: string): this;
 
   /**
    * Define a command, implemented using an action handler.

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -875,6 +875,7 @@ export interface CommandOptions {
 }
 export interface ExecutableCommandOptions extends CommandOptions {
   executableFile?: string;
+  helpFlags?: string;
 }
 
 export interface ParseOptionsResult {


### PR DESCRIPTION
**Disclaimer:** The change introduced here is of low importance.

This PR builds upon the already approved #1930.

Diff only for the change introduced by this PR:
https://github.com/aweebit/commander.js/compare/feature/fixes...feature/help-command-executable-help-flags

## Problem

Currently, help commands don't have support for executable subcommands whose help flags differ from those of the parent command.

Such support could be useful especially when third-party executables are used.

## Solution

Get help flags to pass to an executable subcommand from the subcommand instance rather than the parent instance in `._dispatchHelpCommand()`.

Make it possible to set custom flags for such a subcommand instance by including `helpFlags` in the options passed to `.command()`.

```js
// program.js
const { Command } = require('commander');

const program = new Command();
program.command('executable', 'description', {
  helpFlags: '-c, --custom-help'
});
program.parse();
```

```js
// program-executable.js
const { Command } = require('commander');

const program = new Command()
  .helpOption('-c, --custom-help');
program.parse();
```

```bash
node program help executable
```

## ChangeLog

### Added
- support for executable subcommands with help flags differing from those of the parent command (must be specified in the `helpFlags` option when calling `.command()`)