### PR TITLE
Make OptionValueSource a string with well-known values for auto-complete

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -5,6 +5,14 @@
 /* eslint-disable @typescript-eslint/method-signature-style */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+// This is a trick to encourage editor to suggest the known literals while still
+// allowing any BaseType value.
+// References:
+// - https://github.com/microsoft/TypeScript/issues/29729
+// - https://github.com/sindresorhus/type-fest/blob/main/source/literal-union.d.ts
+// - https://github.com/sindresorhus/type-fest/blob/main/source/primitive.d.ts
+type LiteralUnion<LiteralType, BaseType extends string | number> = LiteralType | (BaseType & Record<never, never>);
+
 export class CommanderError extends Error {
   code: string;
   exitCode: number;
@@ -272,7 +280,8 @@ export interface OutputConfiguration {
 
 export type AddHelpTextPosition = 'beforeAll' | 'before' | 'after' | 'afterAll';
 export type HookEvent = 'preSubcommand' | 'preAction' | 'postAction';
-export type OptionValueSource = 'default' | 'config' | 'env' | 'cli' | 'implied';
+// The source is a string so author can define their own too.
+export type OptionValueSource = LiteralUnion<'default' | 'config' | 'env' | 'cli' | 'implied', string> | undefined;
 
 export type OptionValues = Record<string, any>;
 


### PR DESCRIPTION
# Pull Request

## Problem

Authors are allowed to use their own strings for `OptionValueSource`, but the usual range will just be the values that Commander uses. The TypeScript typing only listed the Commander values to support the primary use, and get autocomplete in the editor.

## Solution

Use a well-known "trick" to specify a string with some known values. The known values are offered for auto-complete by VSCode, and TypeScript allows other values too.

This was prototyped in https://github.com/commander-js/extra-typings

References:
- https://github.com/microsoft/TypeScript/issues/29729
- https://github.com/sindresorhus/type-fest/blob/main/source/literal-union.d.ts
- https://github.com/sindresorhus/type-fest/blob/main/source/primitive.d.ts

## ChangeLog

- fix: update `OptionValueSource` to allow any string to match supported custom use
