### PR TITLE
Refactor help option implementation to hold actual Option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -904,6 +904,8 @@ program
   .helpOption('-e, --HELP', 'read more information');
 ```
 
+You can also customise the help option using `.addHelpOption()` with an `Option` you create yourself.
+
 ### .addHelpCommand()
 
 A help command is added by default if your command has subcommands. You can explicitly turn on or off the implicit help command with `.addHelpCommand()` and `.addHelpCommand(false)`.

--- a/lib/command.js
+++ b/lib/command.js
@@ -1383,13 +1383,13 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
   _checkForMissingMandatoryOptions() {
     // Walk up hierarchy so can call in subcommand after checking for displaying help.
-    for (let cmd = this; cmd; cmd = cmd.parent) {
+    this._getCommandAndAncestors().forEach((cmd) => {
       cmd.options.forEach((anOption) => {
         if (anOption.mandatory && (cmd.getOptionValue(anOption.attributeName()) === undefined)) {
           cmd.missingMandatoryOptionValue(anOption);
         }
       });
-    }
+    });
   }
 
   /**
@@ -1430,9 +1430,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
   _checkForConflictingOptions() {
     // Walk up hierarchy so can call in subcommand after checking for displaying help.
-    for (let cmd = this; cmd; cmd = cmd.parent) {
+    this._getCommandAndAncestors().forEach((cmd) => {
       cmd._checkForConflictingLocalOptions();
-    }
+    });
   }
 
   /**
@@ -1761,14 +1761,13 @@ Expecting one of '${allowedValues.join("', '")}'`);
     if (flag.startsWith('--') && this._showSuggestionAfterError) {
       // Looping to pick up the global options too
       let candidateFlags = [];
-      let command = this;
-      do {
+      for (const command of this._getCommandAndAncestors()) {
         const moreFlags = command.createHelp().visibleOptions(command)
           .filter(option => option.long)
           .map(option => option.long);
         candidateFlags = candidateFlags.concat(moreFlags);
-        command = command.parent;
-      } while (command && !command._enablePositionalOptions);
+        if (command._enablePositionalOptions) break;
+      }
       suggestion = suggestSimilar(flag, candidateFlags);
     }
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -1809,7 +1809,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    *
    * You can optionally supply the  flags and description to override the defaults.
    *
-   * @param {string} [str]
+   * @param {string} str
    * @param {string} [flags]
    * @param {string} [description]
    * @return {this | string} `this` command for chaining, or version string if no arguments

--- a/lib/command.js
+++ b/lib/command.js
@@ -1761,13 +1761,14 @@ Expecting one of '${allowedValues.join("', '")}'`);
     if (flag.startsWith('--') && this._showSuggestionAfterError) {
       // Looping to pick up the global options too
       let candidateFlags = [];
-      for (const command of this._getCommandAndAncestors()) {
+      let command = this;
+      do {
         const moreFlags = command.createHelp().visibleOptions(command)
           .filter(option => option.long)
           .map(option => option.long);
         candidateFlags = candidateFlags.concat(moreFlags);
-        if (command._enablePositionalOptions) break;
-      }
+        command = command.parent;
+      } while (command && !command._enablePositionalOptions);
       suggestion = suggestSimilar(flag, candidateFlags);
     }
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -514,6 +514,28 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   /**
+   * Wrap parseArgs to catch 'commander.invalidArgument'.
+   *
+   * @param {Option | Argument} target
+   * @param {string} value
+   * @param {any} previous
+   * @param {string} invalidArgumentMessage
+   * @api private
+   */
+
+  _callParseArg(target, value, previous, invalidArgumentMessage) {
+    try {
+      return target.parseArg(value, previous);
+    } catch (err) {
+      if (err.code === 'commander.invalidArgument') {
+        const message = `${invalidArgumentMessage} ${err.message}`;
+        this.error(message, { exitCode: err.exitCode, code: err.code });
+      }
+      throw err;
+    }
+  }
+
+  /**
    * Add an option.
    *
    * @param {Option} option
@@ -548,15 +570,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
       // custom processing
       const oldValue = this.getOptionValue(name);
       if (val !== null && option.parseArg) {
-        try {
-          val = option.parseArg(val, oldValue);
-        } catch (err) {
-          if (err.code === 'commander.invalidArgument') {
-            const message = `${invalidValueMessage} ${err.message}`;
-            this.error(message, { exitCode: err.exitCode, code: err.code });
-          }
-          throw err;
-        }
+        val = this._callParseArg(option, val, oldValue, invalidValueMessage);
       } else if (val !== null && option.variadic) {
         val = option._concatValue(val, oldValue);
       }
@@ -1155,15 +1169,8 @@ Expecting one of '${allowedValues.join("', '")}'`);
       // Extra processing for nice error message on parsing failure.
       let parsedValue = value;
       if (value !== null && argument.parseArg) {
-        try {
-          parsedValue = argument.parseArg(value, previous);
-        } catch (err) {
-          if (err.code === 'commander.invalidArgument') {
-            const message = `error: command-argument value '${value}' is invalid for argument '${argument.name()}'. ${err.message}`;
-            this.error(message, { exitCode: err.exitCode, code: err.code });
-          }
-          throw err;
-        }
+        const invalidValueMessage = `error: command-argument value '${value}' is invalid for argument '${argument.name()}'.`;
+        parsedValue = this._callParseArg(argument, value, previous, invalidValueMessage);
       }
       return parsedValue;
     };

