### PR TITLE
Use standard import in examples

### DIFF
--- a/examples/action-this.js
+++ b/examples/action-this.js
@@ -2,8 +2,7 @@
 
 // This example is used as an example in the README for the action handler.
 
-// const { Command } = require('commander'); // (normal include)
-const { Command } = require('../'); // include commander in git clone of commander repo
+const { Command } = require('commander');
 const program = new Command();
 
 program

--- a/examples/alias.js
+++ b/examples/alias.js
@@ -2,8 +2,7 @@
 
 // This example shows giving alternative names for a command.
 
-// const { Command } = require('commander'); // (normal include)
-const { Command } = require('../'); // include commander in git clone of commander repo
+const { Command } = require('commander');
 const program = new Command();
 
 program

--- a/examples/argument.js
+++ b/examples/argument.js
@@ -2,8 +2,7 @@
 
 // This example shows specifying the command arguments using argument() function.
 
-// const { Command } = require('commander'); // (normal include)
-const { Command } = require('../'); // include commander in git clone of commander repo
+const { Command } = require('commander');
 const program = new Command();
 
 program

--- a/examples/arguments-custom-processing.js
+++ b/examples/arguments-custom-processing.js
@@ -4,8 +4,7 @@
 //    Custom argument processing
 //    You may specify a function to do custom processing of argument values.
 
