### PR TITLE
Work around Jest bug

### DIFF
--- a/tests/fixtures/inspect.js
+++ b/tests/fixtures/inspect.js
@@ -2,6 +2,8 @@
 
 const program = require('../../');
 
+process.env.FORCE_COLOR = 0; // work-around bug in Jest: https://github.com/jestjs/jest/issues/14391
+
 program
   .command('sub', 'install one or more packages')
   .parse(process.argv);

--- a/tests/fixtures/pm
+++ b/tests/fixtures/pm
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+process.env.FORCE_COLOR = 0; // work-around bug in Jest: https://github.com/jestjs/jest/issues/14391
+
 var program = require('../../');
 
 program


### PR DESCRIPTION
# Pull Request

## Problem

Work-around a Jest issue that shows up in recent Node.js 18 versions. Ascii colours are being included in spawned command output in certain tests. As first raised in #1950.

Reference: https://github.com/jestjs/jest/issues/14391

## Solution

Suppress colours in the failing tests with environment variable `FORCE_COLOR`. 

This is a simpler version of #1950. (@aweebit added as co-author in commit comment)