### PR TITLE
Fix `.description()`: do not set command description if `undefined` is provided in the first parameter

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -1837,7 +1837,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
   description(str, argsDescription) {
     if (str === undefined && argsDescription === undefined) return this._description;
-    this._description = str;
+    if (str) {
+      this._description = str;
+    }
     if (argsDescription) {
       this._argsDescription = argsDescription;
     }


### PR DESCRIPTION
This is a ridiculously unimportant change, but it fixes one of the errors revealed by a run of the TypeScript check fixed in #1960.

I've learnt my [lesson](https://github.com/tj/commander.js/pull/1930#issuecomment-1676039813), and since the change is technically visible to the outside world, I am making a separate PR for it.

## Peer PRs
### Changes are to be merged into…
- #1967