### PR TITLE
Types for version getter

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -1818,17 +1818,16 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   /**
-   * Set the program version to `str`.
+   * Get or set the program version.
    *
-   * This method auto-registers the "-V, --version" flag
-   * which will print the version number when passed.
+   * This method auto-registers the "-V, --version" option which will print the version number.
    *
-   * You can optionally supply the  flags and description to override the defaults.
+   * You can optionally supply the flags and description to override the defaults.
    *
-   * @param {string} str
+   * @param {string} [str]
    * @param {string} [flags]
    * @param {string} [description]
-   * @return {this | string} `this` command for chaining, or version string if no arguments
+   * @return {this | string | undefined} `this` command for chaining, or version string  if no arguments
    */
 
   version(str, flags, description) {
@@ -1837,7 +1836,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     flags = flags || '-V, --version';
     description = description || 'output the version number';
     const versionOption = this.createOption(flags, description);
-    this._versionOptionName = versionOption.attributeName();
+    this._versionOptionName = versionOption.attributeName(); // [sic] not defined in constructor, partly legacy, partly only needed at root
     this.options.push(versionOption);
     this.on('option:' + versionOption.name(), () => {
       this._outputConfiguration.writeOut(`${str}\n`);

--- a/lib/command.js
+++ b/lib/command.js
@@ -1827,7 +1827,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    * @param {string} [str]
    * @param {string} [flags]
    * @param {string} [description]
-   * @return {this | string | undefined} `this` command for chaining, or version string  if no arguments
+   * @return {this | string | undefined} `this` command for chaining, or version string if no arguments
    */
 
   version(str, flags, description) {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -294,6 +294,10 @@ export class Command {
    * You can optionally supply the  flags and description to override the defaults.
    */
   version(str: string, flags?: string, description?: string): this;
+  /**
+   * Get the program version.
+   */
+  version(): string | undefined;
 
   /**
    * Define a command, implemented using an action handler.

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -36,6 +36,7 @@ expectType<commander.Command | null>(program.parent);
 expectType<commander.Command>(program.version('1.2.3'));
 expectType<commander.Command>(program.version('1.2.3', '-r,--revision'));
 expectType<commander.Command>(program.version('1.2.3', '-r,--revision', 'show revision information'));
+expectType<string | undefined>(program.version());
 
 // command (and CommandOptions)
 expectType<commander.Command>(program.command('action'));


### PR DESCRIPTION
# Pull Request

## Problem

The implementation for `.version()` has always supported returning the (previously defined) version string, but the
types have never included this. I did briefly consider deprecating the whole thing (#1954), but it is being used in the wild
and not hard to support!

## Solution

Small change to types and JSDoc and TSDoc to include the getter behaviour.
