### PR TITLE
Fix broken `typescript-checkJS` script

### DIFF
--- a/lib/suggestSimilar.js
+++ b/lib/suggestSimilar.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 const maxDistance = 3;
 
 function editDistance(a, b) {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test": "jest && npm run test-typings",
     "test-esm": "node ./tests/esm-imports-test.mjs",
     "test-typings": "tsd",
-    "typescript-checkJS": "tsc -p tsconfig.checkJs.json",
+    "typescript-checkJs": "tsc -p tsconfig.checkJs.json",
     "test-all": "npm run test && npm run lint && npm run typescript-checkJS && npm run test-esm"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test": "jest && npm run test-typings",
     "test-esm": "node ./tests/esm-imports-test.mjs",
     "test-typings": "tsd",
-    "typescript-checkJS": "tsc --allowJS --checkJS index.js lib/*.js --noEmit",
+    "typescript-checkJS": "tsc -p tsconfig.checkJs.json",
     "test-all": "npm run test && npm run lint && npm run typescript-checkJS && npm run test-esm"
   },
   "files": [

--- a/tsconfig.checkJs.json
+++ b/tsconfig.checkJs.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "noImplicitAny": false,
+    "noImplicitThis": false
+  },
+  "include": [
+    "**/*.ts",
+    "index.js",
+    "lib/**/*.js"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,20 @@
 {
-    "compilerOptions": {
-        "module": "commonjs",
-        "lib": [
-            "es6"
-        ],
-        "noImplicitAny": true,
-        "noImplicitThis": true,
-        "strictNullChecks": true,
-        "types": [
-          "node",
-          "jest"
-        ],
-        "noEmit": true,
-        "forceConsistentCasingInFileNames": true
-    },
-    "include": ["**/*.ts"],
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": [
+      "es6"
+    ],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "types": [
+      "node",
+      "jest"
+    ],
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": [
+    "**/*.ts"
+  ]
 }


### PR DESCRIPTION
## Problem
Currently, `npm run typescript-checkJS` results in

```
error TS6053: File 'lib/*.js' not found.
  The file is in the program because:
    Root file specified for compilation
```

on Windows (even when run from Git Bash), and in normal termination with no output even when there are type errors in the files on [Linux](https://github.com/tj/commander.js/pull/1960#issuecomment-1676463561) and [macOS](https://github.com/tj/commander.js/pull/1960#issuecomment-1676457677).

## Solution
Fix the script command.

The configuration for the JS check has been moved to a dedicated config file.

The script has been renamed to `typescript-checkJs` for better consistency with [the TSConfig option name](https://www.typescriptlang.org/tsconfig#checkJs). (The script has been broken for a long time without someone noticing, so it is safe to assume it is not used in any contributors' custom scripts, and so the rename won't break anything.)

## Peer PRs

### …building upon this one
- #1962