### PR TITLE
Move Jest configuration to config file

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,12 @@
+const config = {
+  testEnvironment: 'node',
+  collectCoverage: true,
+  transform: {
+    '^.+\\.tsx?$': 'ts-jest'
+  },
+  testPathIgnorePatterns: [
+    '/node_modules/'
+  ]
+};
+
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -73,16 +73,6 @@
     "typescript": "^5.0.4"
   },
   "types": "typings/index.d.ts",
-  "jest": {
-    "testEnvironment": "node",
-    "collectCoverage": true,
-    "transform": {
-      "^.+\\.tsx?$": "ts-jest"
-    },
-    "testPathIgnorePatterns": [
-      "/node_modules/"
-    ]
-  },
   "engines": {
     "node": ">=16"
   },


### PR DESCRIPTION
This is an optional refactor to move the Jest configuration from `package.json` to a configuration file. I used to quite like using `package.json` for extra configuration and reducing number of files, but I do find configuration for packages a little easier to find and work with when the settings when in an external file, and it is annoying being unable to add comments in `package.json`.

Reference: https://jestjs.io/docs/configuration