### PR TITLE
Make `Option.env()` behave as a getter when called with no arguments

### DIFF
--- a/lib/option.js
+++ b/lib/option.js
@@ -109,16 +109,17 @@ class Option {
   }
 
   /**
-   * Set environment variable to check for option value.
+   * Get or set environment variable to check for option value.
    *
    * An environment variable is only used if when processed the current option value is
    * undefined, or the source of the current value is 'default' or 'config' or 'env'.
    *
-   * @param {string} name
-   * @return {Option}
+   * @param {string} [name]
+   * @return {Option | string | undefined}
    */
 
   env(name) {
+    if (!name) return this.envVar;
     this.envVar = name;
     return this;
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -142,12 +142,13 @@ export class Option {
   implies(optionValues: OptionValues): this;
 
   /**
-   * Set environment variable to check for option value.
+   * Get or set environment variable to check for option value.
    *
    * An environment variables is only used if when processed the current option value is
    * undefined, or the source of the current value is 'default' or 'config' or 'env'.
    */
   env(name: string): this;
+  env(): string | undefined;
 
   /**
    * Calculate the full description, including defaultValue etc.

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -410,6 +410,7 @@ expectType<commander.Option>(baseOption.preset('abc'));
 
 // env
 expectType<commander.Option>(baseOption.env('PORT'));
+expectType<string | undefined>(baseOption.env());
 
 // fullDescription
 expectType<string>(baseOption.fullDescription());


### PR DESCRIPTION
Another tiny enhancement third-party libraries could benefit from (like #1970).

## Problem
I had to use the internal `Option.envVar` to build informative error messages in the [async-commander](https://github.com/aweebit/async-commander) library I am currently working on.

## Solution
Make `Option.env()` return the value of the variable when it is called with no parameters.

## ChangeLog
### Added
- `Option.env()` now returns the previously provided environment variable name when called with no argument