### PR TITLE
Fix option value source type

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -780,7 +780,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   setOptionValue(key, value) {
-    return this.setOptionValueWithSource(key, value, undefined);
+    return this.setOptionValueWithSource(key, value);
   }
 
   /**
@@ -788,7 +788,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     *
     * @param {string} key
     * @param {Object} value
-    * @param {string} source - expected values are default/config/env/cli/implied
+    * @param {string} [source] - expected values are default/config/env/cli/implied
     * @return {Command} `this` command for chaining
     */
 
@@ -807,7 +807,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     * Expected values are default | config | env | cli | implied
     *
     * @param {string} key
-    * @return {string}
+    * @return {string | undefined}
     */
 
   getOptionValueSource(key) {
@@ -819,7 +819,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     * Expected values are default | config | env | cli | implied
     *
     * @param {string} key
-    * @return {string}
+    * @return {string | undefined}
     */
 
   getOptionValueSourceWithGlobals(key) {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -595,17 +595,17 @@ export class Command {
   /**
    * Store option value and where the value came from.
    */
-  setOptionValueWithSource(key: string, value: unknown, source: OptionValueSource): this;
+  setOptionValueWithSource(key: string, value: unknown, source?: OptionValueSource | string | undefined): this;
 
   /**
    * Get source of option value.
    */
-  getOptionValueSource(key: string): OptionValueSource | undefined;
+  getOptionValueSource(key: string): OptionValueSource | string | undefined;
 
   /**
     * Get source of option value. See also .optsWithGlobals().
    */
-  getOptionValueSourceWithGlobals(key: string): OptionValueSource | undefined;
+  getOptionValueSourceWithGlobals(key: string): OptionValueSource | string | undefined;
 
   /**
    * Alter parsing of short flags with optional values.

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -173,10 +173,10 @@ expectType<commander.Command>(program.setOptionValue('example', true));
 expectType<commander.Command>(program.setOptionValueWithSource('example', [], 'cli'));
 
 // getOptionValueSource
-expectType<commander.OptionValueSource | undefined>(program.getOptionValueSource('example'));
+expectType<string | undefined>(program.getOptionValueSource('example'));
 
 // getOptionValueSourceWithGlobals
-expectType<commander.OptionValueSource | undefined>(program.getOptionValueSourceWithGlobals('example'));
+expectType<string | undefined>(program.getOptionValueSourceWithGlobals('example'));
 
 // combineFlagAndOptionalValue
 expectType<commander.Command>(program.combineFlagAndOptionalValue());


### PR DESCRIPTION
The change has been manually cherry-picked from https://github.com/tj/commander.js/pull/1919 so that it can be discussed independently.

## Problem

[#1919 (comment)](https://github.com/tj/commander.js/pull/1919/#issuecomment-1656490158)
[#1919 (comment)](https://github.com/tj/commander.js/pull/1919/#issuecomment-1656578103)
[#1919 (comment)](https://github.com/tj/commander.js/pull/1919/#issuecomment-1656581492)

## Solution

Compared with the original solution from #1919 (see https://github.com/tj/commander.js/compare/7fd0b22f1adc75a97bdb4af262a71126cb9f3b8f...52d5885140017009c930e77044b99f4baaf8c9c7), the one suggested here keeps `OptionValueSource` as an exported type (could be used in subclasses to narrow down the allowed custom sources) and uses the `OptionValueSource | string` union instead of just `string` for additional clarity.

## ChangeLog

### Fixed
- option value source type (`undefined` and arbitrary custom source strings are allowed now)

## Peer PRs
### Changes are to be merged into…
- #1919
- #1967