### PR TITLE
Fix `.executableDir()` return type

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -1964,7 +1964,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    * program.executableDir('subcommands');
    *
    * @param {string} [path]
-   * @return {string|Command}
+   * @return {string|null|Command}
    */
 
   executableDir(path) {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -819,7 +819,7 @@ export class Command {
   /**
    * Get the executable search directory.
    */
-  executableDir(): string;
+  executableDir(): string | null;
 
   /**
    * Output help information for this command.

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -275,7 +275,7 @@ expectType<commander.Command>(program.nameFromFilename(__filename));
 
 // executableDir
 expectType<commander.Command>(program.executableDir(__dirname));
-expectType<string>(program.executableDir());
+expectType<string | null>(program.executableDir());
 
 // outputHelp
 // eslint-disable-next-line @typescript-eslint/no-invalid-void-type, @typescript-eslint/no-confusing-void-expression


### PR DESCRIPTION
## Problem

This is currently not covered in types:

```js
const program = new Command();
console.log(program.executableDir()); // null
```

## Solution

Add `null` to the return type of `.executableDir()`.

## ChangeLog

### Fixed
- return type of `.executableDir()`

## Peer PRs
### Changes are to be merged into…
- #1967