### PR TITLE
Revert factory reexport

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,8 @@ const program = new Command();
 exports = module.exports = program; // default export (deprecated)
 exports.program = program; // more explicit access to global command
 
+// createArgument, createCommand, and createOption are implicitly available as they are methods on program.
+
 /**
  * Expose classes
  */
@@ -26,14 +28,3 @@ exports.Help = Help;
 exports.CommanderError = CommanderError;
 exports.InvalidArgumentError = InvalidArgumentError;
 exports.InvalidOptionArgumentError = InvalidArgumentError; // Deprecated
-
-/**
- * Expose object factory functions.
- *
- * These are present implicitly, but need to be explicit
- * to work with TypeScript whole module import (import * as foo) when esModuleInterop: true.
- */
-
-exports.createCommand = program.createCommand;
-exports.createArgument = program.createArgument;
-exports.createOption = program.createOption;

--- a/tests/ts-imports.test.ts
+++ b/tests/ts-imports.test.ts
@@ -102,15 +102,18 @@ describe('import * as commander', () => {
     checkClass(new commander.InvalidOptionArgumentError('failed'), 'InvalidArgumentError');
   });
 
-  test('createCommand', () => {
-    checkClass(commander.createCommand('foo'), 'Command');
-  });
+  // Factory functions are not found if esModuleInterop is true, so comment out tests for now.
+  // Can uncomment these again when we drop the default export of global program and add the factory functions explicitly.
 
-  test('createOption', () => {
-    checkClass(commander.createOption('-e, --example', 'description'), 'Option');
-  });
+  // test('createCommand', () => {
+  //   checkClass(commander.createCommand('foo'), 'Command');
+  // });
 
-  test('createArgument', () => {
-    checkClass(commander.createArgument('<foo>', 'description'), 'Argument');
-  });
+  // test('createOption', () => {
+  //   checkClass(commander.createOption('-e, --example', 'description'), 'Option');
+  // });
+
+  // test('createArgument', () => {
+  //   checkClass(commander.createArgument('<foo>', 'description'), 'Argument');
+  // });
 });


### PR DESCRIPTION
# Pull Request

## Problem

Adding reexports of the factory function in #2013 causes a TypeScript error from one of the optional checks:
```
% npm run typescript-checkJS

> commander@11.0.0 typescript-checkJS
> tsc --allowJS --checkJS index.js lib/*.js --noEmit

index.js:37:1 - error TS2303: Circular definition of import alias 'createCommand'.

37 exports.createCommand = program.createCommand;
   ~~~~~~~~~~~~~~~~~~~~~

index.js:38:1 - error TS2303: Circular definition of import alias 'createArgument'.

38 exports.createArgument = program.createArgument;
   ~~~~~~~~~~~~~~~~~~~~~~

index.js:39:1 - error TS2303: Circular definition of import alias 'createOption'.

39 exports.createOption = program.createOption;
   ~~~~~~~~~~~~~~~~~~~~


Found 3 errors in the same file, starting at: index.js:37
```

## Solution

The failure the re-export was fixing is that the factory functions are not available with a whole-module import (`import * as commander`) when `esModuleInterop: true`. 

A simple work-around if someone does encounter the problem is to use a named import for the factory function(s) they want.

So reverting the ex-export! (And the related tests can come back one day.)