--- a/lib/command.js
+++ b/lib/command.js
@@ -110,6 +110,19 @@ class Command extends EventEmitter {
   }
 
   /**
+   * @returns {Command[]}
+   * @api private
+   */
+
+  _getCommandAndAncestors() {
+    const result = [];
+    for (let command = this; command; command = command.parent) {
+      result.push(command);
+    }
+    return result;
+  }
+
+  /**
    * Define a command.
    *
    * There are two styles of command: pay attention to where to put the description.
@@ -828,7 +841,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
   getOptionValueSourceWithGlobals(key) {
     // global overwrites local, like optsWithGlobals
     let source;
-    getCommandAndParents(this).forEach((cmd) => {
+    this._getCommandAndAncestors().forEach((cmd) => {
       if (cmd.getOptionValueSource(key) !== undefined) {
         source = cmd.getOptionValueSource(key);
       }
@@ -1213,7 +1226,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
   _chainOrCallHooks(promise, event) {
     let result = promise;
     const hooks = [];
-    getCommandAndParents(this)
+    this._getCommandAndAncestors()
       .reverse()
       .filter(cmd => cmd._lifeCycleHooks[event] !== undefined)
       .forEach(hookedCommand => {
@@ -1582,7 +1595,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
   optsWithGlobals() {
     // globals overwrite locals
-    return getCommandAndParents(this).reduce(
+    return this._getCommandAndAncestors().reduce(
       (combinedOptions, cmd) => Object.assign(combinedOptions, cmd.opts()),
       {}
     );
@@ -2027,7 +2040,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     }
     const context = this._getHelpContext(contextOptions);
 
-    getCommandAndParents(this).reverse().forEach(command => command.emit('beforeAllHelp', context));
+    this._getCommandAndAncestors().reverse().forEach(command => command.emit('beforeAllHelp', context));
     this.emit('beforeHelp', context);
 
     let helpInformation = this.helpInformation(context);
@@ -2043,7 +2056,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
       this.emit(this._helpLongFlag); // deprecated
     }
     this.emit('afterHelp', context);
-    getCommandAndParents(this).forEach(command => command.emit('afterAllHelp', context));
+    this._getCommandAndAncestors().forEach(command => command.emit('afterAllHelp', context));
   }
 
   /**
@@ -2184,20 +2197,6 @@ function incrementNodeInspectorPort(args) {
     }
     return arg;
   });
-}
-
-/**
- * @param {Command} startCommand
- * @returns {Command[]}
- * @api private
- */
-
-function getCommandAndParents(startCommand) {
-  const result = [];
-  for (let command = startCommand; command; command = command.parent) {
-    result.push(command);
-  }
-  return result;
 }
 
 exports.Command = Command;

