### PR TITLE
Fix factory functions with typescript whole module import

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,18 +10,30 @@ const { Option } = require('./lib/option.js');
  * Expose the root command.
  */
 
-exports = module.exports = new Command();
-exports.program = exports; // More explicit access to global command.
-// Implicit export of createArgument, createCommand, and createOption.
+const program = new Command();
+exports = module.exports = program; // default export (deprecated)
+exports.program = program; // more explicit access to global command
 
 /**
  * Expose classes
  */
 
-exports.Argument = Argument;
 exports.Command = Command;
-exports.CommanderError = CommanderError;
+exports.Option = Option;
+exports.Argument = Argument;
 exports.Help = Help;
+
+exports.CommanderError = CommanderError;
 exports.InvalidArgumentError = InvalidArgumentError;
 exports.InvalidOptionArgumentError = InvalidArgumentError; // Deprecated
-exports.Option = Option;
+
+/**
+ * Expose object factory functions.
+ *
+ * These are present implicitly, but need to be explicit
+ * to work with TypeScript whole module import (import * as foo) when esModuleInterop: true.
+ */
+
+exports.createCommand = program.createCommand;
+exports.createArgument = program.createArgument;
+exports.createOption = program.createOption;

--- a/tests/ts-imports.test.ts
+++ b/tests/ts-imports.test.ts
@@ -1,6 +1,18 @@
-import { program, Command, Option, CommanderError, InvalidArgumentError, InvalidOptionArgumentError, Help, createCommand } from '../';
+import {
+  program,
+  Command,
+  Option,
+  Argument,
+  Help,
+  CommanderError,
+  InvalidArgumentError,
+  InvalidOptionArgumentError,
+  createCommand,
+  createOption,
+  createArgument
+} from '../';
 
-import * as commander from '../';
+import * as commander from '../'; // This does interesting things when esModuleInterop is true!
 
 // Do some simple checks that expected imports are available at runtime.
 // Similar tests to esm-imports-test.js
@@ -11,38 +23,94 @@ function checkClass(obj: object, name: string): void {
   expect(obj.constructor.name).toEqual(name);
 }
 
-test('legacy default export of global Command', () => {
-  checkClass(commander, 'Command');
+describe('named imports', () => {
+  test('program', () => {
+    checkClass(program, 'Command');
+  });
+
+  test('Command', () => {
+    checkClass(new Command('name'), 'Command');
+  });
+
+  test('Option', () => {
+    checkClass(new Option('-e, --example', 'description'), 'Option');
+  });
+
+  test('Argument', () => {
+    checkClass(new Argument('<foo>', 'description'), 'Argument');
+  });
+
+  test('Help', () => {
+    checkClass(new Help(), 'Help');
+  });
+
+  test('CommanderError', () => {
+    checkClass(new CommanderError(1, 'code', 'failed'), 'CommanderError');
+  });
+
+  test('InvalidArgumentError', () => {
+    checkClass(new InvalidArgumentError('failed'), 'InvalidArgumentError');
+  });
+
+  test('InvalidOptionArgumentError', () => { // Deprecated
+    checkClass(new InvalidOptionArgumentError('failed'), 'InvalidArgumentError');
+  });
+
+  test('createCommand', () => {
+    checkClass(createCommand('foo'), 'Command');
+  });
+
+  test('createOption', () => {
+    checkClass(createOption('-e, --example', 'description'), 'Option');
+  });
+
+  test('createArgument', () => {
+    checkClass(createArgument('<foo>', 'description'), 'Argument');
+  });
 });
 
-test('program', () => {
-  checkClass(program, 'Command');
-});
+describe('import * as commander', () => {
+  test('program', () => {
+    checkClass(commander.program, 'Command');
+  });
 
-test('createCommand', () => {
-  checkClass(createCommand(), 'Command');
-});
+  test('Command', () => {
+    checkClass(new commander.Command('name'), 'Command');
+  });
 
-test('Command', () => {
-  checkClass(new Command('name'), 'Command');
-});
+  test('Option', () => {
+    checkClass(new commander.Option('-e, --example', 'description'), 'Option');
+  });
 
-test('Option', () => {
-  checkClass(new Option('-e, --example', 'description'), 'Option');
-});
+  test('Argument', () => {
+    checkClass(new commander.Argument('<foo>', 'description'), 'Argument');
+  });
 
-test('CommanderError', () => {
-  checkClass(new CommanderError(1, 'code', 'failed'), 'CommanderError');
-});
+  test('Help', () => {
+    checkClass(new commander.Help(), 'Help');
+  });
 
-test('InvalidArgumentError', () => {
-  checkClass(new InvalidArgumentError('failed'), 'InvalidArgumentError');
-});
+  test('CommanderError', () => {
+    checkClass(new commander.CommanderError(1, 'code', 'failed'), 'CommanderError');
+  });
 
-test('InvalidOptionArgumentError', () => { // Deprecated
-  checkClass(new InvalidOptionArgumentError('failed'), 'InvalidArgumentError');
-});
+  test('InvalidArgumentError', () => {
+    checkClass(new commander.InvalidArgumentError('failed'), 'InvalidArgumentError');
+  });
 
-test('Help', () => {
-  checkClass(new Help(), 'Help');
+  test('InvalidOptionArgumentError', () => { // Deprecated
+    checkClass(new commander.InvalidOptionArgumentError('failed'), 'InvalidArgumentError');
+  });
+
+  test('createCommand', () => {
+    checkClass(commander.createCommand('foo'), 'Command');
+  });
+
+  test('createOption', () => {
+    checkClass(commander.createOption('-e, --example', 'description'), 'Option');
+  });
+
+  test('createArgument', () => {
+    checkClass(commander.createArgument('<foo>', 'description'), 'Argument');
+  });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
           "node",
           "jest"
         ],
+        "esModuleInterop": true, // Mainly so can test an import problem which only occurs with this option on!
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },


### PR DESCRIPTION
# Pull Request

A subtle problem with Commander exports got reported in #1974

## Problem

The factory functions like `createOption` were not available using a TypeScript whole module import (`import * as commander`) when `esModuleInterop: true`.

## Solution

Explicitly export the factory functions, rather than just rely on implicitly being available via global program. This is also consistent with eventual goal of dropping deprecated default export of global program.

Inspired by #1974. Lists @aweebit as co-author in commit comment.

## ChangeLog

- fix: global factory functions now available when using TypeScript whole module import (`import * as commander`)