### PR TITLE
Add explicit note to only call parse once

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -967,6 +967,8 @@ program.parse(); // Implicit, and auto-detect electron
 program.parse(['-f', 'filename'], { from: 'user' });
 ```
 
+If you want to parse multiple times, create a new program each time. Calling parse does not clear out any previous state.
+
 ### Parsing Configuration
 
 If the default parsing does not suit your needs, there are some behaviours to support other usage patterns.


### PR DESCRIPTION
# Pull Request

## Problem

Commander does not reset state when `.parse()` is called. I don't consider this as a bug as starting afresh with a new program/Command is simple and robust. But we haven't explicitly stated this is the expected model.

See: #438 #1565 #1819 #1829 #1916

## Solution

Add a note to README. Will still catch some people out, but at least it is documented!