### PR TITLE
Refactor the part of `.addOption()` responsible for storing the default value

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -511,14 +511,14 @@ Expecting one of '${allowedValues.join("', '")}'`);
     const name = option.attributeName();
 
     // store default value
-    if (option.negate) {
+    if (option.defaultValue !== undefined || !option.negate) {
+      this.setOptionValueWithSource(name, option.defaultValue, 'default');
+    } else {
       // --no-foo is special and defaults foo to true, unless a --foo option is already defined
       const positiveLongFlag = option.long.replace(/^--no-/, '--');
       if (!this._findOption(positiveLongFlag)) {
-        this.setOptionValueWithSource(name, option.defaultValue === undefined ? true : option.defaultValue, 'default');
+        this.setOptionValueWithSource(name, true, 'default');
       }
-    } else if (option.defaultValue !== undefined) {
-      this.setOptionValueWithSource(name, option.defaultValue, 'default');
     }
 
     // register the option


### PR DESCRIPTION
**Disclaimer:** The change introduced here is of low importance.

The change has been manually cherry-picked from the now-closed #1915 so that it can be discussed independently.

## Problem

When a default value is explicitly specified for the negating component of a negatable option (the one whose long flag is prefixed with `--no-`), it should be set as the default value for the option just like in case of the non-negating component (or a regular, non-negatable option).

That is exactly what happens in the current `.addOption()` code except for one case, namely when the non-negating component had already been added earlier. To check if that is the case, `._findOption()` has to be called, and that seems excessive.

### Demo

```js
const program = new Command()
  .option('--cheese <flavour>', 'cheese flavour', 'mozzarella')
  .option('--no-cheese', 'plain with no cheese', 'none') // 'none' simply ignored
  .parse();
console.log(program.opts().cheese); // mozzarella
```

## Solution

Eliminate excessive `._findOption()` calls and `undefined` checks.

The change can be considered breaking because `none` is logged when running the demo program from above after it is applied, so might want to include it in the next major release. However, code similar to the demo is so unlikely to have ever been written that I don't think caring about it is worth it.