### PR TITLE
Add more Option and Argument properties to typings

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -50,6 +50,9 @@ export class Argument {
   description: string;
   required: boolean;
   variadic: boolean;
+  defaultValue?: any;
+  defaultValueDescription?: string;
+  argChoices?: string[];
 
   /**
    * Initialize a new command argument with the given name and description.
@@ -102,6 +105,8 @@ export class Option {
   negate: boolean;
   defaultValue?: any;
   defaultValueDescription?: string;
+  presetArg?: unknown;
+  envVar?: string;
   parseArg?: <T>(value: string, previous: T) => T;
   hidden: boolean;
   argChoices?: string[];

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -398,9 +398,25 @@ expectType<string>(helper.wrap('a b c', 50, 3));
 
 expectType<string>(helper.formatHelp(helperCommand, helper));
 
-// Option methods
-
+// Option properties
 const baseOption = new commander.Option('-f,--foo', 'foo description');
+expectType<string>(baseOption.flags);
+expectType<string>(baseOption.description);
+expectType<boolean>(baseOption.required);
+expectType<boolean>(baseOption.optional);
+expectType<boolean>(baseOption.variadic);
+expectType<boolean>(baseOption.mandatory);
+expectType<string | undefined>(baseOption.short);
+expectType<string | undefined>(baseOption.long);
+expectType<boolean>(baseOption.negate);
+expectType<any>(baseOption.defaultValue);
+expectType<string | undefined>(baseOption.defaultValueDescription);
+expectType<unknown>(baseOption.presetArg);
+expectType<string | undefined>(baseOption.envVar);
+expectType<boolean>(baseOption.hidden);
+expectType<string[] | undefined>(baseOption.argChoices);
+
+// Option methods
 
 // default
 expectType<commander.Option>(baseOption.default(3));
@@ -454,6 +470,9 @@ const baseArgument = new commander.Argument('<foo');
 expectType<string>(baseArgument.description);
 expectType<boolean>(baseArgument.required);
 expectType<boolean>(baseArgument.variadic);
+expectType<any>(baseArgument.defaultValue);
+expectType<string | undefined>(baseArgument.defaultValueDescription);
+expectType<string[] | undefined>(baseArgument.argChoices);
 
 // Argument methods
 


### PR DESCRIPTION
# Pull Request

## Problem

Not all of the Option and Argument properties are covered in the typings. I have mixed feeling about covering everything since most people don't need them and they appear in the editor completion suggestions, but appropriate to add things that people ask for or might need, and make Option and Argument symmetrical.

See: #1972

## Solution

Added a few more properties, and typing tests.
