### PR TITLE
Remove default export of global program

### DIFF
--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -58,6 +58,7 @@ const program = new Command()
 - Removed from README in Commander v5.
 - Deprecated from Commander v7.
 - Removed from TypeScript declarations in Commander v8.
+- Removed from CommonJS in Commander v12. Deprecated and gone!
 
 ## Callback to .help() and .outputHelp()
 

--- a/index.js
+++ b/index.js
@@ -6,13 +6,11 @@ const { Option } = require('./lib/option.js');
 
 // @ts-check
 
-/**
- * Expose the root command.
- */
+exports.program = new Command();
 
-exports = module.exports = new Command();
-exports.program = exports; // More explicit access to global command.
-// Implicit export of createArgument, createCommand, and createOption.
+exports.createCommand = (name) => new Command(name);
+exports.createOption = (flags, description) => new Option(flags, description);
+exports.createArgument = (name, description) => new Argument(name, description);
 
 /**
  * Expose classes

--- a/tests/fixtures-extensions/pm.js
+++ b/tests/fixtures-extensions/pm.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const program = require('../../');
+const { program } = require('../../');
 
 program
   .command('try-ts', 'test file extension lookup')

--- a/tests/fixtures/inspect.js
+++ b/tests/fixtures/inspect.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const program = require('../../');
+const { program } = require('../../');
 
 program
   .command('sub', 'install one or more packages')

--- a/tests/fixtures/pm
+++ b/tests/fixtures/pm
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-var program = require('../../');
+var { program } = require('../../');
 
 program
   .version('0.0.1')

--- a/tests/fixtures/pm-cache.js
+++ b/tests/fixtures/pm-cache.js
@@ -1,4 +1,4 @@
-const program = require('../../');
+const { program } = require('../../');
 
 program
   .command('clear', 'clear the cache')

--- a/tests/program.test.js
+++ b/tests/program.test.js
@@ -1,20 +1,67 @@
-const commander = require('../');
+const {
+  program,
+  Command,
+  Option,
+  Argument,
+  Help,
+  CommanderError,
+  InvalidArgumentError,
+  InvalidOptionArgumentError,
+  createCommand,
+  createOption,
+  createArgument
+} = require('../index.js');
 
 // Do some testing of the default export(s).
+// Similar tests to ts-imports.test.ts and esm-imports-test.js.
 
-test('when require commander then is a Command (default export of global)', () => {
-  // Deprecated global command
-  const program = commander;
-  expect(program.constructor.name).toBe('Command');
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "checkClass"] }] */
+
+function checkClass(obj, name) {
+  expect(typeof obj).toEqual('object');
+  expect(obj.constructor.name).toEqual(name);
+}
+
+test('program', () => {
+  checkClass(program, 'Command');
 });
 
-test('when require commander then has program (named export of global)', () => {
-  // program added in v5
-  const program = commander.program;
-  expect(program.constructor.name).toBe('Command');
+test('Command', () => {
+  checkClass(new Command('name'), 'Command');
 });
 
-test('when require commander then has newable Command', () => {
-  const cmd = new commander.Command();
-  expect(cmd.constructor.name).toBe('Command');
+test('Option', () => {
+  checkClass(new Option('-e, --example', 'description'), 'Option');
+});
+
+test('Argument', () => {
+  checkClass(new Argument('<foo>', 'description'), 'Argument');
+});
+
+test('Help', () => {
+  checkClass(new Help(), 'Help');
+});
+
+test('CommanderError', () => {
+  checkClass(new CommanderError(1, 'code', 'failed'), 'CommanderError');
+});
+
+test('InvalidArgumentError', () => {
+  checkClass(new InvalidArgumentError('failed'), 'InvalidArgumentError');
+});
+
+test('InvalidOptionArgumentError', () => { // Deprecated
+  checkClass(new InvalidOptionArgumentError('failed'), 'InvalidArgumentError');
+});
+
+test('createCommand', () => {
+  checkClass(createCommand('foo'), 'Command');
+});
+
+test('createOption', () => {
+  checkClass(createOption('-e, --example', 'description'), 'Option');
+});
+
+test('createArgument', () => {
+  checkClass(createArgument('<foo>', 'description'), 'Argument');
 });

--- a/tests/ts-imports.test.ts
+++ b/tests/ts-imports.test.ts
@@ -1,7 +1,5 @@
 import { program, Command, Option, CommanderError, InvalidArgumentError, InvalidOptionArgumentError, Help, createCommand } from '../';
 
-import * as commander from '../';
-
 // Do some simple checks that expected imports are available at runtime.
 // Similar tests to esm-imports-test.js
 
@@ -10,10 +8,6 @@ function checkClass(obj: object, name: string): void {
   expect(typeof obj).toEqual('object');
   expect(obj.constructor.name).toEqual(name);
 }
-
-test('legacy default export of global Command', () => {
-  checkClass(commander, 'Command');
-});
 
 test('program', () => {
   checkClass(program, 'Command');


### PR DESCRIPTION
# Pull Request

## Problem

We have been slowly moving towards removing the default export of global Command instance. Already removed from the README, removed from the TypeScript, and omitted from the esm interface.

Recently observed some problems due to the legacy export: #2013 #2014

Deprecation: https://github.com/tj/commander.js/blob/4ef19faac1564743d8c7e3ce89ef8d190e1551b4/docs/deprecated.md?plain=1#L41-L60

Issue: #2016

## Solution

Remove from the CommonJS exports too!

## ChangeLog

- Removed: _breaking_: removed default export of a global Command instance from CommonJS (use the named `program` export instead)