### PR TITLE
Refactor help command implementation to hold actual Command

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -906,7 +906,7 @@ program
 
 ### .helpCommand()
 
-A help command is added by default if your command has subcommands. You can explicitly turn on or off the implicit help command with `.addHelpCommand(true)` and `.addHelpCommand(false)`.
+A help command is added by default if your command has subcommands. You can explicitly turn on or off the implicit help command with `.helpCommand(true)` and `.helpCommand(false)`.
 
 You can both turn on and customise the help command by supplying the name and description:
 

--- a/Readme.md
+++ b/Readme.md
@@ -37,7 +37,7 @@ Read this in other languages: English | [简体中文](./Readme_zh-CN.md)
     - [.usage](#usage)
     - [.description and .summary](#description-and-summary)
     - [.helpOption(flags, description)](#helpoptionflags-description)
-    - [.addHelpCommand()](#addhelpcommand)
+    - [.helpCommand()](#helpcommand)
     - [More configuration](#more-configuration-2)
   - [Custom event listeners](#custom-event-listeners)
   - [Bits and pieces](#bits-and-pieces)
@@ -904,15 +904,17 @@ program
   .helpOption('-e, --HELP', 'read more information');
 ```
 
-### .addHelpCommand()
+### .helpCommand()
 
-A help command is added by default if your command has subcommands. You can explicitly turn on or off the implicit help command with `.addHelpCommand()` and `.addHelpCommand(false)`.
+A help command is added by default if your command has subcommands. You can explicitly turn on or off the implicit help command with `.addHelpCommand(true)` and `.addHelpCommand(false)`.
 
 You can both turn on and customise the help command by supplying the name and description:
 
 ```js
-program.addHelpCommand('assist [command]', 'show assistance');
+program.helpCommand('assist [command]', 'show assistance');
 ```
+
+(Or use `.addHelpCommand()` to add a command you construct yourself.)
 
 ### More configuration
 

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -16,6 +16,7 @@ They are currently still available for backwards compatibility, but should not b
   - [Short option flag longer than a single character](#short-option-flag-longer-than-a-single-character)
   - [Import from `commander/esm.mjs`](#import-from-commanderesmmjs)
   - [cmd.\_args](#cmd_args)
+  - [.addHelpCommand(string|boolean|undefined)](#addhelpcommandstringbooleanundefined)
 
 ## RegExp .option() parameter
 
@@ -224,3 +225,25 @@ const registeredArguments = program.registeredArguments;
 ```
 
 Deprecated from Commander v11.
+
+## .addHelpCommand(string|boolean|undefined)
+
+This was originally used with a variety of parameters, but not by passing a Command object despite the "add" name.
+
+```js
+program.addHelpCommand('HELP');
+program.addHelpCommand('HELP', 'SHOW HELP');
+program.addHelpCommand(false);
+
+```
+
+In new code you configure the
+help command with `.helpCommand()`. Or use the new-style `.addHelpCommand()` which takes a Command object, like `.addCommand()`.
+
+```js
+program.addHelpCommand(new Command('HELP'));
+
+program.helpCommand('HELP');
+program.helpCommand('HELP', 'SHOW HELP');
+program.helpCommand(false);
+```

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -237,13 +237,13 @@ program.addHelpCommand(false);
 
 ```
 
-In new code you configure the
-help command with `.helpCommand()`. Or use the new-style `.addHelpCommand()` which takes a Command object, like `.addCommand()`.
+In new code you configure the help command with `.helpCommand()`. Or use `.addHelpCommand()` which now takes a Command object, like `.addCommand()`.
 
 ```js
-program.addHelpCommand(new Command('HELP'));
-
-program.helpCommand('HELP');
-program.helpCommand('HELP', 'SHOW HELP');
+program.helpCommand('HELP [command]');
+program.helpCommand('HELP', 'show help');
 program.helpCommand(false);
+
+program.addHelpCommand(new Command('HELP').argument('[command]').description('show help'));
+
 ```

--- a/docs/deprecated.md
+++ b/docs/deprecated.md
@@ -211,8 +211,8 @@ Deprecated from Commander v11.
 This was originally used with a variety of parameters, but not by passing a Command object despite the "add" name.
 
 ```js
-program.addHelpCommand('HELP');
-program.addHelpCommand('HELP', 'SHOW HELP');
+program.addHelpCommand('assist  [command]');
+program.addHelpCommand('assist', 'show assistance');
 program.addHelpCommand(false);
 
 ```
@@ -220,11 +220,11 @@ program.addHelpCommand(false);
 In new code you configure the help command with `.helpCommand()`. Or use `.addHelpCommand()` which now takes a Command object, like `.addCommand()`.
 
 ```js
-program.helpCommand('HELP [command]');
-program.helpCommand('HELP', 'show help');
+program.helpCommand('assist [command]');
+program.helpCommand('assist', 'show assistance');
 program.helpCommand(false);
 
-program.addHelpCommand(new Command('HELP').argument('[command]').description('show help'));
+program.addHelpCommand(new Command('assist').argument('[command]').description('show assistance'));
 
 ```
 ## Removed

--- a/lib/command.js
+++ b/lib/command.js
@@ -72,9 +72,7 @@ class Command extends EventEmitter {
     this._helpShortFlag = '-h';
     this._helpLongFlag = '--help';
     this._addImplicitHelpCommand = undefined; // Deliberately undefined, not decided whether true or false
-    this._helpCommandName = 'help';
-    this._helpCommandnameAndArgs = 'help [command]';
-    this._helpCommandDescription = 'display help for command';
+    this._helpCommand = null;
     this._helpConfiguration = {};
   }
 
@@ -93,9 +91,7 @@ class Command extends EventEmitter {
     this._helpDescription = sourceCommand._helpDescription;
     this._helpShortFlag = sourceCommand._helpShortFlag;
     this._helpLongFlag = sourceCommand._helpLongFlag;
-    this._helpCommandName = sourceCommand._helpCommandName;
-    this._helpCommandnameAndArgs = sourceCommand._helpCommandnameAndArgs;
-    this._helpCommandDescription = sourceCommand._helpCommandDescription;
+    this._helpCommand = sourceCommand._helpCommand;
     this._helpConfiguration = sourceCommand._helpConfiguration;
     this._exitCallback = sourceCommand._exitCallback;
     this._storeOptionsAsProperties = sourceCommand._storeOptionsAsProperties;
@@ -367,26 +363,62 @@ class Command extends EventEmitter {
   }
 
   /**
-   * Override default decision whether to add implicit help command.
+   * Customise or override default help command.
    *
-   *    addHelpCommand() // force on
-   *    addHelpCommand(false); // force off
-   *    addHelpCommand('help [cmd]', 'display help for [cmd]'); // force on with custom details
+   *    helpCommand(true) // force on
+   *    helpCommand(false); // force off
+   *    helpCommand('help [cmd]', 'display help for [cmd]'); // force on with custom details
    *
    * @return {Command} `this` command for chaining
    */
 
-  addHelpCommand(enableOrNameAndArgs, description) {
+  helpCommand(enableOrNameAndArgs, description) {
+    if (enableOrNameAndArgs === undefined) {
+      // getter for help command
+      if (this._hasImplicitHelpCommand()) {
+        if (!this._helpCommand) this.helpCommand(true);
+        return this._helpCommand;
+      }
+      return null;
+    }
+
     if (enableOrNameAndArgs === false) {
       this._addImplicitHelpCommand = false;
-    } else {
-      this._addImplicitHelpCommand = true;
-      if (typeof enableOrNameAndArgs === 'string') {
-        this._helpCommandName = enableOrNameAndArgs.split(' ')[0];
-        this._helpCommandnameAndArgs = enableOrNameAndArgs;
-      }
-      this._helpCommandDescription = description || this._helpCommandDescription;
+      return this;
     }
+
+    this._addImplicitHelpCommand = true;
+    if (enableOrNameAndArgs === true && this._helpCommand) return this;
+
+    let helpName = 'help';
+    let helpArgs = '[command]';
+    const helpDescription = description || 'display help for command';
+    if (typeof enableOrNameAndArgs === 'string') {
+      const [, newName, newArgs] = enableOrNameAndArgs.match(/([^ ]+) *(.*)/);
+      helpName = newName;
+      helpArgs = newArgs;
+    }
+
+    const helpCommand = this.createCommand(helpName);
+    helpCommand.helpOption(false);
+    if (helpArgs) helpCommand.arguments(helpArgs);
+    if (helpDescription) helpCommand.description(helpDescription);
+    this._helpCommand = helpCommand;
+
+    if (enableOrNameAndArgs === undefined) return this._helpCommand;
+    return this;
+  }
+
+  addHelpCommand(helpCommand) {
+    // Call through to helpCommand for backwards compatibility and handling true/false.
+    // Originally expected true/false/undefined or text arguments.
+    if (helpCommand === undefined) return this.helpCommand(true);
+    if (typeof helpCommand !== 'object') {
+      return this.helpCommand(...arguments);
+    }
+
+    this._addImplicitHelpCommand = true;
+    this._helpCommand = helpCommand;
     return this;
   }
 
@@ -1263,7 +1295,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     if (operands && this._findCommand(operands[0])) {
       return this._dispatchSubcommand(operands[0], operands.slice(1), unknown);
     }
-    if (this._hasImplicitHelpCommand() && operands[0] === this._helpCommandName) {
+    if (this._hasImplicitHelpCommand() && operands[0] === this.helpCommand().name()) {
       return this._dispatchHelpCommand(operands[1]);
     }
     if (this._defaultCommandName) {
@@ -1520,7 +1552,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
           operands.push(arg);
           if (args.length > 0) unknown.push(...args);
           break;
-        } else if (arg === this._helpCommandName && this._hasImplicitHelpCommand()) {
+        } else if (this._hasImplicitHelpCommand() && arg === this.helpCommand().name()) {
           operands.push(arg);
           if (args.length > 0) operands.push(...args);
           break;

--- a/lib/command.js
+++ b/lib/command.js
@@ -365,15 +365,17 @@ class Command extends EventEmitter {
 
   /**
    * Customise or override default help command. By default a help command is automatically added if your command has subcommands.
-   * 
+   *
    * Please note: the API is deliberately similar to `.command()` so that a new command is returned if you pass the
    * command name alone. In all other cases, it returns `this` for chaining.
    *
-   *    program.helpCommand('help [cmd]'); // returns help command for further configuration (see next example)
-   *    program.helpCommand('help [cmd]').description('show help'); // change help command name and description
-   *    program.helpCommand('help [cmd]', 'show help'); // change help command name and description, returns program for chaining
-   *    program.helpCommand(false); // suppress default help command, returns program
-   *    program.helpCommand(true); // add help command even if no subcommands, returns program
+   *    // Returns new help command for configuration
+   *    program.helpCommand('help [cmd]');
+   *    program.helpCommand('help [cmd]').description('show help');
+   *    // Returns `this` for chaining.
+   *    program.helpCommand('help [cmd]', 'show help');
+   *    program.helpCommand(false); // suppress default help command
+   *    program.helpCommand(true); // add help command even if no subcommands
    *
    * @param {string|boolean} enableOrNameAndArgs - enable with custom name and/or arguments, or boolean to override whether added
    * @param {string} [description] - custom description
@@ -430,12 +432,13 @@ class Command extends EventEmitter {
    * @package
    */
   _getHelpCommand() {
-    let hasImplicitHelpCommand = this._addImplicitHelpCommand ?? 
+    const hasImplicitHelpCommand = this._addImplicitHelpCommand ??
       (this.commands.length && !this._actionHandler && !this._findCommand('help'));
-    
+
     if (hasImplicitHelpCommand) {
-      if (this._helpCommand === undefined) 
-        this.helpCommand(undefined, undefined);
+      if (this._helpCommand === undefined) {
+        this.helpCommand(undefined, undefined); // use default name and description
+      }
       return this._helpCommand;
     }
     return null;

--- a/lib/command.js
+++ b/lib/command.js
@@ -373,15 +373,6 @@ class Command extends EventEmitter {
    */
 
   helpCommand(enableOrNameAndArgs, description) {
-    if (enableOrNameAndArgs === undefined) {
-      // getter for help command
-      if (this._hasImplicitHelpCommand()) {
-        if (!this._helpCommand) this.helpCommand(true);
-        return this._helpCommand;
-      }
-      return null;
-    }
-
     if (enableOrNameAndArgs === false) {
       this._addImplicitHelpCommand = false;
       return this;
@@ -405,10 +396,12 @@ class Command extends EventEmitter {
     if (helpDescription) helpCommand.description(helpDescription);
     this._helpCommand = helpCommand;
 
-    if (enableOrNameAndArgs === undefined) return this._helpCommand;
     return this;
   }
 
+  /**
+   * @return {Command} `this` command for chaining
+   */
   addHelpCommand(helpCommand) {
     // Call through to helpCommand for backwards compatibility and handling true/false.
     // Originally expected true/false/undefined or text arguments.
@@ -420,6 +413,19 @@ class Command extends EventEmitter {
     this._addImplicitHelpCommand = true;
     this._helpCommand = helpCommand;
     return this;
+  }
+
+  /**
+   * Return implicit help command.
+   *
+   * @return {Command | null}
+   */
+  getHelpCommand() {
+    if (this._hasImplicitHelpCommand()) {
+      if (!this._helpCommand) this.helpCommand(true);
+      return this._helpCommand;
+    }
+    return null;
   }
 
   /**
@@ -1295,7 +1301,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     if (operands && this._findCommand(operands[0])) {
       return this._dispatchSubcommand(operands[0], operands.slice(1), unknown);
     }
-    if (this._hasImplicitHelpCommand() && operands[0] === this.helpCommand().name()) {
+    if (this._hasImplicitHelpCommand() && operands[0] === this.getHelpCommand().name()) {
       return this._dispatchHelpCommand(operands[1]);
     }
     if (this._defaultCommandName) {
@@ -1552,7 +1558,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
           operands.push(arg);
           if (args.length > 0) unknown.push(...args);
           break;
-        } else if (this._hasImplicitHelpCommand() && arg === this.helpCommand().name()) {
+        } else if (this._hasImplicitHelpCommand() && arg === this.getHelpCommand().name()) {
           operands.push(arg);
           if (args.length > 0) operands.push(...args);
           break;

--- a/lib/command.js
+++ b/lib/command.js
@@ -378,7 +378,7 @@ class Command extends EventEmitter {
 
   helpCommand(enableOrNameAndArgs, description) {
     if (typeof enableOrNameAndArgs === 'boolean') {
-      this._addImplicitHelpCommand = !!enableOrNameAndArgs;
+      this._addImplicitHelpCommand = enableOrNameAndArgs;
       return this;
     }
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -366,20 +366,14 @@ class Command extends EventEmitter {
   /**
    * Customise or override default help command. By default a help command is automatically added if your command has subcommands.
    *
-   * Please note: the API is deliberately similar to `.command()` so that a new command is returned if you pass the
-   * command name alone. In all other cases, it returns `this` for chaining.
-   *
-   *    // Returns new help command for configuration
    *    program.helpCommand('help [cmd]');
-   *    program.helpCommand('help [cmd]').description('show help');
-   *    // Returns `this` for chaining.
    *    program.helpCommand('help [cmd]', 'show help');
    *    program.helpCommand(false); // suppress default help command
    *    program.helpCommand(true); // add help command even if no subcommands
    *
    * @param {string|boolean} enableOrNameAndArgs - enable with custom name and/or arguments, or boolean to override whether added
    * @param {string} [description] - custom description
-   * @return {Command} `this` command for chaining, or the new help command if pass just the command name
+   * @return {Command} `this` command for chaining
    */
 
   helpCommand(enableOrNameAndArgs, description) {
@@ -400,9 +394,7 @@ class Command extends EventEmitter {
     this._addImplicitHelpCommand = true;
     this._helpCommand = helpCommand;
 
-    // Behave like `.command(name, desc)` and return new command unless given description.
-    if (description) return this;
-    return helpCommand;
+    return this;
   }
 
   /**

--- a/lib/command.js
+++ b/lib/command.js
@@ -71,8 +71,9 @@ class Command extends EventEmitter {
     this._helpDescription = 'display help for command';
     this._helpShortFlag = '-h';
     this._helpLongFlag = '--help';
-    this._addImplicitHelpCommand = undefined; // Deliberately undefined, not decided whether true or false
-    this._helpCommand = null;
+    this._addImplicitHelpCommand = undefined; // undecided whether true or false yet, not inherited
+    /** @type {Command} */
+    this._helpCommand = undefined; // lazy initialised, inherited
     this._helpConfiguration = {};
   }
 
@@ -363,51 +364,58 @@ class Command extends EventEmitter {
   }
 
   /**
-   * Customise or override default help command.
+   * Customise or override default help command. By default a help command is automatically added if your command has subcommands.
+   * 
+   * Please note: the API is deliberately similar to `.command()` so that a new command is returned if you pass the
+   * command name alone. In all other cases, it returns `this` for chaining.
    *
-   *    helpCommand(true) // force on
-   *    helpCommand(false); // force off
-   *    helpCommand('help [cmd]', 'display help for [cmd]'); // force on with custom details
+   *    program.helpCommand('help [cmd]'); // returns help command for further configuration (see next example)
+   *    program.helpCommand('help [cmd]').description('show help'); // change help command name and description
+   *    program.helpCommand('help [cmd]', 'show help'); // change help command name and description, returns program for chaining
+   *    program.helpCommand(false); // suppress default help command, returns program
+   *    program.helpCommand(true); // add help command even if no subcommands, returns program
    *
-   * @return {Command} `this` command for chaining
+   * @param {string|boolean} enableOrNameAndArgs - enable with custom name and/or arguments, or boolean to override whether added
+   * @param {string} [description] - custom description
+   * @return {Command} `this` command for chaining, or the new help command if pass just the command name
    */
 
   helpCommand(enableOrNameAndArgs, description) {
-    if (enableOrNameAndArgs === false) {
-      this._addImplicitHelpCommand = false;
+    if (typeof enableOrNameAndArgs === 'boolean') {
+      this._addImplicitHelpCommand = !!enableOrNameAndArgs;
       return this;
     }
 
-    this._addImplicitHelpCommand = true;
-    if (enableOrNameAndArgs === true && this._helpCommand) return this;
-
-    let helpName = 'help';
-    let helpArgs = '[command]';
-    const helpDescription = description || 'display help for command';
-    if (typeof enableOrNameAndArgs === 'string') {
-      const [, newName, newArgs] = enableOrNameAndArgs.match(/([^ ]+) *(.*)/);
-      helpName = newName;
-      helpArgs = newArgs;
-    }
+    enableOrNameAndArgs = enableOrNameAndArgs ?? 'help [command]';
+    const [, helpName, helpArgs] = enableOrNameAndArgs.match(/([^ ]+) *(.*)/);
+    const helpDescription = description ?? 'display help for command';
 
     const helpCommand = this.createCommand(helpName);
     helpCommand.helpOption(false);
     if (helpArgs) helpCommand.arguments(helpArgs);
     if (helpDescription) helpCommand.description(helpDescription);
+
+    this._addImplicitHelpCommand = true;
     this._helpCommand = helpCommand;
 
-    return this;
+    // Behave like `.command(name, desc)` and return new command unless given description.
+    if (description) return this;
+    return helpCommand;
   }
 
   /**
+   * Add prepared custom help command.
+   *
+   * @param {(Command|string|boolean)} helpCommand - custom help command, or deprecated enableOrNameAndArgs as for `.helpCommand()`
+   * @param {string} [deprecatedDescription] - deprecated custom description used with custom name only
    * @return {Command} `this` command for chaining
    */
-  addHelpCommand(helpCommand) {
-    // Call through to helpCommand for backwards compatibility and handling true/false.
-    // Originally expected true/false/undefined or text arguments.
-    if (helpCommand === undefined) return this.helpCommand(true);
+  addHelpCommand(helpCommand, deprecatedDescription) {
+    // If not passed an object, call through to helpCommand for backwards compatibility,
+    // as addHelpCommand was originally used like helpCommand is now.
     if (typeof helpCommand !== 'object') {
-      return this.helpCommand(...arguments);
+      this.helpCommand(helpCommand, deprecatedDescription);
+      return this;
     }
 
     this._addImplicitHelpCommand = true;
@@ -416,28 +424,21 @@ class Command extends EventEmitter {
   }
 
   /**
-   * Return implicit help command.
+   * Lazy create help command.
    *
-   * @return {Command | null}
+   * @return {(Command|null)}
+   * @package
    */
-  getHelpCommand() {
-    if (this._hasImplicitHelpCommand()) {
-      if (!this._helpCommand) this.helpCommand(true);
+  _getHelpCommand() {
+    let hasImplicitHelpCommand = this._addImplicitHelpCommand ?? 
+      (this.commands.length && !this._actionHandler && !this._findCommand('help'));
+    
+    if (hasImplicitHelpCommand) {
+      if (this._helpCommand === undefined) 
+        this.helpCommand(undefined, undefined);
       return this._helpCommand;
     }
     return null;
-  }
-
-  /**
-   * @return {boolean}
-   * @api private
-   */
-
-  _hasImplicitHelpCommand() {
-    if (this._addImplicitHelpCommand === undefined) {
-      return this.commands.length && !this._actionHandler && !this._findCommand('help');
-    }
-    return this._addImplicitHelpCommand;
   }
 
   /**
@@ -1301,7 +1302,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     if (operands && this._findCommand(operands[0])) {
       return this._dispatchSubcommand(operands[0], operands.slice(1), unknown);
     }
-    if (this._hasImplicitHelpCommand() && operands[0] === this.getHelpCommand().name()) {
+    if (this._getHelpCommand() && operands[0] === this._getHelpCommand().name()) {
       return this._dispatchHelpCommand(operands[1]);
     }
     if (this._defaultCommandName) {
@@ -1558,7 +1559,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
           operands.push(arg);
           if (args.length > 0) unknown.push(...args);
           break;
-        } else if (this._hasImplicitHelpCommand() && arg === this.getHelpCommand().name()) {
+        } else if (this._getHelpCommand() && arg === this._getHelpCommand().name()) {
           operands.push(arg);
           if (args.length > 0) operands.push(...args);
           break;

--- a/lib/help.js
+++ b/lib/help.js
@@ -27,13 +27,7 @@ class Help {
   visibleCommands(cmd) {
     const visibleCommands = cmd.commands.filter(cmd => !cmd._hidden);
     if (cmd._hasImplicitHelpCommand()) {
-      // Create a command matching the implicit help command.
-      const [, helpName, helpArgs] = cmd._helpCommandnameAndArgs.match(/([^ ]+) *(.*)/);
-      const helpCommand = cmd.createCommand(helpName)
-        .helpOption(false);
-      helpCommand.description(cmd._helpCommandDescription);
-      if (helpArgs) helpCommand.arguments(helpArgs);
-      visibleCommands.push(helpCommand);
+      visibleCommands.push(cmd.helpCommand());
     }
     if (this.sortSubcommands) {
       visibleCommands.sort((a, b) => {

--- a/lib/help.js
+++ b/lib/help.js
@@ -26,8 +26,9 @@ class Help {
 
   visibleCommands(cmd) {
     const visibleCommands = cmd.commands.filter(cmd => !cmd._hidden);
-    if (cmd._hasImplicitHelpCommand()) {
-      visibleCommands.push(cmd.getHelpCommand());
+    const helpCommand = cmd._getHelpCommand();
+    if (helpCommand && !helpCommand._hidden) {
+      visibleCommands.push(helpCommand);
     }
     if (this.sortSubcommands) {
       visibleCommands.sort((a, b) => {

--- a/lib/help.js
+++ b/lib/help.js
@@ -27,7 +27,7 @@ class Help {
   visibleCommands(cmd) {
     const visibleCommands = cmd.commands.filter(cmd => !cmd._hidden);
     if (cmd._hasImplicitHelpCommand()) {
-      visibleCommands.push(cmd.helpCommand());
+      visibleCommands.push(cmd.getHelpCommand());
     }
     if (this.sortSubcommands) {
       visibleCommands.sort((a, b) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1382,9 +1382,9 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "29.5.6",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.6.tgz",
-      "integrity": "sha512-/t9NnzkOpXb4Nfvg17ieHE6EeSjDS2SGSpNYfoLbUAeL/EOueU/RSdOWFpfQTXBEM7BguYW1XQ0EbM+6RlIh6w==",
+      "version": "29.5.7",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.7.tgz",
+      "integrity": "sha512-HLyetab6KVPSiF+7pFcUyMeLsx25LDNDemw9mGsJBkai/oouwrjTycocSDYopMEwFhN2Y4s9oPyOCZNofgSt2g==",
       "dev": true,
       "dependencies": {
         "expect": "^29.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1410,9 +1410,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.8.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.9.tgz",
-      "integrity": "sha512-UzykFsT3FhHb1h7yD4CA4YhBHq545JC0YnEz41xkipN88eKQtL6rSgocL5tbAP6Ola9Izm/Aw4Ora8He4x0BHg==",
+      "version": "20.8.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.10.tgz",
+      "integrity": "sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1410,9 +1410,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.8.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.10.tgz",
-      "integrity": "sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==",
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
+      "integrity": "sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1382,9 +1382,9 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "29.5.7",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.7.tgz",
-      "integrity": "sha512-HLyetab6KVPSiF+7pFcUyMeLsx25LDNDemw9mGsJBkai/oouwrjTycocSDYopMEwFhN2Y4s9oPyOCZNofgSt2g==",
+      "version": "29.5.8",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.8.tgz",
+      "integrity": "sha512-fXEFTxMV2Co8ZF5aYFJv+YeA08RTYJfhtN5c9JSv/mFEMe+xxjufCb+PHL+bJcMs/ebPUsBu+UNTEz+ydXrR6g==",
       "dev": true,
       "dependencies": {
         "expect": "^29.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -725,9 +725,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
-      "integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.3.tgz",
+      "integrity": "sha512-yZzuIG+jnVu6hNSzFEN07e8BxF3uAzYtQb6uDkaYZLo6oYZDCq454c5kB8zxnzfCYyP4MIuyBn10L0DqwujTmA==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -748,9 +748,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.52.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.52.0.tgz",
-      "integrity": "sha512-mjZVbpaeMZludF2fsWLD0Z9gCref1Tk4i9+wddjRvpUNqqcndPkBD09N/Mapey0b3jaXbLm2kICwFv2E64QinA==",
+      "version": "8.53.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.53.0.tgz",
+      "integrity": "sha512-Kn7K8dx/5U6+cT1yEhpX1w4PCSg0M+XyRILPgvwcEBjerFWCwQj5sbr3/VmxqV0JGHCBCzyd6LxypEuehypY1w==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1721,9 +1721,9 @@
       "dev": true
     },
     "node_modules/acorn": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
+      "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -2687,15 +2687,15 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.52.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.52.0.tgz",
-      "integrity": "sha512-zh/JHnaixqHZsolRB/w9/02akBk9EPrOs9JwcTP2ek7yL5bVvXuRariiaAjjoJ5DvuwQ1WAE/HsMz+w17YgBCg==",
+      "version": "8.53.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.53.0.tgz",
+      "integrity": "sha512-N4VuiPjXDUa4xVeV/GC/RV3hQW9Nw+Y463lkWaKKXKYMvmRiRDAtfpuPFLN+E1/6ZhyR8J2ig+eVREnYgUsiag==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.2",
-        "@eslint/js": "8.52.0",
+        "@eslint/eslintrc": "^2.1.3",
+        "@eslint/js": "8.53.0",
         "@humanwhocodes/config-array": "^0.11.13",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
@@ -5611,9 +5611,9 @@
       }
     },
     "node_modules/punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "engines": {
         "node": ">=6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2168,6 +2168,18 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "node_modules/builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/builtins": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
@@ -3084,9 +3096,9 @@
       }
     },
     "node_modules/eslint-plugin-n": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-16.2.0.tgz",
-      "integrity": "sha512-AQER2jEyQOt1LG6JkGJCCIFotzmlcCZFur2wdKrp1JX2cNotC7Ae0BcD/4lLv3lUAArM9uNS8z/fsvXTd0L71g==",
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-16.3.1.tgz",
+      "integrity": "sha512-w46eDIkxQ2FaTHcey7G40eD+FhTXOdKudDXPUO2n9WNcslze/i/HT2qJ3GXjHngYSGDISIgPNhwGtgoix4zeOw==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
@@ -3094,6 +3106,7 @@
         "eslint-plugin-es-x": "^7.1.0",
         "get-tsconfig": "^4.7.0",
         "ignore": "^5.2.4",
+        "is-builtin-module": "^3.2.1",
         "is-core-module": "^2.12.1",
         "minimatch": "^3.1.2",
         "resolve": "^1.22.2",
@@ -3943,6 +3956,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-builtin-module": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+      "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
+      "dev": true,
+      "dependencies": {
+        "builtin-modules": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-callable": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1487,15 +1487,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.9.0.tgz",
-      "integrity": "sha512-GZmjMh4AJ/5gaH4XF2eXA8tMnHWP+Pm1mjQR2QN4Iz+j/zO04b9TOvJYOX2sCNIQHtRStKTxRY1FX7LhpJT4Gw==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.9.1.tgz",
+      "integrity": "sha512-C7AK2wn43GSaCUZ9do6Ksgi2g3mwFkMO3Cis96kzmgudoVaKyt62yNzJOktP0HDLb/iO2O0n2lBOzJgr6Q/cyg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.9.0",
-        "@typescript-eslint/types": "6.9.0",
-        "@typescript-eslint/typescript-estree": "6.9.0",
-        "@typescript-eslint/visitor-keys": "6.9.0",
+        "@typescript-eslint/scope-manager": "6.9.1",
+        "@typescript-eslint/types": "6.9.1",
+        "@typescript-eslint/typescript-estree": "6.9.1",
+        "@typescript-eslint/visitor-keys": "6.9.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1515,13 +1515,13 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.9.0.tgz",
-      "integrity": "sha512-1R8A9Mc39n4pCCz9o79qRO31HGNDvC7UhPhv26TovDsWPBDx+Sg3rOZdCELIA3ZmNoWAuxaMOT7aWtGRSYkQxw==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.9.1.tgz",
+      "integrity": "sha512-38IxvKB6NAne3g/+MyXMs2Cda/Sz+CEpmm+KLGEM8hx/CvnSRuw51i8ukfwB/B/sESdeTGet1NH1Wj7I0YXswg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.9.0",
-        "@typescript-eslint/visitor-keys": "6.9.0"
+        "@typescript-eslint/types": "6.9.1",
+        "@typescript-eslint/visitor-keys": "6.9.1"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -1532,9 +1532,9 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.9.0.tgz",
-      "integrity": "sha512-+KB0lbkpxBkBSiVCuQvduqMJy+I1FyDbdwSpM3IoBS7APl4Bu15lStPjgBIdykdRqQNYqYNMa8Kuidax6phaEw==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.9.1.tgz",
+      "integrity": "sha512-BUGslGOb14zUHOUmDB2FfT6SI1CcZEJYfF3qFwBeUrU6srJfzANonwRYHDpLBuzbq3HaoF2XL2hcr01c8f8OaQ==",
       "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -1545,13 +1545,13 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.9.0.tgz",
-      "integrity": "sha512-NJM2BnJFZBEAbCfBP00zONKXvMqihZCrmwCaik0UhLr0vAgb6oguXxLX1k00oQyD+vZZ+CJn3kocvv2yxm4awQ==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.9.1.tgz",
+      "integrity": "sha512-U+mUylTHfcqeO7mLWVQ5W/tMLXqVpRv61wm9ZtfE5egz7gtnmqVIw9ryh0mgIlkKk9rZLY3UHygsBSdB9/ftyw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.9.0",
-        "@typescript-eslint/visitor-keys": "6.9.0",
+        "@typescript-eslint/types": "6.9.1",
+        "@typescript-eslint/visitor-keys": "6.9.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -1572,12 +1572,12 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.9.0.tgz",
-      "integrity": "sha512-dGtAfqjV6RFOtIP8I0B4ZTBRrlTT8NHHlZZSchQx3qReaoDeXhYM++M4So2AgFK9ZB0emRPA6JI1HkafzA2Ibg==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.9.1.tgz",
+      "integrity": "sha512-MUaPUe/QRLEffARsmNfmpghuQkW436DvESW+h+M52w0coICHRfD6Np9/K6PdACwnrq1HmuLl+cSPZaJmeVPkSw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.9.0",
+        "@typescript-eslint/types": "6.9.1",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1452,16 +1452,16 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.9.1.tgz",
-      "integrity": "sha512-w0tiiRc9I4S5XSXXrMHOWgHgxbrBn1Ro+PmiYhSg2ZVdxrAJtQgzU5o2m1BfP6UOn7Vxcc6152vFjQfmZR4xEg==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.10.0.tgz",
+      "integrity": "sha512-uoLj4g2OTL8rfUQVx2AFO1hp/zja1wABJq77P6IclQs6I/m9GLrm7jCdgzZkvWdDCQf1uEvoa8s8CupsgWQgVg==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.9.1",
-        "@typescript-eslint/type-utils": "6.9.1",
-        "@typescript-eslint/utils": "6.9.1",
-        "@typescript-eslint/visitor-keys": "6.9.1",
+        "@typescript-eslint/scope-manager": "6.10.0",
+        "@typescript-eslint/type-utils": "6.10.0",
+        "@typescript-eslint/utils": "6.10.0",
+        "@typescript-eslint/visitor-keys": "6.10.0",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -1589,13 +1589,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.9.1.tgz",
-      "integrity": "sha512-38IxvKB6NAne3g/+MyXMs2Cda/Sz+CEpmm+KLGEM8hx/CvnSRuw51i8ukfwB/B/sESdeTGet1NH1Wj7I0YXswg==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.10.0.tgz",
+      "integrity": "sha512-TN/plV7dzqqC2iPNf1KrxozDgZs53Gfgg5ZHyw8erd6jd5Ta/JIEcdCheXFt9b1NYb93a1wmIIVW/2gLkombDg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.9.1",
-        "@typescript-eslint/visitor-keys": "6.9.1"
+        "@typescript-eslint/types": "6.10.0",
+        "@typescript-eslint/visitor-keys": "6.10.0"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -1606,13 +1606,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.9.1.tgz",
-      "integrity": "sha512-eh2oHaUKCK58qIeYp19F5V5TbpM52680sB4zNSz29VBQPTWIlE/hCj5P5B1AChxECe/fmZlspAWFuRniep1Skg==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.10.0.tgz",
+      "integrity": "sha512-wYpPs3hgTFblMYwbYWPT3eZtaDOjbLyIYuqpwuLBBqhLiuvJ+9sEp2gNRJEtR5N/c9G1uTtQQL5AhV0fEPJYcg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.9.1",
-        "@typescript-eslint/utils": "6.9.1",
+        "@typescript-eslint/typescript-estree": "6.10.0",
+        "@typescript-eslint/utils": "6.10.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -1633,9 +1633,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.9.1.tgz",
-      "integrity": "sha512-BUGslGOb14zUHOUmDB2FfT6SI1CcZEJYfF3qFwBeUrU6srJfzANonwRYHDpLBuzbq3HaoF2XL2hcr01c8f8OaQ==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.10.0.tgz",
+      "integrity": "sha512-36Fq1PWh9dusgo3vH7qmQAj5/AZqARky1Wi6WpINxB6SkQdY5vQoT2/7rW7uBIsPDcvvGCLi4r10p0OJ7ITAeg==",
       "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -1646,13 +1646,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.9.1.tgz",
-      "integrity": "sha512-U+mUylTHfcqeO7mLWVQ5W/tMLXqVpRv61wm9ZtfE5egz7gtnmqVIw9ryh0mgIlkKk9rZLY3UHygsBSdB9/ftyw==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.10.0.tgz",
+      "integrity": "sha512-ek0Eyuy6P15LJVeghbWhSrBCj/vJpPXXR+EpaRZqou7achUWL8IdYnMSC5WHAeTWswYQuP2hAZgij/bC9fanBg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.9.1",
-        "@typescript-eslint/visitor-keys": "6.9.1",
+        "@typescript-eslint/types": "6.10.0",
+        "@typescript-eslint/visitor-keys": "6.10.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -1673,17 +1673,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.9.1.tgz",
-      "integrity": "sha512-L1T0A5nFdQrMVunpZgzqPL6y2wVreSyHhKGZryS6jrEN7bD9NplVAyMryUhXsQ4TWLnZmxc2ekar/lSGIlprCA==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.10.0.tgz",
+      "integrity": "sha512-v+pJ1/RcVyRc0o4wAGux9x42RHmAjIGzPRo538Z8M1tVx6HOnoQBCX/NoadHQlZeC+QO2yr4nNSFWOoraZCAyg==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.9.1",
-        "@typescript-eslint/types": "6.9.1",
-        "@typescript-eslint/typescript-estree": "6.9.1",
+        "@typescript-eslint/scope-manager": "6.10.0",
+        "@typescript-eslint/types": "6.10.0",
+        "@typescript-eslint/typescript-estree": "6.10.0",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -1698,12 +1698,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.9.1.tgz",
-      "integrity": "sha512-MUaPUe/QRLEffARsmNfmpghuQkW436DvESW+h+M52w0coICHRfD6Np9/K6PdACwnrq1HmuLl+cSPZaJmeVPkSw==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.10.0.tgz",
+      "integrity": "sha512-xMGluxQIEtOM7bqFCo+rCMh5fqI+ZxV5RUUOa29iVPz1OgCZrtc7rFnz5cLUazlkPKYqX+75iuDq7m0HQ48nCg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.9.1",
+        "@typescript-eslint/types": "6.10.0",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1452,16 +1452,16 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.9.0.tgz",
-      "integrity": "sha512-lgX7F0azQwRPB7t7WAyeHWVfW1YJ9NIgd9mvGhfQpRY56X6AVf8mwM8Wol+0z4liE7XX3QOt8MN1rUKCfSjRIA==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.9.1.tgz",
+      "integrity": "sha512-w0tiiRc9I4S5XSXXrMHOWgHgxbrBn1Ro+PmiYhSg2ZVdxrAJtQgzU5o2m1BfP6UOn7Vxcc6152vFjQfmZR4xEg==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.9.0",
-        "@typescript-eslint/type-utils": "6.9.0",
-        "@typescript-eslint/utils": "6.9.0",
-        "@typescript-eslint/visitor-keys": "6.9.0",
+        "@typescript-eslint/scope-manager": "6.9.1",
+        "@typescript-eslint/type-utils": "6.9.1",
+        "@typescript-eslint/utils": "6.9.1",
+        "@typescript-eslint/visitor-keys": "6.9.1",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -1589,13 +1589,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.9.0.tgz",
-      "integrity": "sha512-1R8A9Mc39n4pCCz9o79qRO31HGNDvC7UhPhv26TovDsWPBDx+Sg3rOZdCELIA3ZmNoWAuxaMOT7aWtGRSYkQxw==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.9.1.tgz",
+      "integrity": "sha512-38IxvKB6NAne3g/+MyXMs2Cda/Sz+CEpmm+KLGEM8hx/CvnSRuw51i8ukfwB/B/sESdeTGet1NH1Wj7I0YXswg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.9.0",
-        "@typescript-eslint/visitor-keys": "6.9.0"
+        "@typescript-eslint/types": "6.9.1",
+        "@typescript-eslint/visitor-keys": "6.9.1"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -1606,13 +1606,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.9.0.tgz",
-      "integrity": "sha512-XXeahmfbpuhVbhSOROIzJ+b13krFmgtc4GlEuu1WBT+RpyGPIA4Y/eGnXzjbDj5gZLzpAXO/sj+IF/x2GtTMjQ==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.9.1.tgz",
+      "integrity": "sha512-eh2oHaUKCK58qIeYp19F5V5TbpM52680sB4zNSz29VBQPTWIlE/hCj5P5B1AChxECe/fmZlspAWFuRniep1Skg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.9.0",
-        "@typescript-eslint/utils": "6.9.0",
+        "@typescript-eslint/typescript-estree": "6.9.1",
+        "@typescript-eslint/utils": "6.9.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -1633,9 +1633,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.9.0.tgz",
-      "integrity": "sha512-+KB0lbkpxBkBSiVCuQvduqMJy+I1FyDbdwSpM3IoBS7APl4Bu15lStPjgBIdykdRqQNYqYNMa8Kuidax6phaEw==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.9.1.tgz",
+      "integrity": "sha512-BUGslGOb14zUHOUmDB2FfT6SI1CcZEJYfF3qFwBeUrU6srJfzANonwRYHDpLBuzbq3HaoF2XL2hcr01c8f8OaQ==",
       "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -1646,13 +1646,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.9.0.tgz",
-      "integrity": "sha512-NJM2BnJFZBEAbCfBP00zONKXvMqihZCrmwCaik0UhLr0vAgb6oguXxLX1k00oQyD+vZZ+CJn3kocvv2yxm4awQ==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.9.1.tgz",
+      "integrity": "sha512-U+mUylTHfcqeO7mLWVQ5W/tMLXqVpRv61wm9ZtfE5egz7gtnmqVIw9ryh0mgIlkKk9rZLY3UHygsBSdB9/ftyw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.9.0",
-        "@typescript-eslint/visitor-keys": "6.9.0",
+        "@typescript-eslint/types": "6.9.1",
+        "@typescript-eslint/visitor-keys": "6.9.1",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -1673,17 +1673,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.9.0.tgz",
-      "integrity": "sha512-5Wf+Jsqya7WcCO8me504FBigeQKVLAMPmUzYgDbWchINNh1KJbxCgVya3EQ2MjvJMVeXl3pofRmprqX6mfQkjQ==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.9.1.tgz",
+      "integrity": "sha512-L1T0A5nFdQrMVunpZgzqPL6y2wVreSyHhKGZryS6jrEN7bD9NplVAyMryUhXsQ4TWLnZmxc2ekar/lSGIlprCA==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.9.0",
-        "@typescript-eslint/types": "6.9.0",
-        "@typescript-eslint/typescript-estree": "6.9.0",
+        "@typescript-eslint/scope-manager": "6.9.1",
+        "@typescript-eslint/types": "6.9.1",
+        "@typescript-eslint/typescript-estree": "6.9.1",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -1698,12 +1698,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.9.0.tgz",
-      "integrity": "sha512-dGtAfqjV6RFOtIP8I0B4ZTBRrlTT8NHHlZZSchQx3qReaoDeXhYM++M4So2AgFK9ZB0emRPA6JI1HkafzA2Ibg==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.9.1.tgz",
+      "integrity": "sha512-MUaPUe/QRLEffARsmNfmpghuQkW436DvESW+h+M52w0coICHRfD6Np9/K6PdACwnrq1HmuLl+cSPZaJmeVPkSw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.9.0",
+        "@typescript-eslint/types": "6.9.1",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1487,15 +1487,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.9.1.tgz",
-      "integrity": "sha512-C7AK2wn43GSaCUZ9do6Ksgi2g3mwFkMO3Cis96kzmgudoVaKyt62yNzJOktP0HDLb/iO2O0n2lBOzJgr6Q/cyg==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.10.0.tgz",
+      "integrity": "sha512-+sZwIj+s+io9ozSxIWbNB5873OSdfeBEH/FR0re14WLI6BaKuSOnnwCJ2foUiu8uXf4dRp1UqHP0vrZ1zXGrog==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.9.1",
-        "@typescript-eslint/types": "6.9.1",
-        "@typescript-eslint/typescript-estree": "6.9.1",
-        "@typescript-eslint/visitor-keys": "6.9.1",
+        "@typescript-eslint/scope-manager": "6.10.0",
+        "@typescript-eslint/types": "6.10.0",
+        "@typescript-eslint/typescript-estree": "6.10.0",
+        "@typescript-eslint/visitor-keys": "6.10.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1515,13 +1515,13 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.9.1.tgz",
-      "integrity": "sha512-38IxvKB6NAne3g/+MyXMs2Cda/Sz+CEpmm+KLGEM8hx/CvnSRuw51i8ukfwB/B/sESdeTGet1NH1Wj7I0YXswg==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.10.0.tgz",
+      "integrity": "sha512-TN/plV7dzqqC2iPNf1KrxozDgZs53Gfgg5ZHyw8erd6jd5Ta/JIEcdCheXFt9b1NYb93a1wmIIVW/2gLkombDg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.9.1",
-        "@typescript-eslint/visitor-keys": "6.9.1"
+        "@typescript-eslint/types": "6.10.0",
+        "@typescript-eslint/visitor-keys": "6.10.0"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -1532,9 +1532,9 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.9.1.tgz",
-      "integrity": "sha512-BUGslGOb14zUHOUmDB2FfT6SI1CcZEJYfF3qFwBeUrU6srJfzANonwRYHDpLBuzbq3HaoF2XL2hcr01c8f8OaQ==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.10.0.tgz",
+      "integrity": "sha512-36Fq1PWh9dusgo3vH7qmQAj5/AZqARky1Wi6WpINxB6SkQdY5vQoT2/7rW7uBIsPDcvvGCLi4r10p0OJ7ITAeg==",
       "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -1545,13 +1545,13 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.9.1.tgz",
-      "integrity": "sha512-U+mUylTHfcqeO7mLWVQ5W/tMLXqVpRv61wm9ZtfE5egz7gtnmqVIw9ryh0mgIlkKk9rZLY3UHygsBSdB9/ftyw==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.10.0.tgz",
+      "integrity": "sha512-ek0Eyuy6P15LJVeghbWhSrBCj/vJpPXXR+EpaRZqou7achUWL8IdYnMSC5WHAeTWswYQuP2hAZgij/bC9fanBg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.9.1",
-        "@typescript-eslint/visitor-keys": "6.9.1",
+        "@typescript-eslint/types": "6.10.0",
+        "@typescript-eslint/visitor-keys": "6.10.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -1572,12 +1572,12 @@
       }
     },
     "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.9.1.tgz",
-      "integrity": "sha512-MUaPUe/QRLEffARsmNfmpghuQkW436DvESW+h+M52w0coICHRfD6Np9/K6PdACwnrq1HmuLl+cSPZaJmeVPkSw==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.10.0.tgz",
+      "integrity": "sha512-xMGluxQIEtOM7bqFCo+rCMh5fqI+ZxV5RUUOa29iVPz1OgCZrtc7rFnz5cLUazlkPKYqX+75iuDq7m0HQ48nCg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.9.1",
+        "@typescript-eslint/types": "6.10.0",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {

--- a/tests/command.chain.test.js
+++ b/tests/command.chain.test.js
@@ -34,10 +34,52 @@ describe('Command methods that should return this for chaining', () => {
     expect(result).toBe(program);
   });
 
-  test('when call .addHelpCommand() then returns this', () => {
+  test('when call .addHelpCommand(cmd) then returns this', () => {
     const program = new Command();
-    const result = program.addHelpCommand(false);
+    const result = program.addHelpCommand(new Command('assist'));
     expect(result).toBe(program);
+  });
+
+  test('when call deprecated .addHelpCommand() then returns this', () => {
+    const program = new Command();
+    const result = program.addHelpCommand();
+    expect(result).toBe(program);
+  });
+
+  test('when call deprecated .addHelpCommand(boolean) then returns this', () => {
+    const program = new Command();
+    const result1 = program.addHelpCommand(true);
+    expect(result1).toBe(program);
+    const result2 = program.addHelpCommand(false);
+    expect(result2).toBe(program);
+  });
+
+  test('when call deprecated .addHelpCommand(string[, string]) then returns this', () => {
+    const program = new Command();
+    const result1 = program.addHelpCommand('assist');
+    expect(result1).toBe(program);
+    const result2 = program.addHelpCommand('assist', 'assist description');
+    expect(result2).toBe(program);
+  });
+
+  test('when call .helpCommand(name) then returns new command', () => {
+    const program = new Command();
+    const result = program.helpCommand();
+    expect(result).not.toBe(program);
+  });
+
+  test('when call .helpCommand(name, description) then returns this', () => {
+    const program = new Command();
+    const result1 = program.helpCommand('assist', 'assist description');
+    expect(result1).toBe(program);
+  });
+
+  test('when call .helpCommand(boolean) then returns this', () => {
+    const program = new Command();
+    const result1 = program.helpCommand(true);
+    expect(result1).toBe(program);
+    const result2 = program.helpCommand(false);
+    expect(result2).toBe(program);
   });
 
   test('when call .exitOverride() then returns this', () => {

--- a/tests/command.chain.test.js
+++ b/tests/command.chain.test.js
@@ -65,7 +65,7 @@ describe('Command methods that should return this for chaining', () => {
   test('when call .helpCommand(name) then returns new command', () => {
     const program = new Command();
     const result = program.helpCommand();
-    expect(result).not.toBe(program);
+    expect(result).toBe(program);
   });
 
   test('when call .helpCommand(name, description) then returns this', () => {

--- a/tests/command.chain.test.js
+++ b/tests/command.chain.test.js
@@ -62,7 +62,7 @@ describe('Command methods that should return this for chaining', () => {
     expect(result2).toBe(program);
   });
 
-  test('when call .helpCommand(name) then returns new command', () => {
+  test('when call .helpCommand(name) then returns this', () => {
     const program = new Command();
     const result = program.helpCommand();
     expect(result).toBe(program);

--- a/tests/command.copySettings.test.js
+++ b/tests/command.copySettings.test.js
@@ -67,8 +67,8 @@ describe('copyInheritedSettings property tests', () => {
     const source = new commander.Command();
     const cmd = new commander.Command();
 
-    // Legacy behaviour, force enable does not inherit,
-    // largely so deprecated program.addHelpCommand(true) does not inherit.
+    // Existing behaviour, force enable/disable does not inherit,
+    // largely so (probably redundant) program.helpCommand(true) does not inherit to leaf subcommands.
     source.helpCommand(true);
     cmd.copyInheritedSettings(source);
     expect(cmd._addHelpOption).toBeUndefined();

--- a/tests/command.copySettings.test.js
+++ b/tests/command.copySettings.test.js
@@ -57,7 +57,7 @@ describe('copyInheritedSettings property tests', () => {
     source.addHelpCommand('HELP [cmd]', 'ddd');
     cmd.copyInheritedSettings(source);
     cmd.helpCommand(true);
-    const helpCommand = cmd.helpCommand();
+    const helpCommand = cmd.getHelpCommand();
     expect(helpCommand).toBeTruthy();
     expect(helpCommand.name()).toBe('HELP');
     expect(helpCommand.description()).toBe('ddd');

--- a/tests/command.copySettings.test.js
+++ b/tests/command.copySettings.test.js
@@ -67,7 +67,7 @@ describe('copyInheritedSettings property tests', () => {
     const source = new commander.Command();
     const cmd = new commander.Command();
 
-    // Legacy behaviour, force enable does not inherit, 
+    // Legacy behaviour, force enable does not inherit,
     // largely so deprecated program.addHelpCommand(true) does not inherit.
     source.helpCommand(true);
     cmd.copyInheritedSettings(source);

--- a/tests/command.copySettings.test.js
+++ b/tests/command.copySettings.test.js
@@ -54,13 +54,24 @@ describe('copyInheritedSettings property tests', () => {
     const source = new commander.Command();
     const cmd = new commander.Command();
 
-    source.addHelpCommand('HELP [cmd]', 'ddd');
+    source.helpCommand('HELP [cmd]', 'ddd');
     cmd.copyInheritedSettings(source);
-    cmd.helpCommand(true);
-    const helpCommand = cmd.getHelpCommand();
+    cmd.helpCommand(true); // force enable
+    const helpCommand = cmd._getHelpCommand();
     expect(helpCommand).toBeTruthy();
     expect(helpCommand.name()).toBe('HELP');
     expect(helpCommand.description()).toBe('ddd');
+  });
+
+  test('when copyInheritedSettings then does not copy help enable override', () => {
+    const source = new commander.Command();
+    const cmd = new commander.Command();
+
+    // Legacy behaviour, force enable does not inherit, 
+    // largely so deprecated program.addHelpCommand(true) does not inherit.
+    source.helpCommand(true);
+    cmd.copyInheritedSettings(source);
+    expect(cmd._addHelpOption).toBeUndefined();
   });
 
   test('when copyInheritedSettings then copies configureHelp(config)', () => {

--- a/tests/command.copySettings.test.js
+++ b/tests/command.copySettings.test.js
@@ -50,15 +50,17 @@ describe('copyInheritedSettings property tests', () => {
     expect(cmd._helpLongFlag).toBe('--zz');
   });
 
-  test('when copyInheritedSettings then copies addHelpCommand(name, description)', () => {
+  test('when copyInheritedSettings then copies custom help command', () => {
     const source = new commander.Command();
     const cmd = new commander.Command();
 
     source.addHelpCommand('HELP [cmd]', 'ddd');
     cmd.copyInheritedSettings(source);
-    expect(cmd._helpCommandName).toBe('HELP');
-    expect(cmd._helpCommandnameAndArgs).toBe('HELP [cmd]');
-    expect(cmd._helpCommandDescription).toBe('ddd');
+    cmd.helpCommand(true);
+    const helpCommand = cmd.helpCommand();
+    expect(helpCommand).toBeTruthy();
+    expect(helpCommand.name()).toBe('HELP');
+    expect(helpCommand.description()).toBe('ddd');
   });
 
   test('when copyInheritedSettings then copies configureHelp(config)', () => {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -421,21 +421,14 @@ export class Command {
   /**
    * Customise or override default help command. By default a help command is automatically added if your command has subcommands.
    *
-   * Please note: the API is deliberately similar to `.command()` so that a new command is returned if you pass the
-   * command name alone. In all other cases, it returns `this` for chaining.
-   *
    * @example
    * ```ts
-   * // Returns new help command for configuration
    * program.helpCommand('help [cmd]');
-   * program.helpCommand('help [cmd]').description('show help');
-   * // Returns `this` for chaining.
    * program.helpCommand('help [cmd]', 'show help');
    * program.helpCommand(false); // suppress default help command
    * program.helpCommand(true); // add help command even if no subcommands
    * ```
    */
-  helpCommand(nameAndArgs: string): ReturnType<this['createCommand']>;
   helpCommand(nameAndArgs: string, description?: string): this;
   helpCommand(enable: boolean): this;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -420,22 +420,24 @@ export class Command {
 
   /**
    * Customise or override default help command. By default a help command is automatically added if your command has subcommands.
-   * 
+   *
    * Please note: the API is deliberately similar to `.command()` so that a new command is returned if you pass the
    * command name alone. In all other cases, it returns `this` for chaining.
    *
    * @example
    * ```ts
-   * program.helpCommand('help [cmd]'); // returns help command for further configuration (see next example)
-   * program.helpCommand('help [cmd]').description('show help'); // change help command name and description
-   * program.helpCommand('help [cmd]', 'show help'); // change help command name and description, returns program for chaining
-   * program.helpCommand(false); // suppress default help command, returns program
-   * program.helpCommand(true); // add help command even if no subcommands, returns program
+   * // Returns new help command for configuration
+   * program.helpCommand('help [cmd]');
+   * program.helpCommand('help [cmd]').description('show help');
+   * // Returns `this` for chaining.
+   * program.helpCommand('help [cmd]', 'show help');
+   * program.helpCommand(false); // suppress default help command
+   * program.helpCommand(true); // add help command even if no subcommands
    * ```
    */
   helpCommand(nameAndArgs: string): ReturnType<this['createCommand']>;
   helpCommand(nameAndArgs: string, description?: string): this;
-  helpCommand(enable: Boolean): this;
+  helpCommand(enable: boolean): this;
 
   /**
    * Add prepared custom help command.

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -419,18 +419,32 @@ export class Command {
   arguments(names: string): this;
 
   /**
-   * Override default decision whether to add implicit help command.
+   * Customise or override default help command. By default a help command is automatically added if your command has subcommands.
+   * 
+   * Please note: the API is deliberately similar to `.command()` so that a new command is returned if you pass the
+   * command name alone. In all other cases, it returns `this` for chaining.
    *
    * @example
+   * ```ts
+   * program.helpCommand('help [cmd]'); // returns help command for further configuration (see next example)
+   * program.helpCommand('help [cmd]').description('show help'); // change help command name and description
+   * program.helpCommand('help [cmd]', 'show help'); // change help command name and description, returns program for chaining
+   * program.helpCommand(false); // suppress default help command, returns program
+   * program.helpCommand(true); // add help command even if no subcommands, returns program
    * ```
-   * addHelpCommand() // force on
-   * addHelpCommand(false); // force off
-   * addHelpCommand('help [cmd]', 'display help for [cmd]'); // force on with custom details
-   * ```
-   *
-   * @returns `this` command for chaining
    */
-  addHelpCommand(enableOrNameAndArgs?: string | boolean, description?: string): this;
+  helpCommand(nameAndArgs: string): ReturnType<this['createCommand']>;
+  helpCommand(nameAndArgs: string, description?: string): this;
+  helpCommand(enable: Boolean): this;
+
+  /**
+   * Add prepared custom help command.
+   */
+  addHelpCommand(cmd: Command): this;
+  /** @deprecated since v12, instead use helpCommand */
+  addHelpCommand(nameAndArgs: string, description?: string): this;
+  /** @deprecated since v12, instead use helpCommand */
+  addHelpCommand(enable?: boolean): this;
 
   /**
    * Add hook for life cycle event.

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -67,6 +67,12 @@ expectType<commander.Command>(program.addHelpCommand(true));
 expectType<commander.Command>(program.addHelpCommand('assist [cmd]'));
 expectType<commander.Command>(program.addHelpCommand('assist [file]', 'display help'));
 
+// helpCommand
+expectType<commander.Command>(program.helpCommand(false));
+expectType<commander.Command>(program.helpCommand(true));
+expectType<commander.Command>(program.helpCommand('assist [cmd]'));
+expectType<commander.Command>(program.helpCommand('assist [file]', 'display help'));
+
 // exitOverride
 expectType<commander.Command>(program.exitOverride());
 expectType<commander.Command>(program.exitOverride((err): never => {

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -59,11 +59,13 @@ expectType<commander.Command>(program.argument('[value]', 'description', parseFl
 expectType<commander.Command>(program.arguments('<cmd> [env]'));
 
 // addHelpCommand
+expectType<commander.Command>(program.addHelpCommand(new commander.Command('assist')));
+// Deprecated uses
 expectType<commander.Command>(program.addHelpCommand());
 expectType<commander.Command>(program.addHelpCommand(false));
 expectType<commander.Command>(program.addHelpCommand(true));
-expectType<commander.Command>(program.addHelpCommand('compress <file>'));
-expectType<commander.Command>(program.addHelpCommand('compress <file>', 'compress target file'));
+expectType<commander.Command>(program.addHelpCommand('assist [cmd]'));
+expectType<commander.Command>(program.addHelpCommand('assist [file]', 'display help'));
 
 // exitOverride
 expectType<commander.Command>(program.exitOverride());


### PR DESCRIPTION
# Pull Request

## Problem

In order of importance:

1) the other `addFoo` routines like `addCommand()` take objects
2) we have to do custom work and add more properties for new Command features, like say helpGroup (#1910)
3) bit messy storing multiple properties to construct help command when needed (minor)

## Solution

- make `.addHelpCommand()` accept a Command
   - so similar to `.addCommand()`
- add `.helpCommand()` which behaves similarly to the old API
   - so similar to `.command()`
- `.addHelpCommand()` still accepts string/boolean/undefined for backwards compatibility, but that usage is deprecated in favour of `.helpCommand()`


## ChangeLog

- added: `.helpCommand()` for configuring built-in help command
- changed: `.addHelpCommand()` now takes a `Command` for configuring built-in help command
- deprecated: `.addHelpCommand()` being passed string or boolean for configuring built-in help command

