### PR TITLE
Restore extra sanity check when enabling storeOptionsAsProperties

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -761,9 +761,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
     if (this.options.length) {
       throw new Error('call .storeOptionsAsProperties() before adding options');
     }
-    // if (Object.keys(this._optionValues).length) {
-    //   throw new Error('call .storeOptionsAsProperties() before setting option values');
-    // }
+    if (Object.keys(this._optionValues).length) {
+      throw new Error('call .storeOptionsAsProperties() before setting option values');
+    }
     this._storeOptionsAsProperties = !!storeAsProperties;
     return this;
   }

--- a/tests/commander.configureCommand.test.js
+++ b/tests/commander.configureCommand.test.js
@@ -85,10 +85,10 @@ test('when storeOptionsAsProperties() after adding option then throw', () => {
   }).toThrow();
 });
 
-// test('when storeOptionsAsProperties() after setting option value then throw', () => {
-//   const program = new commander.Command();
-//   program.setOptionValue('foo', 'bar');
-//   expect(() => {
-//     program.storeOptionsAsProperties();
-//   }).toThrow();
-// });
+test('when storeOptionsAsProperties() after setting option value then throw', () => {
+  const program = new commander.Command();
+  program.setOptionValue('foo', 'bar');
+  expect(() => {
+    program.storeOptionsAsProperties();
+  }).toThrow();
+});


### PR DESCRIPTION
This is just enabling #1928 again, to land in a major version release.