### PR TITLE
Drop Node.js 16

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/Readme.md
+++ b/Readme.md
@@ -1136,7 +1136,7 @@ There is more information available about:
 
 ## Support
 
-The current version of Commander is fully supported on Long Term Support versions of Node.js, and requires at least v16.
+The current version of Commander is fully supported on Long Term Support versions of Node.js, and requires at least v18.
 (For older versions of Node.js, use an older version of Commander.)
 
 The main forum for free and community support is the project [Issues](https://github.com/tj/commander.js/issues) on GitHub.

--- a/Readme_zh-CN.md
+++ b/Readme_zh-CN.md
@@ -1059,7 +1059,7 @@ program
 
 ## 支持
 
-当前版本的 Commander 在 LTS 版本的 Node.js 上完全支持。并且至少需要 v16。
+当前版本的 Commander 在 LTS 版本的 Node.js 上完全支持。并且至少需要 v18。
 （使用更低版本 Node.js 的用户建议安装更低版本的 Commander）
 
 社区支持请访问项目的 [Issues](https://github.com/tj/commander.js/issues)。

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "types": "typings/index.d.ts",
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "support": true
 }


### PR DESCRIPTION
# Pull Request

## Problem

Long Term Support for Node.js 16 has finished.

## Solution

Bump engine and drop support for Node.js 16 in the next major release.

## ChangeLog

- *Breaking:* Commander 12 requires Node.js v18 or higher