-// const commander = require('commander'); // (normal include)
-const commander = require('../'); // include commander in git clone of commander repo
+const commander = require('commander');
 const program = new commander.Command();
 
 function myParseInt(value, dummyPrevious) {

--- a/examples/arguments-extra.js
+++ b/examples/arguments-extra.js
@@ -2,8 +2,7 @@
 
 // This is used as an example in the README for extra argument features.
 
-// const commander = require('commander'); // (normal include)
-const commander = require('../'); // include commander in git clone of commander repo
+const commander = require('commander');
 const program = new commander.Command();
 
 program

--- a/examples/configure-help.js
+++ b/examples/configure-help.js
@@ -1,6 +1,4 @@
-// const commander = require('commander'); // (normal include)
-const commander = require('../'); // include commander in git clone of commander repo
-
+const commander = require('commander');
 const program = new commander.Command();
 
 // This example shows a simple use of configureHelp.

--- a/examples/configure-output.js
+++ b/examples/configure-output.js
@@ -1,6 +1,4 @@
-// const commander = require('commander'); // (normal include)
-const commander = require('../'); // include commander in git clone of commander repo
-
+const commander = require('commander');
 const program = new commander.Command();
 
 function errorColor(str) {

--- a/examples/custom-command-class.js
+++ b/examples/custom-command-class.js
@@ -1,7 +1,5 @@
 #!/usr/bin/env node
-
-// const commander = require('commander'); // (normal include)
-const commander = require('../'); // include commander in git clone of commander repo
+const commander = require('commander');
 
 // Use a class override to customise the command and its subcommands.
 

--- a/examples/custom-help
+++ b/examples/custom-help
@@ -3,8 +3,7 @@
 // This example shows a simple use of addHelpText.
 // This is used as an example in the README.
 
-// const { Command } = require('commander'); // (normal include)
-const { Command } = require('../'); // include commander in git clone of commander repo
+const { Command } = require('commander');
 const program = new Command();
 
 program

--- a/examples/custom-help-description
+++ b/examples/custom-help-description
@@ -2,8 +2,7 @@
 
 // This example shows changing the flags and description for the help option.
 
-// const { Command } = require('commander'); // (normal include)
-const { Command } = require('../'); // include commander in git clone of commander repo
+const { Command } = require('commander');
 const program = new Command();
 
 program

--- a/examples/custom-help-text.js
+++ b/examples/custom-help-text.js
@@ -2,8 +2,7 @@
 
 // This example shows using addHelpText.
 
-// const { Command } = require('commander'); // (normal include)
-const { Command } = require('../'); // include commander in git clone of commander repo
+const { Command } = require('commander');
 const program = new Command();
 
 program.name('awesome');

--- a/examples/custom-version
+++ b/examples/custom-version
@@ -2,8 +2,7 @@
 
 // This example shows changing the flags and description for the version option.
 
-// const { Command } = require('commander'); // (normal include)
-const { Command } = require('../'); // include commander in git clone of commander repo
+const { Command } = require('commander');
 const program = new Command();
 
 program

--- a/examples/defaultCommand.js
+++ b/examples/defaultCommand.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
-// const commander = require('commander'); // (normal include)
-const commander = require('../'); // include commander in git clone of commander repo
+const commander = require('commander');
 const program = new commander.Command();
 
 // Example program using the command configuration option isDefault to specify the default command.

--- a/examples/deploy
+++ b/examples/deploy
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
-// const { Command } = require('commander'); // (normal include)
-const { Command } = require('../'); // include commander in git clone of commander repo
+const { Command } = require('commander');
 const program = new Command();
 
 program

--- a/examples/description
+++ b/examples/description
@@ -2,8 +2,7 @@
 
 // This example shows adding a description which is displayed in the help.
 
-// const { Command } = require('commander'); // (normal include)
-const { Command } = require('../'); // include commander in git clone of commander repo
+const { Command } = require('commander');
 const program = new Command();
 
 program

--- a/examples/global-options-added.js
+++ b/examples/global-options-added.js
@@ -9,8 +9,7 @@
 // (A different pattern for a "global" option is to add it to the root command, rather
 // than to the subcommand. See global-options-nested.js.)
 
-// const { Command } = require('commander'); // (normal include)
-const { Command } = require('../'); // include commander in git clone of commander repo
+const { Command } = require('commander');
 
 // Common options can be added when subcommands are created by using a custom subclass.
 // If the options are unsorted in the help, these will appear first.

--- a/examples/global-options-nested.js
+++ b/examples/global-options-nested.js
@@ -6,9 +6,7 @@
 // (A different pattern for a "global" option is to add it to the subcommands, rather
 // than to the program. See global-options-added.js.)
 
-// const { Command } = require('commander'); // (normal include)
-const { Command } = require('../'); // include commander in git clone of commander repo
-
+const { Command } = require('commander');
 const program = new Command();
 
 program

--- a/examples/help-subcommands-usage.js
+++ b/examples/help-subcommands-usage.js
@@ -1,5 +1,4 @@
-// const commander = require('commander'); // (normal include)
-const commander = require('../'); // include commander in git clone of commander repo
+const commander = require('commander');
 
 // By default the subcommand list includes a fairly simple usage. If you have added a custom usage
 // to the subcommands you may wish to configure the help to show these instead.

--- a/examples/hook.js
+++ b/examples/hook.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
-// const commander = require('commander'); // (normal include)
-const { Command, Option } = require('../'); // include commander in git clone of commander repo
+const { Command, Option } = require('commander');
 const program = new Command();
 
 // This example shows using some hooks for life cycle events.

--- a/examples/nestedCommands.js
+++ b/examples/nestedCommands.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
-// const commander = require('commander'); // (normal include)
-const commander = require('../'); // include commander in git clone of commander repo
+const commander = require('commander');
 const program = new commander.Command();
 
 // Commander supports nested subcommands.

--- a/examples/options-boolean-or-value.js
+++ b/examples/options-boolean-or-value.js
@@ -4,8 +4,7 @@
 //    Other option types, flag|value
 //    You can specify an option which functions as a flag but may also take a value (declared using square brackets).
 
-// const commander = require('commander'); // (normal include)
-const commander = require('../'); // include commander in git clone of commander repo
+const commander = require('commander');
 const program = new commander.Command();
 
 program

--- a/examples/options-common.js
+++ b/examples/options-common.js
@@ -3,8 +3,7 @@
 // This is used as an example in the README for:
 //    Common option types, boolean and value
 
-// const commander = require('commander'); // (normal include)
-const commander = require('../'); // include commander in git clone of commander repo
+const commander = require('commander');
 const program = new commander.Command();
 
 program

--- a/examples/options-conflicts.js
+++ b/examples/options-conflicts.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
-// const { Command, Option } = require('commander'); // (normal include)
-const { Command, Option } = require('../'); // include commander in git clone of commander repo
+const { Command, Option } = require('commander');
 const program = new Command();
 
 // You can use .conflicts() with a single string, which is the camel-case name of the conflicting option.

--- a/examples/options-custom-processing.js
+++ b/examples/options-custom-processing.js
@@ -4,8 +4,7 @@
 //    Custom option processing
 //    You may specify a function to do custom processing of option values.
 
-// const commander = require('commander'); // (normal include)
-const commander = require('../'); // include commander in git clone of commander repo
+const commander = require('commander');
 const program = new commander.Command();
 
 function myParseInt(value, dummyPrevious) {

--- a/examples/options-defaults.js
+++ b/examples/options-defaults.js
@@ -3,8 +3,7 @@
 // This is used as an example in the README for:
 //    Default option value
 
-// const commander = require('commander'); // (normal include)
-const commander = require('../'); // include commander in git clone of commander repo
+const commander = require('commander');
 const program = new commander.Command();
 
 program

--- a/examples/options-env.js
+++ b/examples/options-env.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
-// const { Command, Option } = require('commander'); // (normal include)
-const { Command, Option } = require('../'); // include commander in git clone of commander repo
+const { Command, Option } = require('commander');
 const program = new Command();
 
 program.addOption(new Option('-p, --port <number>', 'specify port number')

--- a/examples/options-extra.js
+++ b/examples/options-extra.js
@@ -4,8 +4,7 @@
 // See also options-env.js for more extensive env examples,
 // and options-conflicts.js for more details about .conflicts().
 
-// const { Command, Option } = require('commander'); // (normal include)
-const { Command, Option } = require('../'); // include commander in git clone of commander repo
+const { Command, Option } = require('commander');
 const program = new Command();
 
 program

--- a/examples/options-implies.js
+++ b/examples/options-implies.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
-// const { Command, Option } = require('commander'); // (normal include)
-const { Command, Option } = require('../'); // include commander in git clone of commander repo
+const { Command, Option } = require('commander');
 const program = new Command();
 
 program

--- a/examples/options-negatable.js
+++ b/examples/options-negatable.js
@@ -4,8 +4,7 @@
 //    Other option types, negatable boolean
 //    You can specify a boolean option long name with a leading `no-` to make it true by default and able to be negated.
 
-// const commander = require('commander'); // (normal include)
-const commander = require('../'); // include commander in git clone of commander repo
+const commander = require('commander');
 const program = new commander.Command();
 
 program

--- a/examples/options-required.js
+++ b/examples/options-required.js
@@ -5,8 +5,7 @@
 //    You may specify a required (mandatory) option using `.requiredOption`.
 //    The option must be specified on the command line, or by having a default value.
 
-// const commander = require('commander'); // (normal include)
-const commander = require('../'); // include commander in git clone of commander repo
+const commander = require('commander');
 const program = new commander.Command();
 
 program

--- a/examples/options-variadic.js
+++ b/examples/options-variadic.js
@@ -2,8 +2,7 @@
 
 // This is used as an example in the README for variadic options.
 
-// const commander = require('commander'); // (normal include)
-const commander = require('../'); // include commander in git clone of commander repo
+const commander = require('commander');
 const program = new commander.Command();
 
 program

--- a/examples/pass-through-options.js
+++ b/examples/pass-through-options.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
-// const { Command } = require('commander'); // (normal include)
-const { Command } = require('../'); // include commander in git clone of commander repo
+const { Command } = require('commander');
 const program = new Command();
 
 program

--- a/examples/pizza
+++ b/examples/pizza
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
-// const { Command } = require('commander'); // (normal include)
-const { Command } = require('../'); // include commander in git clone of commander repo
+const { Command } = require('commander');
 const program = new Command();
 
 program

--- a/examples/pm
+++ b/examples/pm
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
-// const { Command } = require('commander'); // (normal include)
-const { Command } = require('../'); // include commander in git clone of commander repo
+const { Command } = require('commander');
 const program = new Command();
 
 // Example of subcommands which are implemented as stand-alone executable files.

--- a/examples/pm-install
+++ b/examples/pm-install
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
-// const { Command } = require('commander'); // (normal include)
-const { Command } = require('../'); // include commander in git clone of commander repo
+const { Command } = require('commander');
 const program = new Command();
 
 program

--- a/examples/positional-options.js
+++ b/examples/positional-options.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
-// const { Command } = require('commander'); // (normal include)
-const { Command } = require('../'); // include commander in git clone of commander repo
+const { Command } = require('commander');
 const program = new Command();
 
 program

--- a/examples/split.js
+++ b/examples/split.js
@@ -1,5 +1,4 @@
-// const { program } = require('commander'); // (normal include)
-const { program } = require('../'); // include commander in git clone of commander repo
+const { program } = require('commander');
 
 // This is used as an example in the README for the Quick Start.
 

--- a/examples/string-util.js
+++ b/examples/string-util.js
@@ -1,5 +1,4 @@
-// const { Command } = require('commander'); // (normal include)
-const { Command } = require('../'); // include commander in git clone of commander repo
+const { Command } = require('commander');
 const program = new Command();
 
 // This is used as an example in the README for the Quick Start.

--- a/examples/thank.js
+++ b/examples/thank.js
@@ -2,8 +2,7 @@
 
 // This example is used as an example in the README for the action handler.
 
-// const { Command } = require('commander'); // (normal include)
-const { Command } = require('../'); // include commander in git clone of commander repo
+const { Command } = require('commander');
 const program = new Command();
 
 program


### PR DESCRIPTION
It turns out we don't need to use `'../'` for the imports in the example files to be able to run the examples from the repo. Can just import from `'commander'` like in client code and finds the parent package. Small change, but nice tidy!