--- a/lib/command.js
+++ b/lib/command.js
@@ -86,7 +86,7 @@ class Command extends EventEmitter {
    */
   copyInheritedSettings(sourceCommand) {
     this._outputConfiguration = sourceCommand._outputConfiguration;
-    this._helpOption = sourceCommand._helpOption; // (May still be undefined.)
+    this._helpOption = sourceCommand.helpOption();
     this._hasHelpOption = sourceCommand._hasHelpOption;
     this._helpCommandName = sourceCommand._helpCommandName;
     this._helpCommandnameAndArgs = sourceCommand._helpCommandnameAndArgs;

--- a/lib/command.js
+++ b/lib/command.js
@@ -1101,9 +1101,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
     }
 
     // Fallback to parsing the help flag to invoke the help.
-    if (this._helpLongFlag) {
-      return this._dispatchSubcommand(subcommandName, [], [this._helpLongFlag]);
-    }
+    return this._dispatchSubcommand(subcommandName, [], [
+      this._helpLongFlag || this._helpShortFlag
+    ]);
   }
 
   /**

--- a/lib/command.js
+++ b/lib/command.js
@@ -2125,7 +2125,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    * Returns null if has been disabled with .helpOption(false).
    *
    * @returns {(Option | null)} the help option
-   * @package
+   * @package internal use only
    */
   _getHelpOption() {
     // Lazy create help option on demand.

--- a/lib/command.js
+++ b/lib/command.js
@@ -7,7 +7,7 @@ const process = require('process');
 const { Argument, humanReadableArgName } = require('./argument.js');
 const { CommanderError } = require('./error.js');
 const { Help } = require('./help.js');
-const { Option, splitOptionFlags, DualOptions } = require('./option.js');
+const { Option, DualOptions } = require('./option.js');
 const { suggestSimilar } = require('./suggestSimilar');
 
 // @ts-check
@@ -67,11 +67,8 @@ class Command extends EventEmitter {
     };
 
     this._hidden = false;
+    this._helpOption = this.createOption('-h, --help', 'display help for command');
     this._hasHelpOption = true;
-    this._helpFlags = '-h, --help';
-    this._helpDescription = 'display help for command';
-    this._helpShortFlag = '-h';
-    this._helpLongFlag = '--help';
     this._addImplicitHelpCommand = undefined; // Deliberately undefined, not decided whether true or false
     this._helpCommandName = 'help';
     this._helpCommandnameAndArgs = 'help [command]';
@@ -89,11 +86,8 @@ class Command extends EventEmitter {
    */
   copyInheritedSettings(sourceCommand) {
     this._outputConfiguration = sourceCommand._outputConfiguration;
+    this._helpOption = sourceCommand._helpOption;
     this._hasHelpOption = sourceCommand._hasHelpOption;
-    this._helpFlags = sourceCommand._helpFlags;
-    this._helpDescription = sourceCommand._helpDescription;
-    this._helpShortFlag = sourceCommand._helpShortFlag;
-    this._helpLongFlag = sourceCommand._helpLongFlag;
     this._helpCommandName = sourceCommand._helpCommandName;
     this._helpCommandnameAndArgs = sourceCommand._helpCommandnameAndArgs;
     this._helpCommandDescription = sourceCommand._helpCommandDescription;
@@ -1132,7 +1126,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
     // Fallback to parsing the help flag to invoke the help.
     return this._dispatchSubcommand(subcommandName, [], [
-      this._helpLongFlag || this._helpShortFlag
+      this._helpOption.long ?? this._helpOption.short ?? '--help'
     ]);
   }
 
@@ -2058,8 +2052,8 @@ Expecting one of '${allowedValues.join("', '")}'`);
     }
     context.write(helpInformation);
 
-    if (this._helpLongFlag) {
-      this.emit(this._helpLongFlag); // deprecated
+    if (this._helpOption.long) {
+      this.emit(this._helpOption.long); // deprecated
     }
     this.emit('afterHelp', context);
     this._getCommandAndAncestors().forEach(command => command.emit('afterAllHelp', context));
@@ -2080,12 +2074,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
       this._hasHelpOption = flags;
       return this;
     }
-    this._helpFlags = flags || this._helpFlags;
-    this._helpDescription = description || this._helpDescription;
-
-    const helpFlags = splitOptionFlags(this._helpFlags);
-    this._helpShortFlag = helpFlags.shortFlag;
-    this._helpLongFlag = helpFlags.longFlag;
+    flags = flags ?? this._helpOption.flags;
+    description = description ?? this._helpOption.description;
+    this._helpOption = this.createOption(flags, description);
 
     return this;
   }
@@ -2150,8 +2141,8 @@ Expecting one of '${allowedValues.join("', '")}'`);
  */
 
 function outputHelpIfRequested(cmd, args) {
-  const helpOption = cmd._hasHelpOption && args.find(arg => arg === cmd._helpLongFlag || arg === cmd._helpShortFlag);
-  if (helpOption) {
+  const helpRequested = cmd._hasHelpOption && args.find(arg => cmd._helpOption.is(arg));
+  if (helpRequested) {
     cmd.outputHelp();
     // (Do not have all displayed text available so only passing placeholder.)
     cmd._exit(0, 'commander.helpDisplayed', '(outputHelp)');

--- a/lib/command.js
+++ b/lib/command.js
@@ -1088,16 +1088,16 @@ Expecting one of '${allowedValues.join("', '")}'`);
     const subCommand = this._findCommand(commandName);
     if (!subCommand) this.help({ error: true });
 
-    let hookResult;
-    hookResult = this._chainOrCallSubCommandHook(hookResult, subCommand, 'preSubcommand');
-    hookResult = this._chainOrCall(hookResult, () => {
+    let promiseChain;
+    promiseChain = this._chainOrCallSubCommandHook(promiseChain, subCommand, 'preSubcommand');
+    promiseChain = this._chainOrCall(promiseChain, () => {
       if (subCommand._executableHandler) {
         this._executeSubCommand(subCommand, operands.concat(unknown));
       } else {
         return subCommand._parseCommand(operands, unknown);
       }
     });
-    return hookResult;
+    return promiseChain;
   }
 
   /**
@@ -1313,16 +1313,16 @@ Expecting one of '${allowedValues.join("', '")}'`);
       checkForUnknownOptions();
       this._processArguments();
 
-      let actionResult;
-      actionResult = this._chainOrCallHooks(actionResult, 'preAction');
-      actionResult = this._chainOrCall(actionResult, () => this._actionHandler(this.processedArgs));
+      let promiseChain;
+      promiseChain = this._chainOrCallHooks(promiseChain, 'preAction');
+      promiseChain = this._chainOrCall(promiseChain, () => this._actionHandler(this.processedArgs));
       if (this.parent) {
-        actionResult = this._chainOrCall(actionResult, () => {
+        promiseChain = this._chainOrCall(promiseChain, () => {
           this.parent.emit(commandEvent, operands, unknown); // legacy
         });
       }
-      actionResult = this._chainOrCallHooks(actionResult, 'postAction');
-      return actionResult;
+      promiseChain = this._chainOrCallHooks(promiseChain, 'postAction');
+      return promiseChain;
     }
     if (this.parent && this.parent.listenerCount(commandEvent)) {
       checkForUnknownOptions();

--- a/lib/command.js
+++ b/lib/command.js
@@ -66,8 +66,8 @@ class Command extends EventEmitter {
     };
 
     this._hidden = false;
+    /** @type {Option | undefined | null} */
     this._helpOption = undefined; // Lazy created on demand.
-    this._hasHelpOption = true;
     this._addImplicitHelpCommand = undefined; // Deliberately undefined, not decided whether true or false
     this._helpCommandName = 'help';
     this._helpCommandnameAndArgs = 'help [command]';
@@ -85,8 +85,7 @@ class Command extends EventEmitter {
    */
   copyInheritedSettings(sourceCommand) {
     this._outputConfiguration = sourceCommand._outputConfiguration;
-    this._helpOption = sourceCommand.helpOption();
-    this._hasHelpOption = sourceCommand._hasHelpOption;
+    this._helpOption = sourceCommand._helpOption;
     this._helpCommandName = sourceCommand._helpCommandName;
     this._helpCommandnameAndArgs = sourceCommand._helpCommandnameAndArgs;
     this._helpCommandDescription = sourceCommand._helpCommandDescription;
@@ -1097,7 +1096,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
     // Fallback to parsing the help flag to invoke the help.
     return this._dispatchSubcommand(subcommandName, [], [
-      this.helpOption().long ?? this.helpOption().short ?? '--help'
+      this._getHelpOption().long ?? this._getHelpOption().short ?? '--help'
     ]);
   }
 
@@ -1902,7 +1901,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
         return humanReadableArgName(arg);
       });
       return [].concat(
-        (this.options.length || this._hasHelpOption ? '[options]' : []),
+        (this.options.length || (this._helpOption !== null) ? '[options]' : []),
         (this.commands.length ? '[command]' : []),
         (this.registeredArguments.length ? args : [])
       ).join(' ');
@@ -2023,8 +2022,8 @@ Expecting one of '${allowedValues.join("', '")}'`);
     }
     context.write(helpInformation);
 
-    if (this.helpOption().long) {
-      this.emit(this.helpOption().long); // deprecated
+    if (this._getHelpOption().long) {
+      this.emit(this._getHelpOption().long); // deprecated
     }
     this.emit('afterHelp', context);
     this._getCommandAndAncestors().forEach(command => command.emit('afterAllHelp', context));
@@ -2033,50 +2032,53 @@ Expecting one of '${allowedValues.join("', '")}'`);
   /**
    * You can pass in flags and a description to customise the built-in help option
    * Pass in false to disable the built-in help option.
-   * Lastly, can call with no arguments to return the built-in help option.
    *
    * @example
    * program.helpOption('-?, --help' 'show help'); // customise
    * program.helpOption(false); // disable
-   * const helpOption = program.helpOption(); // getter
    *
-   * @param {string | boolean} [flags]
+   * @param {string | boolean} flags
    * @param {string} [description]
-   * @return {Command | Option} `this` command for chaining (or help option if no arguments)
+   * @return {Command} `this` command for chaining
    */
 
   helpOption(flags, description) {
-    // Getter, lazy create help option on demand.
-    if (flags === undefined && description === undefined) {
-      if (this._helpOption === undefined) {
-        this._helpOption = this.createOption('-h, --help', 'display help for command');
-      }
-      return this._helpOption;
-    }
-
     // Support disabling built-in help option.
     if (typeof flags === 'boolean') {
-      this._hasHelpOption = flags;
+      this._helpOption = flags ? undefined : null;
       return this;
     }
 
     // Customise flags and description.
-    flags = flags ?? this.helpOption().flags;
-    description = description ?? this.helpOption().description;
+    flags = flags ?? this._getHelpOption().flags;
+    description = description ?? this._getHelpOption().description;
     this._helpOption = this.createOption(flags, description);
 
     return this;
   }
 
   /**
+   *
+   * @returns {Option} the help option
+   */
+  _getHelpOption() {
+    // Lazy create help option on demand.
+    if (this._helpOption === undefined) {
+      this._helpOption = this.createOption('-h, --help', 'display help for command');
+    }
+    return this._helpOption;
+  }
+
+  /**
    * Supply your own option to use for the built-in help option.
    * This is an alternative to using helpOption() to customise the flags and description etc.
    *
-   * @param {Option|undefined} option
-   * @return {Command|Option} `this` command for chaining
+   * @param {Option} option
+   * @return {Command} `this` command for chaining
    */
   addHelpOption(option) {
     this._helpOption = option;
+    return this;
   }
 
   /**
@@ -2139,8 +2141,8 @@ Expecting one of '${allowedValues.join("', '")}'`);
  */
 
 function outputHelpIfRequested(cmd, args) {
-  const helpOption = cmd.helpOption();
-  const helpRequested = cmd._hasHelpOption && args.find(arg => helpOption.is(arg));
+  const helpOption = cmd._getHelpOption();
+  const helpRequested = helpOption && args.find(arg => helpOption.is(arg));
   if (helpRequested) {
     cmd.outputHelp();
     // (Do not have all displayed text available so only passing placeholder.)

--- a/lib/command.js
+++ b/lib/command.js
@@ -1101,7 +1101,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
     }
 
     // Fallback to parsing the help flag to invoke the help.
-    return this._dispatchSubcommand(subcommandName, [], [this._helpLongFlag]);
+    if (this._helpLongFlag) {
+      return this._dispatchSubcommand(subcommandName, [], [this._helpLongFlag]);
+    }
   }
 
   /**
@@ -2034,7 +2036,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
     }
     context.write(helpInformation);
 
-    this.emit(this._helpLongFlag); // deprecated
+    if (this._helpLongFlag) {
+      this.emit(this._helpLongFlag); // deprecated
+    }
     this.emit('afterHelp', context);
     getCommandAndParents(this).forEach(command => command.emit('afterAllHelp', context));
   }

--- a/lib/command.js
+++ b/lib/command.js
@@ -750,10 +750,13 @@ Expecting one of '${allowedValues.join("', '")}'`);
     */
 
   storeOptionsAsProperties(storeAsProperties = true) {
-    this._storeOptionsAsProperties = !!storeAsProperties;
     if (this.options.length) {
       throw new Error('call .storeOptionsAsProperties() before adding options');
     }
+    if (Object.keys(this._optionValues).length) {
+      throw new Error('call .storeOptionsAsProperties() before setting option values');
+    }
+    this._storeOptionsAsProperties = !!storeAsProperties;
     return this;
   }
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -1825,17 +1825,16 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   /**
-   * Set the program version to `str`.
+   * Get or set the program version.
    *
-   * This method auto-registers the "-V, --version" flag
-   * which will print the version number when passed.
+   * This method auto-registers the "-V, --version" option which will print the version number.
    *
-   * You can optionally supply the  flags and description to override the defaults.
+   * You can optionally supply the flags and description to override the defaults.
    *
-   * @param {string} str
+   * @param {string} [str]
    * @param {string} [flags]
    * @param {string} [description]
-   * @return {this | string} `this` command for chaining, or version string if no arguments
+   * @return {this | string | undefined} `this` command for chaining, or version string if no arguments
    */
 
   version(str, flags, description) {
@@ -1844,7 +1843,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     flags = flags || '-V, --version';
     description = description || 'output the version number';
     const versionOption = this.createOption(flags, description);
-    this._versionOptionName = versionOption.attributeName();
+    this._versionOptionName = versionOption.attributeName(); // [sic] not defined in constructor, partly legacy, partly only needed at root
     this.options.push(versionOption);
     this.on('option:' + versionOption.name(), () => {
       this._outputConfiguration.writeOut(`${str}\n`);

--- a/lib/command.js
+++ b/lib/command.js
@@ -2030,7 +2030,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   /**
-   * You can pass in flags and a description to customise the built-in help option
+   * You can pass in flags and a description to customise the built-in help option.
    * Pass in false to disable the built-in help option.
    *
    * @example
@@ -2062,17 +2062,18 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   /**
+   * Lazy create help option.
+   * Returns null if has been disabled with .helpOption(false).
    *
    * @returns {(Option | null)} the help option
+   * @package
    */
   _getHelpOption() {
-    return null;
     // Lazy create help option on demand.
-    // if (this._helpOption === undefined) {
-    //   this.helpOption(undefined, undefined);
-    // }
-    // // May be null if disabled with helpOption(false).
-    // return this._helpOption;
+    if (this._helpOption === undefined) {
+      this.helpOption(undefined, undefined);
+    }
+    return this._helpOption;
   }
 
   /**

--- a/lib/command.js
+++ b/lib/command.js
@@ -67,7 +67,7 @@ class Command extends EventEmitter {
     };
 
     this._hidden = false;
-    this._helpOption = this.createOption('-h, --help', 'display help for command');
+    this._helpOption = undefined; // Lazy created on demand.
     this._hasHelpOption = true;
     this._addImplicitHelpCommand = undefined; // Deliberately undefined, not decided whether true or false
     this._helpCommandName = 'help';
@@ -86,7 +86,7 @@ class Command extends EventEmitter {
    */
   copyInheritedSettings(sourceCommand) {
     this._outputConfiguration = sourceCommand._outputConfiguration;
-    this._helpOption = sourceCommand._helpOption;
+    this._helpOption = sourceCommand._helpOption; // (May still be undefined.)
     this._hasHelpOption = sourceCommand._hasHelpOption;
     this._helpCommandName = sourceCommand._helpCommandName;
     this._helpCommandnameAndArgs = sourceCommand._helpCommandnameAndArgs;
@@ -1126,7 +1126,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
     // Fallback to parsing the help flag to invoke the help.
     return this._dispatchSubcommand(subcommandName, [], [
-      this._helpOption.long ?? this._helpOption.short ?? '--help'
+      this.helpOption().long ?? this.helpOption().short ?? '--help'
     ]);
   }
 
@@ -2052,33 +2052,60 @@ Expecting one of '${allowedValues.join("', '")}'`);
     }
     context.write(helpInformation);
 
-    if (this._helpOption.long) {
-      this.emit(this._helpOption.long); // deprecated
+    if (this.helpOption().long) {
+      this.emit(this.helpOption().long); // deprecated
     }
     this.emit('afterHelp', context);
     this._getCommandAndAncestors().forEach(command => command.emit('afterAllHelp', context));
   }
 
   /**
-   * You can pass in flags and a description to override the help
-   * flags and help description for your command. Pass in false to
-   * disable the built-in help option.
+   * You can pass in flags and a description to customise the built-in help option
+   * Pass in false to disable the built-in help option.
+   * Lastly, can call with no arguments to return the built-in help option.
+   *
+   * @example
+   * program.helpOption('-?, --help' 'show help'); // customise
+   * program.helpOption(false); // disable
+   * const helpOption = program.helpOption(); // getter
    *
    * @param {string | boolean} [flags]
    * @param {string} [description]
-   * @return {Command} `this` command for chaining
+   * @return {Command | Option} `this` command for chaining (or help option if no arguments)
    */
 
   helpOption(flags, description) {
+    // Getter, lazy create help option on demand.
+    if (flags === undefined && description === undefined) {
+      if (this._helpOption === undefined) {
+        this._helpOption = this.createOption('-h, --help', 'display help for command');
+      }
+      return this._helpOption;
+    }
+
+    // Support disabling built-in help option.
     if (typeof flags === 'boolean') {
       this._hasHelpOption = flags;
       return this;
     }
-    flags = flags ?? this._helpOption.flags;
-    description = description ?? this._helpOption.description;
+
+    // Customise flags and description.
+    flags = flags ?? this.helpOption().flags;
+    description = description ?? this.helpOption().description;
     this._helpOption = this.createOption(flags, description);
 
     return this;
+  }
+
+  /**
+   * Supply your own option to use for the built-in help option.
+   * This is an alternative to using helpOption() to customise the flags and description etc.
+   *
+   * @param {Option|undefined} option
+   * @return {Command|Option} `this` command for chaining
+   */
+  addHelpOption(option) {
+    this._helpOption = option;
   }
 
   /**
@@ -2141,7 +2168,8 @@ Expecting one of '${allowedValues.join("', '")}'`);
  */
 
 function outputHelpIfRequested(cmd, args) {
-  const helpRequested = cmd._hasHelpOption && args.find(arg => cmd._helpOption.is(arg));
+  const helpOption = cmd.helpOption();
+  const helpRequested = cmd._hasHelpOption && args.find(arg => helpOption.is(arg));
   if (helpRequested) {
     cmd.outputHelp();
     // (Do not have all displayed text available so only passing placeholder.)

--- a/lib/command.js
+++ b/lib/command.js
@@ -66,8 +66,8 @@ class Command extends EventEmitter {
     };
 
     this._hidden = false;
-    /** @type {Option | undefined | null} */
-    this._helpOption = undefined; // Lazy created on demand.
+    /** @type {(Option | null | undefined)} */
+    this._helpOption = undefined; // Lazy created on demand. May be null if help option is disabled.
     this._addImplicitHelpCommand = undefined; // Deliberately undefined, not decided whether true or false
     this._helpCommandName = 'help';
     this._helpCommandnameAndArgs = 'help [command]';
@@ -1096,7 +1096,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
     // Fallback to parsing the help flag to invoke the help.
     return this._dispatchSubcommand(subcommandName, [], [
-      this._getHelpOption().long ?? this._getHelpOption().short ?? '--help'
+      this._getHelpOption()?.long ?? this._getHelpOption()?.short ?? '--help'
     ]);
   }
 
@@ -2022,7 +2022,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     }
     context.write(helpInformation);
 
-    if (this._getHelpOption().long) {
+    if (this._getHelpOption()?.long) {
       this.emit(this._getHelpOption().long); // deprecated
     }
     this.emit('afterHelp', context);
@@ -2045,13 +2045,17 @@ Expecting one of '${allowedValues.join("', '")}'`);
   helpOption(flags, description) {
     // Support disabling built-in help option.
     if (typeof flags === 'boolean') {
-      this._helpOption = flags ? undefined : null;
+      if (flags) {
+        this._helpOption = this._helpOption ?? undefined; // preserve existing option
+      } else {
+        this._helpOption = null; // disable
+      }
       return this;
     }
 
     // Customise flags and description.
-    flags = flags ?? this._getHelpOption().flags;
-    description = description ?? this._getHelpOption().description;
+    flags = flags ?? '-h, --help';
+    description = description ?? 'display help for command';
     this._helpOption = this.createOption(flags, description);
 
     return this;
@@ -2059,14 +2063,16 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
   /**
    *
-   * @returns {Option} the help option
+   * @returns {(Option | null)} the help option
    */
   _getHelpOption() {
+    return null;
     // Lazy create help option on demand.
-    if (this._helpOption === undefined) {
-      this._helpOption = this.createOption('-h, --help', 'display help for command');
-    }
-    return this._helpOption;
+    // if (this._helpOption === undefined) {
+    //   this.helpOption(undefined, undefined);
+    // }
+    // // May be null if disabled with helpOption(false).
+    // return this._helpOption;
   }
 
   /**

--- a/lib/help.js
+++ b/lib/help.js
@@ -70,19 +70,19 @@ class Help {
 
   visibleOptions(cmd) {
     const visibleOptions = cmd.options.filter((option) => !option.hidden);
-    // Implicit help
-    const showShortHelpFlag = cmd._hasHelpOption && cmd._helpShortFlag && !cmd._findOption(cmd._helpShortFlag);
-    const showLongHelpFlag = cmd._hasHelpOption && !cmd._findOption(cmd._helpLongFlag);
-    if (showShortHelpFlag || showLongHelpFlag) {
-      let helpOption;
-      if (!showShortHelpFlag) {
-        helpOption = cmd.createOption(cmd._helpLongFlag, cmd._helpDescription);
-      } else if (!showLongHelpFlag) {
-        helpOption = cmd.createOption(cmd._helpShortFlag, cmd._helpDescription);
-      } else {
-        helpOption = cmd.createOption(cmd._helpFlags, cmd._helpDescription);
+    // Built-in help option.
+    if (cmd._hasHelpOption && !cmd._helpOption.hidden) {
+      const helpOption = cmd._helpOption;
+      // Automatically hide conflicting flags. (Bit magical and messy, but preserve for now!)
+      const removeShort = helpOption.short && cmd._findOption(helpOption.short);
+      const removeLong = helpOption.long && cmd._findOption(helpOption.long);
+      if (!removeShort && !removeLong) {
+        visibleOptions.push(helpOption); // no changes needed
+      } else if (helpOption.long && !removeLong) {
+        visibleOptions.push(cmd.createOption(helpOption.long, helpOption.description));
+      } else if (helpOption.short && !removeShort) {
+        visibleOptions.push(cmd.createOption(helpOption.short, helpOption.description));
       }
-      visibleOptions.push(helpOption);
     }
     if (this.sortOptions) {
       visibleOptions.sort(this.compareOptions);

--- a/lib/help.js
+++ b/lib/help.js
@@ -71,8 +71,8 @@ class Help {
   visibleOptions(cmd) {
     const visibleOptions = cmd.options.filter((option) => !option.hidden);
     // Built-in help option.
-    if (cmd._hasHelpOption && !cmd._helpOption.hidden) {
-      const helpOption = cmd._helpOption;
+    if (cmd._hasHelpOption && !cmd.helpOption().hidden) {
+      const helpOption = cmd.helpOption();
       // Automatically hide conflicting flags. (Bit magical and messy, but preserve for now!)
       const removeShort = helpOption.short && cmd._findOption(helpOption.short);
       const removeLong = helpOption.long && cmd._findOption(helpOption.long);

--- a/lib/help.js
+++ b/lib/help.js
@@ -101,10 +101,10 @@ class Help {
     if (!this.showGlobalOptions) return [];
 
     const globalOptions = [];
-    for (let parentCmd = cmd.parent; parentCmd; parentCmd = parentCmd.parent) {
-      const visibleOptions = parentCmd.options.filter((option) => !option.hidden);
+    cmd._getCommandAndAncestors().slice(1).forEach((ancestorCmd) => {
+      const visibleOptions = ancestorCmd.options.filter((option) => !option.hidden);
       globalOptions.push(...visibleOptions);
-    }
+    });
     if (this.sortOptions) {
       globalOptions.sort(this.compareOptions);
     }
@@ -240,11 +240,11 @@ class Help {
     if (cmd._aliases[0]) {
       cmdName = cmdName + '|' + cmd._aliases[0];
     }
-    let parentCmdNames = '';
-    for (let parentCmd = cmd.parent; parentCmd; parentCmd = parentCmd.parent) {
-      parentCmdNames = parentCmd.name() + ' ' + parentCmdNames;
-    }
-    return parentCmdNames + cmdName + ' ' + cmd.usage();
+    let ancestorCmdNames = '';
+    cmd._getCommandAndAncestors().slice(1).forEach((ancestorCmd) => {
+      ancestorCmdNames = ancestorCmd.name() + ' ' + ancestorCmdNames;
+    });
+    return ancestorCmdNames + cmdName + ' ' + cmd.usage();
   }
 
   /**

--- a/lib/help.js
+++ b/lib/help.js
@@ -69,8 +69,8 @@ class Help {
   visibleOptions(cmd) {
     const visibleOptions = cmd.options.filter((option) => !option.hidden);
     // Built-in help option.
-    if (cmd._hasHelpOption && !cmd.helpOption().hidden) {
-      const helpOption = cmd.helpOption();
+    const helpOption = cmd._getHelpOption();
+    if (helpOption && !helpOption.hidden) {
       // Automatically hide conflicting flags. (Bit magical and messy, but preserve for now!)
       const removeShort = helpOption.short && cmd._findOption(helpOption.short);
       const removeLong = helpOption.long && cmd._findOption(helpOption.long);

--- a/lib/help.js
+++ b/lib/help.js
@@ -101,10 +101,10 @@ class Help {
     if (!this.showGlobalOptions) return [];
 
     const globalOptions = [];
-    cmd._getCommandAndAncestors().slice(1).forEach((ancestorCmd) => {
+    for (let ancestorCmd = cmd.parent; ancestorCmd; ancestorCmd = ancestorCmd.parent) {
       const visibleOptions = ancestorCmd.options.filter((option) => !option.hidden);
       globalOptions.push(...visibleOptions);
-    });
+    }
     if (this.sortOptions) {
       globalOptions.sort(this.compareOptions);
     }
@@ -241,9 +241,9 @@ class Help {
       cmdName = cmdName + '|' + cmd._aliases[0];
     }
     let ancestorCmdNames = '';
-    cmd._getCommandAndAncestors().slice(1).forEach((ancestorCmd) => {
+    for (let ancestorCmd = cmd.parent; ancestorCmd; ancestorCmd = ancestorCmd.parent) {
       ancestorCmdNames = ancestorCmd.name() + ' ' + ancestorCmdNames;
-    });
+    }
     return ancestorCmdNames + cmdName + ' ' + cmd.usage();
   }
 

--- a/lib/help.js
+++ b/lib/help.js
@@ -71,7 +71,7 @@ class Help {
     // Built-in help option.
     const helpOption = cmd._getHelpOption();
     if (helpOption && !helpOption.hidden) {
-      // Automatically hide conflicting flags. (Bit magical and messy, but preserve for now!)
+      // Automatically hide conflicting flags. Bit dubious but a historical behaviour that is convenient for single-command programs.
       const removeShort = helpOption.short && cmd._findOption(helpOption.short);
       const removeLong = helpOption.long && cmd._findOption(helpOption.long);
       if (!removeShort && !removeLong) {

--- a/lib/option.js
+++ b/lib/option.js
@@ -327,5 +327,4 @@ function splitOptionFlags(flags) {
 }
 
 exports.Option = Option;
-exports.splitOptionFlags = splitOptionFlags;
 exports.DualOptions = DualOptions;

--- a/tests/command.addHelpOption.test.js
+++ b/tests/command.addHelpOption.test.js
@@ -1,0 +1,54 @@
+const { Command, Option } = require('../');
+
+// More complete tests are in command.helpOption.test.js.
+
+describe('addHelpOption', () => {
+  let writeSpy;
+  let writeErrorSpy;
+
+  beforeAll(() => {
+    // Optional. Suppress expected output to keep test output clean.
+    writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => { });
+    writeErrorSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => { });
+  });
+
+  afterEach(() => {
+    writeSpy.mockClear();
+    writeErrorSpy.mockClear();
+  });
+
+  afterAll(() => {
+    writeSpy.mockRestore();
+    writeErrorSpy.mockRestore();
+  });
+
+  test('when addHelpOption has custom flags then custom short flag invokes help', () => {
+    const program = new Command();
+    program
+      .exitOverride()
+      .addHelpOption(new Option('-c,--custom-help'));
+
+    expect(() => {
+      program.parse(['-c'], { from: 'user' });
+    }).toThrow('(outputHelp)');
+  });
+
+  test('when addHelpOption has custom flags then custom long flag invokes help', () => {
+    const program = new Command();
+    program
+      .exitOverride()
+      .addHelpOption(new Option('-c,--custom-help'));
+
+    expect(() => {
+      program.parse(['--custom-help'], { from: 'user' });
+    }).toThrow('(outputHelp)');
+  });
+
+  test('when addHelpOption with hidden help option then help does not include help option', () => {
+    const program = new Command();
+    program
+      .addHelpOption(new Option('-c,--custom-help', 'help help help').hideHelp());
+    const helpInfo = program.helpInformation();
+    expect(helpInfo).not.toMatch(/help/);
+  });
+});

--- a/tests/command.chain.test.js
+++ b/tests/command.chain.test.js
@@ -130,9 +130,16 @@ describe('Command methods that should return this for chaining', () => {
     expect(result).toBe(program);
   });
 
-  test('when call .helpOption() then returns this', () => {
+  test('when call .helpOption(flags) then returns this', () => {
     const program = new Command();
-    const result = program.helpOption(false);
+    const flags = '-h, --help';
+    const result = program.helpOption(flags);
+    expect(result).toBe(program);
+  });
+
+  test('when call .addHelpOption() then returns this', () => {
+    const program = new Command();
+    const result = program.addHelpOption(new Option('-h, --help'));
     expect(result).toBe(program);
   });
 

--- a/tests/command.copySettings.test.js
+++ b/tests/command.copySettings.test.js
@@ -31,11 +31,10 @@ describe('copyInheritedSettings property tests', () => {
   test('when copyInheritedSettings then copies helpOption(false)', () => {
     const source = new commander.Command();
     const cmd = new commander.Command();
-    expect(cmd._hasHelpOption).toBeTruthy();
 
     source.helpOption(false);
     cmd.copyInheritedSettings(source);
-    expect(cmd._hasHelpOption).toBeFalsy();
+    expect(cmd._getHelpOption()).toBe(null);
   });
 
   test('when copyInheritedSettings then copies helpOption(flags, description)', () => {
@@ -44,11 +43,12 @@ describe('copyInheritedSettings property tests', () => {
 
     source.helpOption('-Z, --zz', 'ddd');
     cmd.copyInheritedSettings(source);
-    const helpOption = cmd.helpOption();
-    expect(helpOption.flags).toBe('-Z, --zz');
-    expect(helpOption.description).toBe('ddd');
-    expect(helpOption.short).toBe('-Z');
-    expect(helpOption.long).toBe('--zz');
+    expect(cmd._getHelpOption()).toBe(source._getHelpOption());
+    // const helpOption = cmd._getHelpOption();
+    // expect(helpOption.flags).toBe('-Z, --zz');
+    // expect(helpOption.description).toBe('ddd');
+    // expect(helpOption.short).toBe('-Z');
+    // expect(helpOption.long).toBe('--zz');
   });
 
   test('when copyInheritedSettings then copies addHelpCommand(name, description)', () => {

--- a/tests/command.copySettings.test.js
+++ b/tests/command.copySettings.test.js
@@ -44,10 +44,11 @@ describe('copyInheritedSettings property tests', () => {
 
     source.helpOption('-Z, --zz', 'ddd');
     cmd.copyInheritedSettings(source);
-    expect(cmd._helpOption.flags).toBe('-Z, --zz');
-    expect(cmd._helpOption.description).toBe('ddd');
-    expect(cmd._helpOption.short).toBe('-Z');
-    expect(cmd._helpOption.long).toBe('--zz');
+    const helpOption = cmd.helpOption();
+    expect(helpOption.flags).toBe('-Z, --zz');
+    expect(helpOption.description).toBe('ddd');
+    expect(helpOption.short).toBe('-Z');
+    expect(helpOption.long).toBe('--zz');
   });
 
   test('when copyInheritedSettings then copies addHelpCommand(name, description)', () => {

--- a/tests/command.copySettings.test.js
+++ b/tests/command.copySettings.test.js
@@ -44,10 +44,10 @@ describe('copyInheritedSettings property tests', () => {
 
     source.helpOption('-Z, --zz', 'ddd');
     cmd.copyInheritedSettings(source);
-    expect(cmd._helpFlags).toBe('-Z, --zz');
-    expect(cmd._helpDescription).toBe('ddd');
-    expect(cmd._helpShortFlag).toBe('-Z');
-    expect(cmd._helpLongFlag).toBe('--zz');
+    expect(cmd._helpOption.flags).toBe('-Z, --zz');
+    expect(cmd._helpOption.description).toBe('ddd');
+    expect(cmd._helpOption.short).toBe('-Z');
+    expect(cmd._helpOption.long).toBe('--zz');
   });
 
   test('when copyInheritedSettings then copies addHelpCommand(name, description)', () => {

--- a/tests/commander.configureCommand.test.js
+++ b/tests/commander.configureCommand.test.js
@@ -84,3 +84,11 @@ test('when storeOptionsAsProperties() after adding option then throw', () => {
     program.storeOptionsAsProperties(false);
   }).toThrow();
 });
+
+test('when storeOptionsAsProperties() after setting option value then throw', () => {
+  const program = new commander.Command();
+  program.setOptionValue('foo', 'bar');
+  expect(() => {
+    program.storeOptionsAsProperties(false);
+  }).toThrow();
+});

--- a/tests/commander.configureCommand.test.js
+++ b/tests/commander.configureCommand.test.js
@@ -81,7 +81,7 @@ test('when storeOptionsAsProperties() after adding option then throw', () => {
   const program = new commander.Command();
   program.option('--port <number>', 'port number', '80');
   expect(() => {
-    program.storeOptionsAsProperties(false);
+    program.storeOptionsAsProperties();
   }).toThrow();
 });
 
@@ -89,6 +89,6 @@ test('when storeOptionsAsProperties() after setting option value then throw', ()
   const program = new commander.Command();
   program.setOptionValue('foo', 'bar');
   expect(() => {
-    program.storeOptionsAsProperties(false);
+    program.storeOptionsAsProperties();
   }).toThrow();
 });

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -293,7 +293,7 @@ export class Command {
    *
    * You can optionally supply the  flags and description to override the defaults.
    */
-  version(str?: string, flags?: string, description?: string): this;
+  version(str: string, flags?: string, description?: string): this;
 
   /**
    * Define a command, implemented using an action handler.

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -839,6 +839,12 @@ export class Command {
   helpOption(flags?: string | boolean, description?: string): this;
 
   /**
+   * Supply your own option to use for the built-in help option.
+   * This is an alternative to using helpOption() to customise the flags and description etc.
+   */
+  addHelpOption(option: Option): this;
+
+  /**
    * Output help information and exit.
    *
    * Outputs built-in help, and custom text added using `.addHelpText()`.

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -5,6 +5,14 @@
 /* eslint-disable @typescript-eslint/method-signature-style */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+// This is a trick to encourage editor to suggest the known literals while still
+// allowing any BaseType value.
+// References:
+// - https://github.com/microsoft/TypeScript/issues/29729
+// - https://github.com/sindresorhus/type-fest/blob/main/source/literal-union.d.ts
+// - https://github.com/sindresorhus/type-fest/blob/main/source/primitive.d.ts
+type LiteralUnion<LiteralType, BaseType extends string | number> = LiteralType | (BaseType & Record<never, never>);
+
 export class CommanderError extends Error {
   code: string;
   exitCode: number;
@@ -272,7 +280,8 @@ export interface OutputConfiguration {
 
 export type AddHelpTextPosition = 'beforeAll' | 'before' | 'after' | 'afterAll';
 export type HookEvent = 'preSubcommand' | 'preAction' | 'postAction';
-export type OptionValueSource = 'default' | 'config' | 'env' | 'cli' | 'implied';
+// The source is a string so author can define their own too.
+export type OptionValueSource = LiteralUnion<'default' | 'config' | 'env' | 'cli' | 'implied', string> | undefined;
 
 export type OptionValues = Record<string, any>;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -294,6 +294,10 @@ export class Command {
    * You can optionally supply the  flags and description to override the defaults.
    */
   version(str: string, flags?: string, description?: string): this;
+  /**
+   * Get the program version.
+   */
+  version(): string | undefined;
 
   /**
    * Define a command, implemented using an action handler.

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -36,6 +36,7 @@ expectType<commander.Command | null>(program.parent);
 expectType<commander.Command>(program.version('1.2.3'));
 expectType<commander.Command>(program.version('1.2.3', '-r,--revision'));
 expectType<commander.Command>(program.version('1.2.3', '-r,--revision', 'show revision information'));
+expectType<string | undefined>(program.version());
 
 // command (and CommandOptions)
 expectType<commander.Command>(program.command('action'));

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -302,6 +302,9 @@ expectType<commander.Command>(program.helpOption('-h,--help', 'custom descriptio
 expectType<commander.Command>(program.helpOption(undefined, 'custom description'));
 expectType<commander.Command>(program.helpOption(false));
 
+// addHelpOption
+expectType<commander.Command>(program.addHelpOption(new commander.Option('-h,--help')));
+
 // addHelpText
 expectType<commander.Command>(program.addHelpText('after', 'text'));
 expectType<commander.Command>(program.addHelpText('afterAll', 'text'));


### PR DESCRIPTION
# Pull Request

The main motivation for this refactor is to potentially simplify future work that uses more Option properties. For example, adding help group to Option like in #1910.

Instead of extending `.helpOption()` to add parallel features like:
```
program.helpOption('-s, --support', 'Show help', { helpGroup: 'Demo Options:' });
```

could instead use same approach as normal options:
```
program.addHelpOption(new Option('-s, --support', 'Show help').group('Demo Options:'));
```

(This overlaps with motivation and implementation in #1929.)

## Problem

Additions to `Option` that can be used with `.addOption()` can't be used with the help option. For example, hiding the help option (#689).

There are an annoying number of help option related properties on `Command`.

Determining the help option flags does not go through `cmd.createOption()` so misses some potential custom class behaviour, such as custom flags parsing. (Minor!)

## Solution

Store a help Option rather than the necessary deconstructed properties.

Add `.addHelpOption()` to add author created option, exposing more configuration just like `.addOption()` does.

## ChangeLog

- Added: `.addHelpOption()` as another way of configuring built-in help option
- Changed: refactor internal implementation of built-in help option

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->
