### PR TITLE
Replace {any} with {*} for native JSDoc

### DIFF
--- a/lib/argument.js
+++ b/lib/argument.js
@@ -66,7 +66,7 @@ class Argument {
   /**
    * Set the default value, and optionally supply the description to be displayed in the help.
    *
-   * @param {any} value
+   * @param {*} value
    * @param {string} [description]
    * @return {Argument}
    */

--- a/lib/command.js
+++ b/lib/command.js
@@ -519,7 +519,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    *
    * @param {Option | Argument} target
    * @param {string} value
-   * @param {any} previous
+   * @param {*} previous
    * @param {string} invalidArgumentMessage
    * @api private
    */

--- a/lib/option.js
+++ b/lib/option.js
@@ -40,7 +40,7 @@ class Option {
   /**
    * Set the default value, and optionally supply the description to be displayed in the help.
    *
-   * @param {any} value
+   * @param {*} value
    * @param {string} [description]
    * @return {Option}
    */
@@ -59,7 +59,7 @@ class Option {
    * new Option('--color').default('GREYSCALE').preset('RGB');
    * new Option('--donate [amount]').preset('20').argParser(parseFloat);
    *
-   * @param {any} arg
+   * @param {*} arg
    * @return {Option}
    */
 
@@ -275,7 +275,7 @@ class DualOptions {
   /**
    * Did the value come from the option, and not from possible matching dual option?
    *
-   * @param {any} value
+   * @param {*} value
    * @param {Option} option
    * @returns {boolean}
    */


### PR DESCRIPTION
# Pull Request

## Problem

I used TypeScript `any` in some of the JSDoc, but want the JSDoc to be native.

Prompted by mention in #1973

## Solution

Simple replace of `{any}` with `{*}`.
