### PR TITLE
Fix: Use `node`-prefixed requires for builtins

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -1,8 +1,8 @@
-const EventEmitter = require('events').EventEmitter;
-const childProcess = require('child_process');
-const path = require('path');
-const fs = require('fs');
-const process = require('process');
+const EventEmitter = require('node:events').EventEmitter;
+const childProcess = require('node:child_process');
+const path = require('node:path');
+const fs = require('node:fs');
+const process = require('node:process');
 
 const { Argument, humanReadableArgName } = require('./argument.js');
 const { CommanderError } = require('./error.js');


### PR DESCRIPTION
# Pull Request

## Problem

I want to use a Commander-based CLI tool from Deno, as explained in #2169 

## Solution

Fixes and closes #2169 by using Node-prefixed imports.

**Note:** Node-prefixed imports are supported on Node 16+, so this may break older apps on _very_ old versions of Node. As a result I would suggest a major version bump to signal a compatibility change. Node 16 has reached EOL, so people really should be upgrading if they can.

No code was changed in Commander itself; just imports.

## ChangeLog

- Use `node:`-prefixed requires; this may break compatibility with older versions of Node (up to 15). Please upgrade Node, bundle your app with rewriting to remove the `node:` prefix on requires, or avoid upgrading Commander if Node cannot be upgraded.
