### PR TITLE
Add customErrorHandler with example

### DIFF
--- a/examples/custom-error-handler.js
+++ b/examples/custom-error-handler.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+// This example is used as an example of rewrite the standart error log method.
+
+const { Command } = require('../');
+const program = new Command();
+
+program.customErrorHandler((data) => {
+  process.stderr.write(data.replace('error', 'Error (changed)'));
+});
+
+program
+  .command('set-name')
+  .argument('<name>')
+  .action(function(e) {
+    console.log('Saved name:', e);
+  });
+
+program.parse();
+
+// Try the following:
+//    node custom-error-handler.js set-name

--- a/lib/command.js
+++ b/lib/command.js
@@ -21,6 +21,8 @@ class Command extends EventEmitter {
     super();
     /** @type {Command[]} */
     this.commands = [];
+    /** @type {((data: string) => void) | null} */
+    this.customErrorHandlerCallback = null;
     /** @type {Option[]} */
     this.options = [];
     this.parent = null;
@@ -59,7 +61,7 @@ class Command extends EventEmitter {
     // see .configureOutput() for docs
     this._outputConfiguration = {
       writeOut: (str) => process.stdout.write(str),
-      writeErr: (str) => process.stderr.write(str),
+      writeErr: (str) => this.customErrorHandlerCallback ? this.customErrorHandlerCallback(str) : process.stderr.write(str),
       getOutHelpWidth: () => process.stdout.isTTY ? process.stdout.columns : undefined,
       getErrHelpWidth: () => process.stderr.isTTY ? process.stderr.columns : undefined,
       outputError: (str, write) => write(str)
@@ -171,6 +173,15 @@ class Command extends EventEmitter {
 
     if (desc) return this;
     return cmd;
+  }
+
+  /**
+   * Rewrite the standard error log function
+   *
+   * @param {(data: string) => void} callback
+   */
+  customErrorHandler(callback) {
+    this.customErrorHandlerCallback = callback;
   }
 
   /**


### PR DESCRIPTION

## Problem

When error messages are not stylized as the other errors in application it worsens an user experience.

## Solution
It make possible to rewrite the standard error log method
Provided the method:
```typescript
customErrorHandler(callback: (data: string) => void): this;
```

