### PR TITLE
Rework exitOverride description

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1094,8 +1094,9 @@ program.error('Custom processing has failed', { exitCode: 2, code: 'my.custom.er
 By default, Commander calls `process.exit` when it detects errors, or after displaying the help or version. You can override
 this behaviour and optionally supply a callback. The default override throws a `CommanderError`.
 
-The override callback is passed a `CommanderError` with properties `exitCode` number, `code` string, and `message`. The default override behaviour is to throw the error, except for async handling of executable subcommand completion which carries on. The normal display of error messages or version or help
-is not affected by the override which is called after the display.
+The override callback is passed a `CommanderError` with properties `exitCode` number, `code` string, and `message`.
+Commander expects the callback to terminate the normal program flow, and will throw the error if the callback returns.
+The normal display of error messages or version or help is not affected by the override which is called after the display.
 
 ```js
 program.exitOverride();

--- a/Readme.md
+++ b/Readme.md
@@ -1092,7 +1092,7 @@ program.error('Custom processing has failed', { exitCode: 2, code: 'my.custom.er
 ### Override exit and output handling
 
 By default, Commander calls `process.exit` when it detects errors, or after displaying the help or version. You can override
-this behaviour and optionally supply a callback. The default override throws a `CommanderError`.
+this behaviour and optionally supply a callback to be called first. The default override throws a `CommanderError`.
 
 The override callback is passed a `CommanderError` with properties `exitCode` number, `code` string, and `message`.
 Commander expects the callback to terminate the normal program flow, and will call `process.exit` if the callback returns.

--- a/Readme.md
+++ b/Readme.md
@@ -1095,7 +1095,7 @@ By default, Commander calls `process.exit` when it detects errors, or after disp
 this behaviour and optionally supply a callback. The default override throws a `CommanderError`.
 
 The override callback is passed a `CommanderError` with properties `exitCode` number, `code` string, and `message`.
-Commander expects the callback to terminate the normal program flow, and will throw the error if the callback returns.
+Commander expects the callback to terminate the normal program flow, and will call `process.exit` if the callback returns.
 The normal display of error messages or version or help is not affected by the override which is called after the display.
 
 ```js

--- a/Readme.md
+++ b/Readme.md
@@ -1092,7 +1092,7 @@ program.error('Custom processing has failed', { exitCode: 2, code: 'my.custom.er
 ### Override exit and output handling
 
 By default, Commander calls `process.exit` when it detects errors, or after displaying the help or version. You can override
-this behaviour and optionally supply a callback to be called first. The default override throws a `CommanderError`.
+this behaviour and optionally supply a callback. The default override throws a `CommanderError`.
 
 The override callback is passed a `CommanderError` with properties `exitCode` number, `code` string, and `message`.
 Commander expects the callback to terminate the normal program flow, and will call `process.exit` if the callback returns.


### PR DESCRIPTION
# Pull Request

## Problem

Some users try using `exitOverride`  to have the program continue and are surprised when Commander exits anyway. 

Related: #1444 #2092

## Solution

Add to README description.