### PR TITLE
Simplify security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,12 +2,7 @@
 
 ## Supported Versions
 
-Old versions receive security updates for six months.
-
-| Version | Supported                                  |
-| ------- | ------------------------------------------ |
-| 11.x    | :white_check_mark: support ends 2024-07-03 |
-| < 11    | :x:                                        |
+Security updates are supported for the current version and the previous major version.
 
 Pull Requests for security issues will be considered for older versions back to 2.x.
 


### PR DESCRIPTION
# Pull Request

## Problem

The timeframe for supporting old versions for six months is a bit unusual and needs extra info on how it is implemented (i.e. table of expiry dates). It is custom and does not fit into standard Tidelift support patterns.

## Solution

Supporting security updates for current version and previous major version is simple to explain and understand. It is a standard pattern on Tidelift.

As long as we release the next major version longer than six months from now, the change is an extension to the support period, so ok to do now without waiting for a major release to change policy.

## ChangeLog

Extend security support to full lifetime of previous major version.