### PR TITLE
Refactor to wrap invalid argument

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -514,6 +514,28 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   /**
+   * Wrap parseArgs to catch 'commander.invalidArgument'.
+   *
+   * @param {Option | Argument} target
+   * @param {string} value
+   * @param {any} previous
+   * @param {string} invalidArgumentMessage
+   * @api private
+   */
+
+  _parseTargetArg(target, value, previous, invalidArgumentMessage) {
+    try {
+      return target.parseArg(value, previous);
+    } catch (err) {
+      if (err.code === 'commander.invalidArgument') {
+        const message = `${invalidArgumentMessage} ${err.message}`;
+        this.error(message, { exitCode: err.exitCode, code: err.code });
+      }
+      throw err;
+    }
+  }
+
+  /**
    * Add an option.
    *
    * @param {Option} option
@@ -548,15 +570,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
       // custom processing
       const oldValue = this.getOptionValue(name);
       if (val !== null && option.parseArg) {
-        try {
-          val = option.parseArg(val, oldValue);
-        } catch (err) {
-          if (err.code === 'commander.invalidArgument') {
-            const message = `${invalidValueMessage} ${err.message}`;
-            this.error(message, { exitCode: err.exitCode, code: err.code });
-          }
-          throw err;
-        }
+        val = this._parseTargetArg(option, val, oldValue, invalidValueMessage);
       } else if (val !== null && option.variadic) {
         val = option._concatValue(val, oldValue);
       }
@@ -1155,15 +1169,8 @@ Expecting one of '${allowedValues.join("', '")}'`);
       // Extra processing for nice error message on parsing failure.
       let parsedValue = value;
       if (value !== null && argument.parseArg) {
-        try {
-          parsedValue = argument.parseArg(value, previous);
-        } catch (err) {
-          if (err.code === 'commander.invalidArgument') {
-            const message = `error: command-argument value '${value}' is invalid for argument '${argument.name()}'. ${err.message}`;
-            this.error(message, { exitCode: err.exitCode, code: err.code });
-          }
-          throw err;
-        }
+        const invalidValueMessage = `error: command-argument value '${value}' is invalid for argument '${argument.name()}'.`;
+        parsedValue = this._parseTargetArg(argument, value, previous, invalidValueMessage);
       }
       return parsedValue;
     };

--- a/lib/command.js
+++ b/lib/command.js
@@ -523,7 +523,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    * @api private
    */
 
-  _parseTargetArg(target, value, previous, invalidArgumentMessage) {
+  _callParseArg(target, value, previous, invalidArgumentMessage) {
     try {
       return target.parseArg(value, previous);
     } catch (err) {
@@ -570,7 +570,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
       // custom processing
       const oldValue = this.getOptionValue(name);
       if (val !== null && option.parseArg) {
-        val = this._parseTargetArg(option, val, oldValue, invalidValueMessage);
+        val = this._callParseArg(option, val, oldValue, invalidValueMessage);
       } else if (val !== null && option.variadic) {
         val = option._concatValue(val, oldValue);
       }
@@ -1170,7 +1170,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
       let parsedValue = value;
       if (value !== null && argument.parseArg) {
         const invalidValueMessage = `error: command-argument value '${value}' is invalid for argument '${argument.name()}'.`;
-        parsedValue = this._parseTargetArg(argument, value, previous, invalidValueMessage);
+        parsedValue = this._callParseArg(argument, value, previous, invalidValueMessage);
       }
       return parsedValue;
     };


### PR DESCRIPTION
# Pull Request

This is an optional refactor.

## Problem

The extra try/catch code to handle `command.invalidArgument` means calling `option.parseArgs` and `argument.parseArgs` is noisy.

## Solution

I liked the refactoring in #1913 which wrapped exception and promise handling. Here it is just the exception handling, but still cleans up the calling code.