### PR TITLE
Exit with non-zero code when subprocess terminated by signal

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -1067,15 +1067,15 @@ Expecting one of '${allowedValues.join("', '")}'`);
     }
 
     // By default terminate process when spawned process terminates.
-    // Suppressing the exit if exitCallback defined is a bit messy and of limited use, but does allow process to stay running!
     const exitCallback = this._exitCallback;
-    if (!exitCallback) {
-      proc.on('close', process.exit.bind(process));
-    } else {
-      proc.on('close', () => {
-        exitCallback(new CommanderError(process.exitCode || 0, 'commander.executeSubCommandAsync', '(close)'));
-      });
-    }
+    proc.on('close', (code, _signal) => {
+      code = code ?? 1; // code is null if spawned process terminated due to a signal
+      if (!exitCallback) {
+        process.exit(code);
+      } else {
+        exitCallback(new CommanderError(code, 'commander.executeSubCommandAsync', '(close)'));
+      }
+    });
     proc.on('error', (err) => {
       // @ts-ignore
       if (err.code === 'ENOENT') {

--- a/tests/command.executableSubcommand.signals.test.js
+++ b/tests/command.executableSubcommand.signals.test.js
@@ -37,10 +37,10 @@ describeOrSkipOnWindows('signals', () => {
     const { status } = childProcess.spawnSync(pmPath, ['exit-override', 'terminate'], {});
     expect(status).toBeGreaterThan(0);
   });
-});
 
-// Not a signal test, but closely related code so adding here.
-test('when command has exitOverride and executable subcommand fails then program exit code is subcommand exit code', () => {
-  const { status } = childProcess.spawnSync(pmPath, ['exit-override', 'fail'], {});
-  expect(status).toEqual(42);
+  // Not a signal test, but closely related code so adding here.
+  test('when command has exitOverride and executable subcommand fails then program exit code is subcommand exit code', () => {
+    const { status } = childProcess.spawnSync(pmPath, ['exit-override', 'fail'], {});
+    expect(status).toEqual(42);
+  });
 });

--- a/tests/command.executableSubcommand.signals.test.js
+++ b/tests/command.executableSubcommand.signals.test.js
@@ -1,39 +1,46 @@
 const childProcess = require('child_process');
 const path = require('path');
 
-// Test that a signal sent to the parent process is received by the executable subcommand process (which is listening).
+const pmPath = path.join(__dirname, './fixtures/pm');
 
-// Disabling tests on Windows as:
+// Disabling some tests on Windows as:
 // "Windows does not support sending signals"
 //  https://nodejs.org/api/process.html#process_signal_events
 const describeOrSkipOnWindows = (process.platform === 'win32') ? describe.skip : describe;
 
-// Note: the previous (sinon) test had custom code for SIGUSR1, revisit if required:
-//    As described at https://nodejs.org/api/process.html#process_signal_events
-//    this signal will start a debugger and thus the process might output an
-//    additional error message:
-//      "Failed to open socket on port 5858, waiting 1000 ms before retrying".
+describeOrSkipOnWindows('signals', () => {
+  test.each(['SIGINT', 'SIGHUP', 'SIGTERM', 'SIGUSR1', 'SIGUSR2'])('when program sent %s then executableSubcommand sent signal too', (signal, done) => {
+    // Spawn program. The listen subcommand waits for a signal and writes the name of the signal to stdout.
+    const proc = childProcess.spawn(pmPath, ['listen'], {});
 
-describeOrSkipOnWindows.each([['SIGINT'], ['SIGHUP'], ['SIGTERM'], ['SIGUSR1'], ['SIGUSR2']])(
-  'test signal handling in executableSubcommand', (value) => {
-    // Slightly tricky test, stick with callback and disable lint warning.
-    // eslint-disable-next-line jest/no-done-callback
-    test(`when command killed with ${value} then executableSubcommand receives ${value}`, (done) => {
-      const pmPath = path.join(__dirname, './fixtures/pm');
-
-      // The child process writes to stdout.
-      const proc = childProcess.spawn(pmPath, ['listen'], {});
-
-      let processOutput = '';
-      proc.stdout.on('data', (data) => {
-        if (processOutput.length === 0) {
-          proc.kill(`${value}`);
-        }
-        processOutput += data.toString();
-      });
-      proc.on('close', (code) => {
-        expect(processOutput).toBe(`Listening for signal...${value}`);
-        done();
-      });
+    let processOutput = '';
+    proc.stdout.on('data', (data) => {
+      if (processOutput.length === 0) {
+        // Send signal to program.
+        proc.kill(`${signal}`);
+      }
+      processOutput += data.toString();
+    });
+    proc.on('close', (code) => {
+      // Check the child subcommand received the signal too.
+      expect(processOutput).toBe(`Listening for signal...${signal}`);
+      done();
     });
   });
+
+  test('when executable subcommand sent signal then program exit code is non-zero', () => {
+    const { status } = childProcess.spawnSync(pmPath, ['terminate'], {});
+    expect(status).not.toEqual(0);
+  });
+
+  test('when command has exitOverride and executable subcommand sent signal then exit code is non-zero', () => {
+    const { status } = childProcess.spawnSync(pmPath, ['exit-override', 'terminate'], {});
+    expect(status).not.toEqual(0);
+  });
+});
+
+// // Not a signal test, but closely related code so adding here.
+test('when command has exitOverride and executable subcommand fails then program exit code is subcommand exit code', () => {
+  const { status } = childProcess.spawnSync(pmPath, ['exit-override', 'fail'], {});
+  expect(status).toEqual(42);
+});

--- a/tests/command.executableSubcommand.signals.test.js
+++ b/tests/command.executableSubcommand.signals.test.js
@@ -30,17 +30,17 @@ describeOrSkipOnWindows('signals', () => {
 
   test('when executable subcommand sent signal then program exit code is non-zero', () => {
     const { status } = childProcess.spawnSync(pmPath, ['terminate'], {});
-    expect(status).not.toEqual(0);
+    expect(status).toBeGreaterThan(0);
   });
 
   test('when command has exitOverride and executable subcommand sent signal then exit code is non-zero', () => {
     const { status } = childProcess.spawnSync(pmPath, ['exit-override', 'terminate'], {});
-    expect(status).not.toEqual(0);
+    expect(status).toBeGreaterThan(0);
   });
-});
 
-// // Not a signal test, but closely related code so adding here.
-test('when command has exitOverride and executable subcommand fails then program exit code is subcommand exit code', () => {
-  const { status } = childProcess.spawnSync(pmPath, ['exit-override', 'fail'], {});
-  expect(status).toEqual(42);
+  // Not a signal test, but closely related code so adding here.
+  test('when command has exitOverride and executable subcommand fails then program exit code is subcommand exit code', () => {
+    const { status } = childProcess.spawnSync(pmPath, ['exit-override', 'fail'], {});
+    expect(status).toEqual(42);
+  });
 });

--- a/tests/command.executableSubcommand.signals.test.js
+++ b/tests/command.executableSubcommand.signals.test.js
@@ -1,7 +1,7 @@
 const childProcess = require('child_process');
 const path = require('path');
 
-const pmPath = path.join(__dirname, './fixtures/pm');
+const pmPath = path.join(__dirname, 'fixtures', 'pm');
 
 // Disabling some tests on Windows as:
 // "Windows does not support sending signals"
@@ -37,10 +37,10 @@ describeOrSkipOnWindows('signals', () => {
     const { status } = childProcess.spawnSync(pmPath, ['exit-override', 'terminate'], {});
     expect(status).toBeGreaterThan(0);
   });
+});
 
-  // Not a signal test, but closely related code so adding here.
-  test('when command has exitOverride and executable subcommand fails then program exit code is subcommand exit code', () => {
-    const { status } = childProcess.spawnSync(pmPath, ['exit-override', 'fail'], {});
-    expect(status).toEqual(42);
-  });
+// Not a signal test, but closely related code so adding here.
+test('when command has exitOverride and executable subcommand fails then program exit code is subcommand exit code', () => {
+  const { status } = childProcess.spawnSync(pmPath, ['exit-override', 'fail'], {});
+  expect(status).toEqual(42);
 });

--- a/tests/fixtures/pm
+++ b/tests/fixtures/pm
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
-var { program } = require('../../');
+const path = require('node:path');
+const { program } = require('../../');
 
 program
   .version('0.0.1')
@@ -15,4 +16,14 @@ program
   .command('specifyInstall', 'specify install subcommand', { executableFile: 'pm-install' })
   .command('specifyPublish', 'specify publish subcommand', { executableFile: 'pm-publish' })
   .command('silent', 'silently succeed')
+  .command('fail', 'exit with non-zero status code')
+  .command('terminate', 'terminate due to signal');
+
+program
+  .command('exit-override')
+  .exitOverride((err) => { process.exit(err.exitCode); })
+  .command('fail', 'exit with non-zero status code', { executableFile: path.join(__dirname, 'pm-fail.js') })
+  .command('terminate', 'terminate due to signal', { executableFile: path.join(__dirname, 'pm-terminate.js') });
+
+program
   .parse(process.argv);

--- a/tests/fixtures/pm-fail.js
+++ b/tests/fixtures/pm-fail.js
@@ -1,0 +1,1 @@
+process.exit(42);

--- a/tests/fixtures/pm-terminate.js
+++ b/tests/fixtures/pm-terminate.js
@@ -1,0 +1,1 @@
+process.kill(process.pid, 'SIGINT');


### PR DESCRIPTION
# Pull Request

## Problem

There are a couple of problems with the `'close'` event handler from spawned executable subcommand:
- exit code is effectively zero if subprocess terminated due to a signal
- exit code passed to exit override is (probably) always zero

See #2021

## Solution

Use the event `code`argument, or `1` if code is `null` because of a signal. 

Why `1` for signal? The exit code seen in the shell when a process terminates due to a signal is often the signal number plus an offset, like 128+n in bash. We don't have a good way of mapping a signal name to a signal number, and don't have a way of returning the right offset for the current shell through `process.exit()`. Using `kill` to terminate main process with the same signal as subprocess feels a bit heavy handed and dubious. So going for exit code of `1` as simple and an incremental improvement from existing code.

Targeting a major version as changing years old behaviour, although I think it is effectively a bug fix.

## ChangeLog

- fix: use non-zero exit code when spawned executable subcommand terminates due to a signal
