### PR TITLE
Update CHANGELOG for 11.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1190,6 +1190,7 @@ program
 [#1896]: https://github.com/tj/commander.js/pull/1896
 [#1930]: https://github.com/tj/commander.js/pull/1930
 [#1965]: https://github.com/tj/commander.js/pull/1965
+[#1969]: https://github.com/tj/commander.js/pull/1969
 [#1982]: https://github.com/tj/commander.js/pull/1982
 [#1983]: https://github.com/tj/commander.js/pull/1983
 [#2010]: https://github.com/tj/commander.js/pull/2010

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - TypeScript: update `OptionValueSource` to allow any string, to match supported use of custom sources ([#1983])
 - TypeScript: add that `Command.version()` can also be used as getter ([#1982])
-- TypeScript: add null return type to `Commands.executableDir()`, when not configured ([#1965])
+- TypeScript: add null return type to `Commands.executableDir()`, for when not configured ([#1965])
 - subcommands with an executable handler and only a short help flag are now handled correctly by the parent's help command ([#1930])
 
 ### Added
@@ -22,7 +22,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `registeredArguments` property on `Command` with the array of defined `Argument` (like `Command.options` for `Option`) ([#2010])
 - TypeScript declarations for Option properties: `envVar`, `presetArg` ([#2019])
 - TypeScript declarations for Argument properties: `argChoices`, `defaultValue`, `defaultValueDescription` ([#2019])
-- example file which shows how to use custom usage in the list of subcommands ([#1896])
+- example file which shows how to configure help to display any custom usage in the list of subcommands ([#1896])
+
+### Changed
+
+- (developer) refactor TypeScript configs for multiple use-cases, and enable checks in JavaScript files in supporting editors ([#1969])
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 <!-- markdownlint-disable MD024 -->
 <!-- markdownlint-disable MD004 -->
 
+## [11.1.0] (2023-10-??)
+
+### Fixed
+
+- TypeScript: update `OptionValueSource` to allow any string, to match supported use of custom sources ([#1983])
+- TypeScript: add that `Command.version()` can also be used as getter ([#1982])
+- TypeScript: add null return type to `Commands.executableDir()`, when not configured ([#1965])
+- subcommands with an executable handler and only a short help flag are now handled correctly by the parent's help command ([#1930])
+
+### Added
+
+- `registeredArguments` property on `Command` with the array of defined `Argument` (like `Command.options` for `Option`) ([#2010])
+- TypeScript declarations for Option properties: `envVar`, `presetArg` ([#2019])
+- TypeScript declarations for Argument properties: `argChoices`, `defaultValue`, `defaultValueDescription` ([#2019])
+- example file which shows how to use custom usage in the list of subcommands ([#1896])
+
+### Deprecated
+
+- `Command._args` was private anyway, but now available as `registeredArguments` ([#2010])
+
 ## [11.0.0] (2023-06-16)
 
 ### Fixed
@@ -1163,6 +1183,13 @@ program
 [#1864]: https://github.com/tj/commander.js/pull/1864
 [#1874]: https://github.com/tj/commander.js/pull/1874
 [#1886]: https://github.com/tj/commander.js/pull/1886
+[#1896]: https://github.com/tj/commander.js/pull/1896
+[#1930]: https://github.com/tj/commander.js/pull/1930
+[#1965]: https://github.com/tj/commander.js/pull/1965
+[#1982]: https://github.com/tj/commander.js/pull/1982
+[#1983]: https://github.com/tj/commander.js/pull/1983
+[#2010]: https://github.com/tj/commander.js/pull/2010
+[#2019]: https://github.com/tj/commander.js/pull/2019
 
 <!-- Referenced in 5.x -->
 [#1]: https://github.com/tj/commander.js/issues/1
@@ -1242,6 +1269,7 @@ program
 [#1028]: https://github.com/tj/commander.js/pull/1028
 
 [Unreleased]: https://github.com/tj/commander.js/compare/master...develop
+[11.1.0]: https://github.com/tj/commander.js/compare/v11.0.0...v11.1.0
 [11.0.0]: https://github.com/tj/commander.js/compare/v10.0.1...v11.0.0
 [10.0.1]: https://github.com/tj/commander.js/compare/v10.0.0...v10.0.1
 [10.0.0]: https://github.com/tj/commander.js/compare/v9.5.0...v10.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 <!-- markdownlint-disable MD024 -->
 <!-- markdownlint-disable MD004 -->
 
-## [11.1.0] (2023-10-??)
+## [11.1.0] (2023-10-13)
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commander",
-  "version": "11.0.0",
+  "version": "11.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "commander",
-      "version": "11.0.0",
+      "version": "11.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commander",
-  "version": "11.0.0",
+  "version": "11.1.0",
   "description": "the complete solution for node.js command-line programs",
   "keywords": [
     "commander",


### PR DESCRIPTION
Preparing for a minor release. I have gone through the Pending Release label, and taken a look at branch difference too.

I usually update the version number too in PR, but would it be more convenient if I leave that for you at release time @abetomo so you can use (say) `npm version minor` and get the tagging done at the same time?

I noticed #1928 introduces a throw, so I think it would be better in a major version. I'll remove it from `develop` branch and add it to `release/12.x`. (#2026)