### PR TITLE
Fix aggregated import and remove test for unsupported default export in TypeScript

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,8 @@ const { Option } = require('./lib/option.js');
  */
 
 const program = new Command();
-exports = module.exports = program;
-exports.program = program; // more explicit access to global command (deprecated)
+exports = module.exports = program; // default export (deprecated)
+exports.program = program; // more explicit access to global command
 
 // Support aggregated import (import * as commander) in TypeScript.
 // Do not delete these lines even if they seem redundant!

--- a/index.js
+++ b/index.js
@@ -10,9 +10,18 @@ const { Option } = require('./lib/option.js');
  * Expose the root command.
  */
 
-exports = module.exports = new Command();
-exports.program = exports; // More explicit access to global command.
-// Implicit export of createArgument, createCommand, and createOption.
+const program = new Command();
+exports = module.exports = program;
+exports.program = program; // more explicit access to global command (deprecated)
+
+// Support aggregated import (import * as commander) in TypeScript.
+// Do not delete these lines even if they seem redundant!
+// @ts-ignore
+exports.createCommand = program.createCommand;
+// @ts-ignore
+exports.createArgument = program.createArgument;
+// @ts-ignore
+exports.createOption = program.createOption;
 
 /**
  * Expose classes

--- a/index.js
+++ b/index.js
@@ -16,11 +16,8 @@ exports.program = program; // more explicit access to global command (deprecated
 
 // Support aggregated import (import * as commander) in TypeScript.
 // Do not delete these lines even if they seem redundant!
-// @ts-ignore
 exports.createCommand = program.createCommand;
-// @ts-ignore
 exports.createArgument = program.createArgument;
-// @ts-ignore
 exports.createOption = program.createOption;
 
 /**

--- a/tests/ts-imports.test.ts
+++ b/tests/ts-imports.test.ts
@@ -1,7 +1,5 @@
 import { program, Command, Option, CommanderError, InvalidArgumentError, InvalidOptionArgumentError, Help, createCommand } from '../';
 
-import * as commander from '../';
-
 // Do some simple checks that expected imports are available at runtime.
 // Similar tests to esm-imports-test.js
 
@@ -10,10 +8,6 @@ function checkClass(obj: object, name: string): void {
   expect(typeof obj).toEqual('object');
   expect(obj.constructor.name).toEqual(name);
 }
-
-test('legacy default export of global Command', () => {
-  checkClass(commander, 'Command');
-});
 
 test('program', () => {
   checkClass(program, 'Command');

--- a/tests/ts-imports.test.ts
+++ b/tests/ts-imports.test.ts
@@ -1,4 +1,6 @@
-import { program, Command, Option, CommanderError, InvalidArgumentError, InvalidOptionArgumentError, Help, createCommand } from '../';
+import * as commander from '../';
+
+const { program, Command, Option, CommanderError, InvalidArgumentError, InvalidOptionArgumentError, Help, createCommand } = commander;
 
 // Do some simple checks that expected imports are available at runtime.
 // Similar tests to esm-imports-test.js
@@ -9,34 +11,54 @@ function checkClass(obj: object, name: string): void {
   expect(obj.constructor.name).toEqual(name);
 }
 
-test('program', () => {
-  checkClass(program, 'Command');
+describe('commander (check that "esModuleInterop": true is set in TSConfig if this block fails)', () => {
+  test.each([
+    'program',
+    'createCommand',
+    'createArgument',
+    'createOption',
+    'CommanderError',
+    'InvalidArgumentError',
+    'InvalidOptionArgumentError',
+    'Command',
+    'Argument',
+    'Option',
+    'Help'
+  ])('has %s', (key) => {
+    expect(commander).toHaveProperty(key);
+  });
 });
 
-test('createCommand', () => {
-  checkClass(createCommand(), 'Command');
-});
+describe('class name as expected', () => {
+  test('program', () => {
+    checkClass(program, 'Command');
+  });
 
-test('Command', () => {
-  checkClass(new Command('name'), 'Command');
-});
+  test('createCommand', () => {
+    checkClass(createCommand(), 'Command');
+  });
 
-test('Option', () => {
-  checkClass(new Option('-e, --example', 'description'), 'Option');
-});
+  test('Command', () => {
+    checkClass(new Command('name'), 'Command');
+  });
 
-test('CommanderError', () => {
-  checkClass(new CommanderError(1, 'code', 'failed'), 'CommanderError');
-});
+  test('Option', () => {
+    checkClass(new Option('-e, --example', 'description'), 'Option');
+  });
 
-test('InvalidArgumentError', () => {
-  checkClass(new InvalidArgumentError('failed'), 'InvalidArgumentError');
-});
+  test('CommanderError', () => {
+    checkClass(new CommanderError(1, 'code', 'failed'), 'CommanderError');
+  });
 
-test('InvalidOptionArgumentError', () => { // Deprecated
-  checkClass(new InvalidOptionArgumentError('failed'), 'InvalidArgumentError');
-});
+  test('InvalidArgumentError', () => {
+    checkClass(new InvalidArgumentError('failed'), 'InvalidArgumentError');
+  });
 
-test('Help', () => {
-  checkClass(new Help(), 'Help');
+  test('InvalidOptionArgumentError', () => { // Deprecated
+    checkClass(new InvalidOptionArgumentError('failed'), 'InvalidArgumentError');
+  });
+
+  test('Help', () => {
+    checkClass(new Help(), 'Help');
+  });
 });

--- a/tests/ts-imports.test.ts
+++ b/tests/ts-imports.test.ts
@@ -1,6 +1,6 @@
-import * as commander from '../';
+import { program, Command, Option, CommanderError, InvalidArgumentError, InvalidOptionArgumentError, Help, createCommand } from '../';
 
-const { program, Command, Option, CommanderError, InvalidArgumentError, InvalidOptionArgumentError, Help, createCommand } = commander;
+import * as commander from '../';
 
 // Do some simple checks that expected imports are available at runtime.
 // Similar tests to esm-imports-test.js

--- a/tests/ts-imports.test.ts
+++ b/tests/ts-imports.test.ts
@@ -11,7 +11,7 @@ function checkClass(obj: object, name: string): void {
   expect(obj.constructor.name).toEqual(name);
 }
 
-describe('commander (check that "esModuleInterop": true is set in TSConfig if this block fails)', () => {
+describe('commander', () => {
   test.each([
     'program',
     'createCommand',
@@ -29,7 +29,7 @@ describe('commander (check that "esModuleInterop": true is set in TSConfig if th
   });
 });
 
-describe('class name as expected', () => {
+describe('class name', () => {
   test('program', () => {
     checkClass(program, 'Command');
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "node16",
+    "esModuleInterop": true, /*
+      should be the default with node16,
+      but ts-jest overwrites it with false unless explicitly set
+    */
     "lib": [
       "es6"
     ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,20 @@
 {
-    "compilerOptions": {
-        "module": "commonjs",
-        "lib": [
-            "es6"
-        ],
-        "noImplicitAny": true,
-        "noImplicitThis": true,
-        "strictNullChecks": true,
-        "types": [
-          "node",
-          "jest"
-        ],
-        "noEmit": true,
-        "forceConsistentCasingInFileNames": true
-    },
-    "include": ["**/*.ts"],
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": [
+      "es6"
+    ],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "types": [
+      "node",
+      "jest"
+    ],
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": [
+    "**/*.ts"
+  ],
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,6 @@
 {
   "compilerOptions": {
-    "module": "node16",
-    "esModuleInterop": true, /*
-      should be the default with node16,
-      but ts-jest overwrites it with false unless explicitly set
-    */
+    "module": "commonjs",
     "lib": [
       "es6"
     ],


### PR DESCRIPTION
Please have a look at the commit descriptions for details.

## ChangeLog

### Fixed
- added missing `createCommand`, `createArgument`, `createOption` exports to TypeScript aggregated ESM import (`import * as commander`) when `"esModuleInterop": true` is set in TSConfig

## Peer PRs
### Changes are to be merged into…
- #1975