### PR TITLE
Remove Readme.md from bundle

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,7 @@
 # Commander.js
 
 [![Build Status](https://github.com/tj/commander.js/workflows/build/badge.svg)](https://github.com/tj/commander.js/actions?query=workflow%3A%22build%22)
-[![NPM Version](http://img.shields.io/npm/v/commander.svg?style=flat)](https://www.npmjs.org/package/commander)
+[![NPM Version](https://img.shields.io/npm/v/commander.svg?style=flat)](https://www.npmjs.org/package/commander)
 [![NPM Downloads](https://img.shields.io/npm/dm/commander.svg?style=flat)](https://npmcharts.com/compare/commander?minimal=true)
 [![Install Size](https://packagephobia.now.sh/badge?p=commander)](https://packagephobia.now.sh/result?p=commander)
 

--- a/Readme_npm.md
+++ b/Readme_npm.md
@@ -1,0 +1,7 @@
+# Commander.js
+
+The complete solution for [node.js](http://nodejs.org) command-line interfaces.
+
+...
+
+Read more on [Github](https://github.com/tj/commander.js).

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "test-esm": "node ./tests/esm-imports-test.mjs",
     "typecheck-ts": "tsd && tsc -p tsconfig.ts.json",
     "typecheck-js": "tsc -p tsconfig.js.json",
-    "test-all": "npm run test && npm run lint && npm run typecheck-js && npm run test-esm"
+    "test-all": "npm run test && npm run lint && npm run typecheck-js && npm run test-esm",
+    "prepack": "node -p 'require(`fs`).renameSync(`./Readme.md`, `./_Readme.md`)'",
+    "postpack": "node -p 'require(`fs`).renameSync(`./_Readme.md`, `./Readme.md`)'"
   },
   "files": [
     "index.js",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "typecheck-ts": "tsd && tsc -p tsconfig.ts.json",
     "typecheck-js": "tsc -p tsconfig.js.json",
     "test-all": "npm run test && npm run lint && npm run typecheck-js && npm run test-esm",
-    "prepack": "node -p 'require(`fs`).renameSync(`./Readme.md`, `./_Readme.md`)'",
-    "postpack": "node -p 'require(`fs`).renameSync(`./_Readme.md`, `./Readme.md`)'"
+    "prepack": "node -p 'var fs = require(`fs`); fs.renameSync(`./Readme.md`, `./_Readme.md`); fs.renameSync(`./Readme_npm.md`, `./Readme.md`)'",
+    "postpack": "node -p 'var fs = require(`fs`); fs.renameSync(`./Readme.md`, `./Readme_npm.md`); fs.renameSync(`./_Readme.md`, `./Readme.md`);'"
   },
   "files": [
     "index.js",


### PR DESCRIPTION
Closes #2056 

This change can save 25% of the bundle size, from 177kb to 134,8kb (45.8kb to 33.1 gzip), saving up to ~1,3TB/week (108,256,856 * 12.7 kB / 1024/ 1024) of bandwidth.