### PR TITLE
Throw error when add option with clashing flags

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -548,8 +548,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
     const matchingOption = (option.short && this._findOption(option.short)) ||
       (option.long && this._findOption(option.long));
     if (matchingOption) {
-      throw new Error(`Cannot add option '${option.flags}'${this._name && ` to command '${this._name}'`} since an option using same flag has already been added
-- conflicts with option '${matchingOption.flags}'`);
+      const matchingFlag = (option.long && this._findOption(option.long)) ? option.long : option.short;
+      throw new Error(`Cannot add option '${option.flags}'${this._name && ` to command '${this._name}'`} due to conflicting flag '${matchingFlag}'
+-  already used by option '${matchingOption.flags}'`);
     }
     this.options.push(option);
   }

--- a/tests/options.registerClash.test.js
+++ b/tests/options.registerClash.test.js
@@ -18,6 +18,24 @@ describe('.option()', () => {
         .option('-H, --cheese');
     }).toThrow('Cannot add option');
   });
+
+  test('when use help options separately then does not throw', () => {
+    expect(() => {
+      const program = new Command();
+      program
+        .option('-h, --help', 'display help');
+    }).not.toThrow();
+  });
+
+  test('when reuse flags in subcommand then does not throw', () => {
+    expect(() => {
+      const program = new Command();
+      program
+        .option('e, --example');
+      program.command('sub')
+        .option('e, --example');
+    }).not.toThrow();
+  });
 });
 
 describe('.addOption()', () => {

--- a/tests/options.registerClash.test.js
+++ b/tests/options.registerClash.test.js
@@ -1,0 +1,41 @@
+const { Command, Option } = require('../');
+
+describe('.option()', () => {
+  test('when short option flag conflicts then throws', () => {
+    expect(() => {
+      const program = new Command();
+      program
+        .option('-c, --cheese <type>', 'cheese type')
+        .option('-c, --conflict');
+    }).toThrow('Cannot add option');
+  });
+
+  test('when long option flag conflicts then throws', () => {
+    expect(() => {
+      const program = new Command();
+      program
+        .option('-c, --cheese <type>', 'cheese type')
+        .option('-H, --cheese');
+    }).toThrow('Cannot add option');
+  });
+});
+
+describe('.addOption()', () => {
+  test('when short option flags conflicts then throws', () => {
+    expect(() => {
+      const program = new Command();
+      program
+        .option('-c, --cheese <type>', 'cheese type')
+        .addOption(new Option('-c, --conflict'));
+    }).toThrow('Cannot add option');
+  });
+
+  test('when long option flags conflicts then throws', () => {
+    expect(() => {
+      const program = new Command();
+      program
+        .option('-c, --cheese <type>', 'cheese type')
+        .addOption(new Option('-H, --cheese'));
+    }).toThrow('Cannot add option');
+  });
+});


### PR DESCRIPTION
# Pull Request

## Problem

There are no warnings/errors for adding options with overlapping flags.

One of the "more usage errors" suggestion in a poll: https://github.com/tj/commander.js/issues/1978#issuecomment-1689391455

## Solution

Throw an error from `.option()` or `.addOption()` if there are clashing flags.

This is building on #1923, and adds tests.

Example:
```console
% node index.mjs
/Users/john/Documents/Sandpits/commander/my-fork/lib/command.js:552
      throw new Error(`Cannot add option '${option.flags}'${this._name && ` to command '${this._name}'`} due to conflicting flag '${matchingFlag}'
            ^

Error: Cannot add option '-e, --erase' to command 'main' due to conflicting flag '-e'
-  already used by option '-e, --example'
...
```

## ChangeLog

- _Breaking_: throw an error if add an option with flags which are already in use

