### PR TITLE
Add support for help groups for options

### DIFF
--- a/lib/help.js
+++ b/lib/help.js
@@ -15,6 +15,7 @@ class Help {
     this.sortSubcommands = false;
     this.sortOptions = false;
     this.showGlobalOptions = false;
+    this.optionGroups = {};
   }
 
   /**
@@ -331,6 +332,41 @@ class Help {
   }
 
   /**
+   * 
+   * @param {Command} cmd 
+   * @param {Help} helper 
+   * @returns { object }
+   */
+  visibleOptionGroups(cmd, helper) {
+    const result = {'Options:' : []};
+
+    // Invert the optionGroups object to a map of optionName to groupName.
+    const groupLookup = new Map();
+    Object.keys(this.optionGroups).concat().forEach((title) => {
+      result[title] = [];
+      this.optionGroups[title].forEach(optionName => {
+        // (only supporting option appearing in one group for now, last one wins)
+        groupLookup.set(optionName, title);
+      });
+    });
+
+    // Build list of options in each group title (in order as returned by visibleOptions).
+    helper.visibleOptions(cmd).forEach((option) => {
+      const title = groupLookup.get(option.attributeName()) ?? 'Options:';
+      result[title].push(option);
+    });
+
+    // Remove empty groups.
+    Object.keys(this.optionGroups).forEach((title) => {
+      if (result[title].length === 0) {
+        delete result[title];
+      }
+    });
+
+    return result;
+  }
+
+  /**
    * Generate the built-in help text.
    *
    * @param {Command} cmd
@@ -372,12 +408,13 @@ class Help {
     }
 
     // Options
-    const optionList = helper.visibleOptions(cmd).map((option) => {
-      return formatItem(helper.optionTerm(option), helper.optionDescription(option));
-    });
-    if (optionList.length > 0) {
-      output = output.concat(['Options:', formatList(optionList), '']);
-    }
+    const visibleOptionGroups = helper.visibleOptionGroups(cmd, helper);
+      Object.keys(visibleOptionGroups).forEach((groupTitle) => {
+        const optionList = visibleOptionGroups[groupTitle].map((opt) => {
+           return formatItem(helper.optionTerm(opt), helper.optionDescription(opt));
+        });
+        output = output.concat([groupTitle, formatList(optionList), '']);
+      });
 
     if (this.showGlobalOptions) {
       const globalOptionList = helper.visibleGlobalOptions(cmd).map((option) => {

--- a/lib/help.js
+++ b/lib/help.js
@@ -357,7 +357,7 @@ class Help {
     });
 
     // Remove empty groups.
-    Object.keys(this.optionGroups).forEach((title) => {
+    Object.keys(result).forEach((title) => {
       if (result[title].length === 0) {
         delete result[title];
       }

--- a/lib/help.js
+++ b/lib/help.js
@@ -332,13 +332,13 @@ class Help {
   }
 
   /**
-   * 
-   * @param {Command} cmd 
-   * @param {Help} helper 
+   *
+   * @param {Command} cmd
+   * @param {Help} helper
    * @returns { object }
    */
   visibleOptionGroups(cmd, helper) {
-    const result = {'Options:' : []};
+    const result = { 'Options:': [] };
 
     // Invert the optionGroups object to a map of optionName to groupName.
     const groupLookup = new Map();
@@ -409,12 +409,12 @@ class Help {
 
     // Options
     const visibleOptionGroups = helper.visibleOptionGroups(cmd, helper);
-      Object.keys(visibleOptionGroups).forEach((groupTitle) => {
-        const optionList = visibleOptionGroups[groupTitle].map((opt) => {
-           return formatItem(helper.optionTerm(opt), helper.optionDescription(opt));
-        });
-        output = output.concat([groupTitle, formatList(optionList), '']);
+    Object.keys(visibleOptionGroups).forEach((groupTitle) => {
+      const optionList = visibleOptionGroups[groupTitle].map((opt) => {
+        return formatItem(helper.optionTerm(opt), helper.optionDescription(opt));
       });
+      output = output.concat([groupTitle, formatList(optionList), '']);
+    });
 
     if (this.showGlobalOptions) {
       const globalOptionList = helper.visibleGlobalOptions(cmd).map((option) => {


### PR DESCRIPTION
# Pull Request

## Problem

See: #1897
Related PR: #1908 #1910

## Solution

This is a proof of concept adding a map of group titles to the Help configuration. This sort of mapping has some advantages compared with adding a group property to each Option:
- specify group title once instead of multiple times
- support for grouping `help` and `version` without needing to create custom Options
- support for grouping user-created options without needing to create custom Options
- (for Command groups, would support putting external commands into groups without extra work)

However, directly supplying the map does not feel very Commander-like. Adding a method on Command to add a single option group at a time might be more in the chaining style while retaining the practical advantages. Adding a group property to the Option would be more object-oriented, and other libraries allow this (https://github.com/tj/commander.js/issues/1897#issuecomment-1610897543).

Playing with the idea partly to think about how Help could be refactored to make this more feasible to implement with an author supplied override.

Example use:
```js
const { program, Option } = require('commander');

program
  .option('-c, --carbon')
  .option('-r, --rabbit', 'cudly little friends')
  .option('-o, --oxygen')
  .addOption(new Option('-s, --sheep'))
  .option('--no-sheep') // negated
  .option('-n', 'neon') // short
  .option('--armadillo') // long
  .option('--zzz')
  .option('--dog', 'faithful furry companions')
  .option('--no-dog')

program.configureHelp({
  optionGroups: {
    'Animal Options:': ['rabbit', 'armadillo', 'sheep', 'dog'],
    'Element Options:': ['carbon', 'oxygen', 'n' /* neon */],
    'Help Options:': ['help']
    }
  }),

program.parse();
```

```console
% node map2-options.js --help
Usage: map2-options [options]

Options:
  --zzz

Animal Options:
  -r, --rabbit  cudly little friends
  -s, --sheep
  --no-sheep
  --armadillo
  --dog         faithful furry companions
  --no-dog

Element Options:
  -c, --carbon
  -o, --oxygen
  -n            neon

Help Options:
  -h, --help    display help for command
```