### PR TITLE
Strict optionals

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -47,6 +47,7 @@ class Command extends EventEmitter {
     this._exitCallback = null;
     this._aliases = [];
     this._combineFlagAndOptionalValue = true;
+    this._strictOptionalOptionArguments = false;
     this._description = '';
     this._summary = '';
     this._argsDescription = undefined; // legacy
@@ -101,6 +102,7 @@ class Command extends EventEmitter {
     this._exitCallback = sourceCommand._exitCallback;
     this._storeOptionsAsProperties = sourceCommand._storeOptionsAsProperties;
     this._combineFlagAndOptionalValue = sourceCommand._combineFlagAndOptionalValue;
+    this._strictOptionalOptionArguments = sourceCommand._strictOptionalOptionArguments;
     this._allowExcessArguments = sourceCommand._allowExcessArguments;
     this._enablePositionalOptions = sourceCommand._enablePositionalOptions;
     this._showHelpAfterError = sourceCommand._showHelpAfterError;
@@ -686,6 +688,20 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
   requiredOption(flags, description, fn, defaultValue) {
     return this._optionEx({ mandatory: true }, flags, description, fn, defaultValue);
+  }
+
+  /**
+    * When strict, handle options with optional option-arguments as prescribed by POSIX
+    * and optional option-arguments can only be supplied by combining them with the flag.
+    * e.g. `-cMozzarella` or `--cheese=Mozzarella`
+    *
+    * @param {Boolean} [strict=true]
+    * @return {Command} `this` command for chaining
+    */
+
+  strictOptionalOptionArguments(strict = true) {
+    this._strictOptionalOptionArguments = !!strict;
+    return this;
   }
 
   /**

--- a/lib/command.js
+++ b/lib/command.js
@@ -1506,7 +1506,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
           } else if (option.optional) {
             let value = null;
             // historical behaviour is optional value is following arg unless an option
-            if (args.length > 0 && !maybeOption(args[0])) {
+            if (args.length > 0 && !maybeOption(args[0]) && !this._strictOptionalOptionArguments) {
               value = args.shift();
             }
             this.emit(`option:${option.name()}`, value);

--- a/lib/option.js
+++ b/lib/option.js
@@ -318,11 +318,19 @@ function splitOptionFlags(flags) {
   const flagParts = flags.split(/[ |,]+/);
   if (flagParts.length > 1 && !/^[[<]/.test(flagParts[1])) shortFlag = flagParts.shift();
   longFlag = flagParts.shift();
+  // Add support for strict optional syntax without significantly changing parsing!
+  if (longFlag?.includes('[')) { // --port[=VALUE]
+    longFlag = longFlag.split('[')[0];
+  }
+  if (shortFlag?.includes('[')) { // -p[VALUE]
+    shortFlag = shortFlag.split('[')[0];
+  }
   // Add support for lone short flag without significantly changing parsing!
   if (!shortFlag && /^-[^-]$/.test(longFlag)) {
     shortFlag = longFlag;
     longFlag = undefined;
   }
+
   return { shortFlag, longFlag };
 }
 


### PR DESCRIPTION
# Pull Request

## Problem

Commander does not support strict optional option-arguments per POSIX. This is an interesting mode as it resolves the ambiguity between an optional option-argument and a (positional) command-argument.

```
program -p
program -pPORT
program --port
program --port=PORT
program ARG
program -p ARG
program --port ARG
```

See #1901 (also #1951)

## Solution

Add `.strictOptionalOptionArguments()` to enable the POSIX treatment.

Example:

```js
import { Command } from 'commander';
const program = new Command();

program
  .strictOptionalOptionArguments()
  .option('-C[num], --context[=num]', 'grep style flag help')
  .option('-t, --track[=(direct|inherit)]', 'git style flag help');

program.parse();
console.log({ opts: program.opts(), args: program.args });
```

Note: the flags displayed in the help are as specified in the `.option()` call, so author can describe them in their preferred usage style .

```console
% node index.mjs --help
Usage: index [options]

Options:
  -C[num], --context[=num]        grep style flag help
  -t, --track[=(direct|inherit)]  git style flag help
  -h, --help                      display help for command
% node index.mjs -C -t 
{ opts: { context: true, track: true }, args: [] }
% node index.mjs -C 1 -t 2
{ opts: { context: true, track: true }, args: [ '1', '2' ] }
% node index.mjs -C1 -t2  
{ opts: { context: '1', track: '2' }, args: [] }
% node index.mjs --context 1 --track 2
{ opts: { context: true, track: true }, args: [ '1', '2' ] }
% node index.mjs --context=1 --track=2
{ opts: { context: '1', track: '2' }, args: [] }
```


## ChangeLog

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->
