### PR TITLE
Reformat code with Prettier

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,20 +14,17 @@ const tseslintConfigs = tseslint.config(
     languageOptions: {
       parserOptions: { project: './tsconfig.js.json' },
     },
-    extends: [
-      ...tseslint.configs.recommended,
-    ],
+    extends: [...tseslint.configs.recommended],
     rules: {
       '@typescript-eslint/no-var-requires': 'off', // (tseslint does not autodetect commonjs context )
     },
-  }, {
+  },
+  {
     files: tsconfigTsFiles,
     languageOptions: {
       parserOptions: { project: './tsconfig.ts.json' },
     },
-    extends: [
-      ...tseslint.configs.recommended,
-    ],
+    extends: [...tseslint.configs.recommended],
   },
 );
 
@@ -59,17 +56,20 @@ module.exports = [
     files: ['**/*.test.{js,mjs,cjs}'],
     rules: {
       'no-unused-vars': 'off', // lots in tests, minimise churn for now
-    }
+    },
   },
   {
     files: [...tsconfigTsFiles, ...tsconfigJsFiles],
     rules: {
-      '@typescript-eslint/ban-ts-comment': ['error', {
-        'ts-expect-error': 'allow-with-description',
-        'ts-ignore': 'allow-with-description',
-        'ts-nocheck': true,
-        'ts-check': true,
-    }],
+      '@typescript-eslint/ban-ts-comment': [
+        'error',
+        {
+          'ts-expect-error': 'allow-with-description',
+          'ts-ignore': 'allow-with-description',
+          'ts-nocheck': true,
+          'ts-check': true,
+        },
+      ],
     },
   },
 ];

--- a/esm.mjs
+++ b/esm.mjs
@@ -12,5 +12,5 @@ export const {
   Command,
   Argument,
   Option,
-  Help
+  Help,
 } = commander;

--- a/examples/action-this.js
+++ b/examples/action-this.js
@@ -9,7 +9,7 @@ program
   .command('serve')
   .argument('<script>')
   .option('-p, --port <number>', 'port number', 80)
-  .action(function() {
+  .action(function () {
     console.error('Run script %s on port %s', this.args[0], this.opts().port);
   });
 

--- a/examples/arguments-extra.js
+++ b/examples/arguments-extra.js
@@ -6,8 +6,19 @@ const commander = require('commander');
 const program = new commander.Command();
 
 program
-  .addArgument(new commander.Argument('<drink-size>', 'drink cup size').choices(['small', 'medium', 'large']))
-  .addArgument(new commander.Argument('[timeout]', 'timeout in seconds').default(60, 'one minute'))
+  .addArgument(
+    new commander.Argument('<drink-size>', 'drink cup size').choices([
+      'small',
+      'medium',
+      'large',
+    ]),
+  )
+  .addArgument(
+    new commander.Argument('[timeout]', 'timeout in seconds').default(
+      60,
+      'one minute',
+    ),
+  )
   .action((drinkSize, timeout) => {
     console.log(`Drink size: ${drinkSize}`);
     console.log(`Timeout (s): ${timeout}`);

--- a/examples/configure-help.js
+++ b/examples/configure-help.js
@@ -8,11 +8,17 @@ const program = new commander.Command();
 
 program.configureHelp({
   sortSubcommands: true,
-  subcommandTerm: (cmd) => cmd.name() // Just show the name, instead of short usage.
+  subcommandTerm: (cmd) => cmd.name(), // Just show the name, instead of short usage.
 });
 
-program.command('zebra <herd-size>', 'African equines with distinctive black-and-white striped coats');
-program.command('aardvark [colour]', 'medium-sized, burrowing, nocturnal mammal');
+program.command(
+  'zebra <herd-size>',
+  'African equines with distinctive black-and-white striped coats',
+);
+program.command(
+  'aardvark [colour]',
+  'medium-sized, burrowing, nocturnal mammal',
+);
 program
   .command('beaver', 'large, semiaquatic rodent')
   .option('--pond')

--- a/examples/configure-output.js
+++ b/examples/configure-output.js
@@ -6,19 +6,15 @@ function errorColor(str) {
   return `\x1b[31m${str}\x1b[0m`;
 }
 
-program
-  .configureOutput({
-    // Visibly override write routines as example!
-    writeOut: (str) => process.stdout.write(`[OUT] ${str}`),
-    writeErr: (str) => process.stdout.write(`[ERR] ${str}`),
-    // Output errors in red.
-    outputError: (str, write) => write(errorColor(str))
-  });
+program.configureOutput({
+  // Visibly override write routines as example!
+  writeOut: (str) => process.stdout.write(`[OUT] ${str}`),
+  writeErr: (str) => process.stdout.write(`[ERR] ${str}`),
+  // Output errors in red.
+  outputError: (str, write) => write(errorColor(str)),
+});
 
-program
-  .version('1.2.3')
-  .option('-c, --compress')
-  .command('sub-command');
+program.version('1.2.3').option('-c, --compress').command('sub-command');
 
 program.parse();
 

--- a/examples/custom-command-class.js
+++ b/examples/custom-command-class.js
@@ -32,11 +32,9 @@ program
     inpectCommand(command);
   });
 
-program
-  .command('build <target>')
-  .action((buildTarget, options, command) => {
-    inpectCommand(command);
-  });
+program.command('build <target>').action((buildTarget, options, command) => {
+  inpectCommand(command);
+});
 
 program.parse();
 

--- a/examples/custom-help
+++ b/examples/custom-help
@@ -6,13 +6,15 @@
 const { Command } = require('commander');
 const program = new Command();
 
-program
-  .option('-f, --foo', 'enable some foo');
+program.option('-f, --foo', 'enable some foo');
 
-program.addHelpText('after', `
+program.addHelpText(
+  'after',
+  `
 
 Example call:
-  $ custom-help --help`);
+  $ custom-help --help`,
+);
 
 program.parse(process.argv);
 

--- a/examples/custom-help-text.js
+++ b/examples/custom-help-text.js
@@ -19,10 +19,13 @@ program
 program
   .command('extra')
   .addHelpText('before', 'Note: the extra command does not do anything')
-  .addHelpText('after', `
+  .addHelpText(
+    'after',
+    `
 Examples:
   awesome extra --help
-  awesome help extra`);
+  awesome help extra`,
+  );
 
 program.parse();
 

--- a/examples/deploy
+++ b/examples/deploy
@@ -25,11 +25,19 @@ program
   .option('-e, --exec_mode <mode>', 'Which exec mode to use', 'fast')
   .action((script, options) => {
     console.log('read config from %s', program.opts().config);
-    console.log('exec "%s" using %s mode and config %s', script, options.exec_mode, program.opts().config);
-  }).addHelpText('after', `
+    console.log(
+      'exec "%s" using %s mode and config %s',
+      script,
+      options.exec_mode,
+      program.opts().config,
+    );
+  })
+  .addHelpText(
+    'after',
+    `
 Examples:
   $ deploy exec sequential
-  $ deploy exec async`
+  $ deploy exec async`,
   );
-  
+
 program.parse(process.argv);

--- a/examples/global-options-added.js
+++ b/examples/global-options-added.js
@@ -23,13 +23,15 @@ class MyRootCommand extends Command {
 
 const program = new MyRootCommand();
 
-program.command('print')
+program
+  .command('print')
   .option('--a4', 'Use A4 sized paper')
   .action((options) => {
     console.log('print options: %O', options);
   });
 
-program.command('serve')
+program
+  .command('serve')
   .option('-p, --port <number>', 'port number for server')
   .action((options) => {
     console.log('serve options: %O', options);

--- a/examples/global-options-nested.js
+++ b/examples/global-options-nested.js
@@ -9,9 +9,7 @@
 const { Command } = require('commander');
 const program = new Command();
 
-program
-  .configureHelp({ showGlobalOptions: true })
-  .option('-g, --global');
+program.configureHelp({ showGlobalOptions: true }).option('-g, --global');
 
 program
   .command('sub')
@@ -19,7 +17,7 @@ program
   .action((options, cmd) => {
     console.log({
       opts: cmd.opts(),
-      optsWithGlobals: cmd.optsWithGlobals()
+      optsWithGlobals: cmd.optsWithGlobals(),
     });
   });
 

--- a/examples/help-subcommands-usage.js
+++ b/examples/help-subcommands-usage.js
@@ -6,19 +6,24 @@ const commander = require('commander');
 // See also ./configure-help.js which shows configuring the subcommand list to have no usage at all
 // and just the subcommand name.
 
-const program = new commander.Command()
-  .configureHelp({ subcommandTerm: (cmd) => cmd.name() + ' ' + cmd.usage() });
+const program = new commander.Command().configureHelp({
+  subcommandTerm: (cmd) => cmd.name() + ' ' + cmd.usage(),
+});
 
-program.command('make <FILENAME>')
+program
+  .command('make <FILENAME>')
   .usage('-root ROOTDIR [-abc] <FILENAME>')
   .requiredOption('--root <ROOTDIR>')
   .option('-a')
   .option('-b')
   .option('-c')
   .summary('example command with custom usage')
-  .description('this full description is  displayed in the full help and not in the list of subcommands');
+  .description(
+    'this full description is  displayed in the full help and not in the list of subcommands',
+  );
 
-program.command('serve <SERVICE>')
+program
+  .command('serve <SERVICE>')
   .option('--port <PORTNUMBER>')
   .description('example command with default simple usage');
 

--- a/examples/hook.js
+++ b/examples/hook.js
@@ -24,7 +24,9 @@ program
   .hook('preAction', (thisCommand, actionCommand) => {
     if (thisCommand.opts().trace) {
       console.log('>>>>');
-      console.log(`About to call action handler for subcommand: ${actionCommand.name()}`);
+      console.log(
+        `About to call action handler for subcommand: ${actionCommand.name()}`,
+      );
       console.log('arguments: %O', actionCommand.args);
       console.log('options: %o', actionCommand.opts());
       console.log('<<<<');
@@ -43,13 +45,18 @@ program
     }
   });
 
-program.command('start')
+program
+  .command('start')
   .argument('[script]', 'script name', 'server.js')
   .option('-d, --delay <seconds>', 'how long to delay before starting')
-  .addOption(new Option('-p, --port <number>', 'port number').default(8080).env('PORT'))
-  .action(async(script, options) => {
+  .addOption(
+    new Option('-p, --port <number>', 'port number').default(8080).env('PORT'),
+  )
+  .action(async (script, options) => {
     if (options.delay) {
-      await new Promise(resolve => setTimeout(resolve, parseInt(options.delay) * 1000));
+      await new Promise((resolve) =>
+        setTimeout(resolve, parseInt(options.delay) * 1000),
+      );
     }
     console.log(`Starting ${script} on port ${options.port}`);
   });

--- a/examples/nestedCommands.js
+++ b/examples/nestedCommands.js
@@ -9,31 +9,23 @@ const program = new commander.Command();
 
 // Add nested commands using `.command()`.
 const brew = program.command('brew');
-brew
-  .command('tea')
-  .action(() => {
-    console.log('brew tea');
-  });
-brew
-  .command('coffee')
-  .action(() => {
-    console.log('brew coffee');
-  });
+brew.command('tea').action(() => {
+  console.log('brew tea');
+});
+brew.command('coffee').action(() => {
+  console.log('brew coffee');
+});
 
 // Add nested commands using `.addCommand().
 // The command could be created separately in another module.
 function makeHeatCommand() {
   const heat = new commander.Command('heat');
-  heat
-    .command('jug')
-    .action(() => {
-      console.log('heat jug');
-    });
-  heat
-    .command('pot')
-    .action(() => {
-      console.log('heat pot');
-    });
+  heat.command('jug').action(() => {
+    console.log('heat jug');
+  });
+  heat.command('pot').action(() => {
+    console.log('heat pot');
+  });
   return heat;
 }
 program.addCommand(makeHeatCommand());

--- a/examples/options-boolean-or-value.js
+++ b/examples/options-boolean-or-value.js
@@ -7,8 +7,7 @@
 const commander = require('commander');
 const program = new commander.Command();
 
-program
-  .option('-c, --cheese [type]', 'Add cheese with optional type');
+program.option('-c, --cheese [type]', 'Add cheese with optional type');
 
 program.parse(process.argv);
 

--- a/examples/options-conflicts.js
+++ b/examples/options-conflicts.js
@@ -9,26 +9,32 @@ program
   .addOption(new Option('--credit-card'))
   .action((options) => {
     if (options.cash) {
-      console.log('Paying by cash')
+      console.log('Paying by cash');
     } else if (options.creditCard) {
-      console.log('Paying by credit card')
+      console.log('Paying by credit card');
     } else {
-      console.log('Payment method unknown')
+      console.log('Payment method unknown');
     }
   });
 
-  // The default value for an option does not cause a conflict.
-  // A value specified using an environment variable is checked for conflicts.
+// The default value for an option does not cause a conflict.
+// A value specified using an environment variable is checked for conflicts.
 program
   .command('source')
-  .addOption(new Option('-p, --port <number>', 'port number for server')
-    .default(80)
-    .env('PORT')
-  ).addOption(new Option('--interactive', 'prompt for user input instead of listening to a port')
-    .conflicts('port')
-  ).action((options) => {
+  .addOption(
+    new Option('-p, --port <number>', 'port number for server')
+      .default(80)
+      .env('PORT'),
+  )
+  .addOption(
+    new Option(
+      '--interactive',
+      'prompt for user input instead of listening to a port',
+    ).conflicts('port'),
+  )
+  .action((options) => {
     if (options.interactive) {
-      console.log('What do you want to do today?')
+      console.log('What do you want to do today?');
     } else {
       console.log(`Running server on port: ${options.port}`);
     }
@@ -38,8 +44,18 @@ program
 // A negated option is not separate from the positive option for conflicts (they have same option name).
 program
   .command('paint')
-  .addOption(new Option('--summer', 'use a mixture of summer colors').conflicts(['autumn', 'colour']))
-  .addOption(new Option('--autumn', 'use a mixture of autumn colors').conflicts(['summer', 'colour']))
+  .addOption(
+    new Option('--summer', 'use a mixture of summer colors').conflicts([
+      'autumn',
+      'colour',
+    ]),
+  )
+  .addOption(
+    new Option('--autumn', 'use a mixture of autumn colors').conflicts([
+      'summer',
+      'colour',
+    ]),
+  )
   .addOption(new Option('--colour <shade>', 'use a single solid colour'))
   .addOption(new Option('--no-colour', 'leave surface natural'))
   .action((options) => {
@@ -54,7 +70,7 @@ program
       colour = 'autumn';
     }
     console.log(`Painting colour is ${colour}`);
-    });
+  });
 
 program.parse();
 

--- a/examples/options-custom-processing.js
+++ b/examples/options-custom-processing.js
@@ -31,10 +31,14 @@ function commaSeparatedList(value) {
 program
   .option('-f, --float <number>', 'float argument', parseFloat)
   .option('-i, --integer <number>', 'integer argument', myParseInt)
-  .option('-v, --verbose', 'verbosity that can be increased', increaseVerbosity, 0)
+  .option(
+    '-v, --verbose',
+    'verbosity that can be increased',
+    increaseVerbosity,
+    0,
+  )
   .option('-c, --collect <value>', 'repeatable value', collect, [])
-  .option('-l, --list <items>', 'comma separated list', commaSeparatedList)
-;
+  .option('-l, --list <items>', 'comma separated list', commaSeparatedList);
 
 program.parse();
 

--- a/examples/options-defaults.js
+++ b/examples/options-defaults.js
@@ -6,8 +6,11 @@
 const commander = require('commander');
 const program = new commander.Command();
 
-program
-  .option('-c, --cheese <type>', 'Add the specified type of cheese', 'blue');
+program.option(
+  '-c, --cheese <type>',
+  'Add the specified type of cheese',
+  'blue',
+);
 
 program.parse();
 

--- a/examples/options-env.js
+++ b/examples/options-env.js
@@ -2,19 +2,21 @@
 const { Command, Option } = require('commander');
 const program = new Command();
 
-program.addOption(new Option('-p, --port <number>', 'specify port number')
-  .default(80)
-  .env('PORT')
+program.addOption(
+  new Option('-p, --port <number>', 'specify port number')
+    .default(80)
+    .env('PORT'),
 );
-program.addOption(new Option('-c, --colour', 'turn on colour output')
-  .env('COLOUR')
+program.addOption(
+  new Option('-c, --colour', 'turn on colour output').env('COLOUR'),
 );
-program.addOption(new Option('-C, --no-colour', 'turn off colour output')
-  .env('NO_COLOUR')
+program.addOption(
+  new Option('-C, --no-colour', 'turn off colour output').env('NO_COLOUR'),
 );
-program.addOption(new Option('-s, --size <type>', 'specify size of drink')
-  .choices(['small', 'medium', 'large'])
-  .env('SIZE')
+program.addOption(
+  new Option('-s, --size <type>', 'specify size of drink')
+    .choices(['small', 'medium', 'large'])
+    .env('SIZE'),
 );
 
 program.parse();

--- a/examples/options-extra.js
+++ b/examples/options-extra.js
@@ -9,12 +9,33 @@ const program = new Command();
 
 program
   .addOption(new Option('-s, --secret').hideHelp())
-  .addOption(new Option('-t, --timeout <delay>', 'timeout in seconds').default(60, 'one minute'))
-  .addOption(new Option('-d, --drink <size>', 'drink cup size').choices(['small', 'medium', 'large']))
+  .addOption(
+    new Option('-t, --timeout <delay>', 'timeout in seconds').default(
+      60,
+      'one minute',
+    ),
+  )
+  .addOption(
+    new Option('-d, --drink <size>', 'drink cup size').choices([
+      'small',
+      'medium',
+      'large',
+    ]),
+  )
   .addOption(new Option('-p, --port <number>', 'port number').env('PORT'))
-  .addOption(new Option('--donate [amount]', 'optional donation in dollars').preset('20').argParser(parseFloat))
-  .addOption(new Option('--disable-server', 'disables the server').conflicts('port'))
-  .addOption(new Option('--free-drink', 'small drink included free ').implies({ drink: 'small' }));
+  .addOption(
+    new Option('--donate [amount]', 'optional donation in dollars')
+      .preset('20')
+      .argParser(parseFloat),
+  )
+  .addOption(
+    new Option('--disable-server', 'disables the server').conflicts('port'),
+  )
+  .addOption(
+    new Option('--free-drink', 'small drink included free ').implies({
+      drink: 'small',
+    }),
+  );
 
 program.parse();
 

--- a/examples/options-implies.js
+++ b/examples/options-implies.js
@@ -4,9 +4,22 @@ const program = new Command();
 
 program
   .addOption(new Option('--quiet').implies({ logLevel: 'off' }))
-  .addOption(new Option('--log-level <level>').choices(['info', 'warning', 'error', 'off']).default('info'))
-  .addOption(new Option('-c, --cheese <type>', 'Add the specified type of cheese').implies({ dairy: true }))
-  .addOption(new Option('--no-cheese', 'You do not want any cheese').implies({ dairy: false }))
+  .addOption(
+    new Option('--log-level <level>')
+      .choices(['info', 'warning', 'error', 'off'])
+      .default('info'),
+  )
+  .addOption(
+    new Option(
+      '-c, --cheese <type>',
+      'Add the specified type of cheese',
+    ).implies({ dairy: true }),
+  )
+  .addOption(
+    new Option('--no-cheese', 'You do not want any cheese').implies({
+      dairy: false,
+    }),
+  )
   .addOption(new Option('--dairy', 'May contain dairy'));
 
 program.parse();

--- a/examples/options-negatable.js
+++ b/examples/options-negatable.js
@@ -16,7 +16,8 @@ program.parse();
 
 const options = program.opts();
 const sauceStr = options.sauce ? 'sauce' : 'no sauce';
-const cheeseStr = (options.cheese === false) ? 'no cheese' : `${options.cheese} cheese`;
+const cheeseStr =
+  options.cheese === false ? 'no cheese' : `${options.cheese} cheese`;
 console.log(`You ordered a pizza with ${sauceStr} and ${cheeseStr}`);
 
 // Try the following:

--- a/examples/options-required.js
+++ b/examples/options-required.js
@@ -8,8 +8,7 @@
 const commander = require('commander');
 const program = new commander.Command();
 
-program
-  .requiredOption('-c, --cheese <type>', 'pizza must have cheese');
+program.requiredOption('-c, --cheese <type>', 'pizza must have cheese');
 
 program.parse();
 

--- a/examples/pizza
+++ b/examples/pizza
@@ -18,9 +18,9 @@ const cheese = !options.cheese ? 'no' : options.cheese;
 console.log('  - %s cheese', cheese);
 
 // Try the following on macOS or Linux:
-//    ./pizza --help    
+//    ./pizza --help
 //
 // Try the following:
-//    ./pizza --help    
+//    ./pizza --help
 //    node pizza --peppers --cheese=blue
 //    node pizza --no-cheese

--- a/examples/pm
+++ b/examples/pm
@@ -14,9 +14,13 @@ program
   .name('pm')
   .version('0.0.1')
   .description('Fake package manager')
-  .command('install [name]', 'install one or more packages').alias('i')
-  .command('search [query]', 'search with optional query').alias('s')
-  .command('update', 'update installed packages', { executableFile: 'myUpdateSubCommand' })
+  .command('install [name]', 'install one or more packages')
+  .alias('i')
+  .command('search [query]', 'search with optional query')
+  .alias('s')
+  .command('update', 'update installed packages', {
+    executableFile: 'myUpdateSubCommand',
+  })
   .command('list', 'list packages installed', { isDefault: true });
 
 program.parse(process.argv);

--- a/examples/pm-install
+++ b/examples/pm-install
@@ -3,8 +3,7 @@
 const { Command } = require('commander');
 const program = new Command();
 
-program
-  .option('-f, --force', 'force installation');
+program.option('-f, --force', 'force installation');
 
 program.parse(process.argv);
 
@@ -17,7 +16,7 @@ if (!pkgs.length) {
 
 console.log();
 if (program.opts().force) console.log('  force: install');
-pkgs.forEach(function(pkg) {
+pkgs.forEach(function (pkg) {
   console.log('  install : %s', pkg);
 });
 console.log();

--- a/examples/positional-options.js
+++ b/examples/positional-options.js
@@ -3,9 +3,7 @@
 const { Command } = require('commander');
 const program = new Command();
 
-program
-  .enablePositionalOptions()
-  .option('-p, --progress');
+program.enablePositionalOptions().option('-p, --progress');
 
 program
   .command('upload <file>')

--- a/examples/split.js
+++ b/examples/split.js
@@ -2,9 +2,7 @@ const { program } = require('commander');
 
 // This is used as an example in the README for the Quick Start.
 
-program
-  .option('--first')
-  .option('-s, --separator <char>');
+program.option('--first').option('-s, --separator <char>');
 
 program.parse();
 

--- a/examples/string-util.js
+++ b/examples/string-util.js
@@ -8,7 +8,8 @@ program
   .description('CLI to some JavaScript string utilities')
   .version('0.8.0');
 
-program.command('split')
+program
+  .command('split')
   .description('Split a string into substrings and display as an array.')
   .argument('<string>', 'string to split')
   .option('--first', 'display just the first substring')
@@ -18,7 +19,8 @@ program.command('split')
     console.log(str.split(options.separator, limit));
   });
 
-program.command('join')
+program
+  .command('join')
   .description('Join the command-arguments into a single string')
   .argument('<strings...>', 'one or more strings')
   .option('-s, --separator <char>', 'separator character', ',')

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,11 +2,9 @@ const config = {
   testEnvironment: 'node',
   collectCoverage: true,
   transform: {
-    '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.ts.json' }]
+    '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.ts.json' }],
   },
-  testPathIgnorePatterns: [
-    '/node_modules/'
-  ]
+  testPathIgnorePatterns: ['/node_modules/'],
 };
 
 module.exports = config;

--- a/lib/argument.js
+++ b/lib/argument.js
@@ -98,7 +98,9 @@ class Argument {
     this.argChoices = values.slice();
     this.parseArg = (arg, previous) => {
       if (!this.argChoices.includes(arg)) {
-        throw new InvalidArgumentError(`Allowed choices are ${this.argChoices.join(', ')}.`);
+        throw new InvalidArgumentError(
+          `Allowed choices are ${this.argChoices.join(', ')}.`,
+        );
       }
       if (this.variadic) {
         return this._concatValue(arg, previous);
@@ -136,9 +138,7 @@ class Argument {
 function humanReadableArgName(arg) {
   const nameOutput = arg.name() + (arg.variadic === true ? '...' : '');
 
-  return arg.required
-    ? '<' + nameOutput + '>'
-    : '[' + nameOutput + ']';
+  return arg.required ? '<' + nameOutput + '>' : '[' + nameOutput + ']';
 }
 
 exports.Argument = Argument;

--- a/lib/command.js
+++ b/lib/command.js
@@ -60,9 +60,11 @@ class Command extends EventEmitter {
     this._outputConfiguration = {
       writeOut: (str) => process.stdout.write(str),
       writeErr: (str) => process.stderr.write(str),
-      getOutHelpWidth: () => process.stdout.isTTY ? process.stdout.columns : undefined,
-      getErrHelpWidth: () => process.stderr.isTTY ? process.stderr.columns : undefined,
-      outputError: (str, write) => write(str)
+      getOutHelpWidth: () =>
+        process.stdout.isTTY ? process.stdout.columns : undefined,
+      getErrHelpWidth: () =>
+        process.stderr.isTTY ? process.stderr.columns : undefined,
+      outputError: (str, write) => write(str),
     };
 
     this._hidden = false;
@@ -89,7 +91,8 @@ class Command extends EventEmitter {
     this._helpConfiguration = sourceCommand._helpConfiguration;
     this._exitCallback = sourceCommand._exitCallback;
     this._storeOptionsAsProperties = sourceCommand._storeOptionsAsProperties;
-    this._combineFlagAndOptionalValue = sourceCommand._combineFlagAndOptionalValue;
+    this._combineFlagAndOptionalValue =
+      sourceCommand._combineFlagAndOptionalValue;
     this._allowExcessArguments = sourceCommand._allowExcessArguments;
     this._enablePositionalOptions = sourceCommand._enablePositionalOptions;
     this._showHelpAfterError = sourceCommand._showHelpAfterError;
@@ -335,9 +338,12 @@ class Command extends EventEmitter {
    */
 
   arguments(names) {
-    names.trim().split(/ +/).forEach((detail) => {
-      this.argument(detail);
-    });
+    names
+      .trim()
+      .split(/ +/)
+      .forEach((detail) => {
+        this.argument(detail);
+      });
     return this;
   }
 
@@ -350,10 +356,18 @@ class Command extends EventEmitter {
   addArgument(argument) {
     const previousArgument = this.registeredArguments.slice(-1)[0];
     if (previousArgument && previousArgument.variadic) {
-      throw new Error(`only the last argument can be variadic '${previousArgument.name()}'`);
+      throw new Error(
+        `only the last argument can be variadic '${previousArgument.name()}'`,
+      );
     }
-    if (argument.required && argument.defaultValue !== undefined && argument.parseArg === undefined) {
-      throw new Error(`a default value for a required argument is never used: '${argument.name()}'`);
+    if (
+      argument.required &&
+      argument.defaultValue !== undefined &&
+      argument.parseArg === undefined
+    ) {
+      throw new Error(
+        `a default value for a required argument is never used: '${argument.name()}'`,
+      );
     }
     this.registeredArguments.push(argument);
     return this;
@@ -421,8 +435,11 @@ class Command extends EventEmitter {
    * @package
    */
   _getHelpCommand() {
-    const hasImplicitHelpCommand = this._addImplicitHelpCommand ??
-      (this.commands.length && !this._actionHandler && !this._findCommand('help'));
+    const hasImplicitHelpCommand =
+      this._addImplicitHelpCommand ??
+      (this.commands.length &&
+        !this._actionHandler &&
+        !this._findCommand('help'));
 
     if (hasImplicitHelpCommand) {
       if (this._helpCommand === undefined) {
@@ -574,10 +591,14 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   _registerOption(option) {
-    const matchingOption = (option.short && this._findOption(option.short)) ||
+    const matchingOption =
+      (option.short && this._findOption(option.short)) ||
       (option.long && this._findOption(option.long));
     if (matchingOption) {
-      const matchingFlag = (option.long && this._findOption(option.long)) ? option.long : option.short;
+      const matchingFlag =
+        option.long && this._findOption(option.long)
+          ? option.long
+          : option.short;
       throw new Error(`Cannot add option '${option.flags}'${this._name && ` to command '${this._name}'`} due to conflicting flag '${matchingFlag}'
 -  already used by option '${matchingOption.flags}'`);
     }
@@ -598,11 +619,15 @@ Expecting one of '${allowedValues.join("', '")}'`);
       return [cmd.name()].concat(cmd.aliases());
     };
 
-    const alreadyUsed = knownBy(command).find((name) => this._findCommand(name));
+    const alreadyUsed = knownBy(command).find((name) =>
+      this._findCommand(name),
+    );
     if (alreadyUsed) {
       const existingCmd = knownBy(this._findCommand(alreadyUsed)).join('|');
       const newCmd = knownBy(command).join('|');
-      throw new Error(`cannot add command '${newCmd}' as already have command '${existingCmd}'`);
+      throw new Error(
+        `cannot add command '${newCmd}' as already have command '${existingCmd}'`,
+      );
     }
 
     this.commands.push(command);
@@ -625,7 +650,11 @@ Expecting one of '${allowedValues.join("', '")}'`);
       // --no-foo is special and defaults foo to true, unless a --foo option is already defined
       const positiveLongFlag = option.long.replace(/^--no-/, '--');
       if (!this._findOption(positiveLongFlag)) {
-        this.setOptionValueWithSource(name, option.defaultValue === undefined ? true : option.defaultValue, 'default');
+        this.setOptionValueWithSource(
+          name,
+          option.defaultValue === undefined ? true : option.defaultValue,
+          'default',
+        );
       }
     } else if (option.defaultValue !== undefined) {
       this.setOptionValueWithSource(name, option.defaultValue, 'default');
@@ -682,7 +711,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
   _optionEx(config, flags, description, fn, defaultValue) {
     if (typeof flags === 'object' && flags instanceof Option) {
-      throw new Error('To add an Option object use addOption() instead of option() or requiredOption()');
+      throw new Error(
+        'To add an Option object use addOption() instead of option() or requiredOption()',
+      );
     }
     const option = this.createOption(flags, description);
     option.makeOptionMandatory(!!config.mandatory);
@@ -730,20 +761,26 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   /**
-  * Add a required option which must have a value after parsing. This usually means
-  * the option must be specified on the command line. (Otherwise the same as .option().)
-  *
-  * The `flags` string contains the short and/or long flags, separated by comma, a pipe or space.
-  *
-  * @param {string} flags
-  * @param {string} [description]
-  * @param {(Function|*)} [parseArg] - custom option processing function or default value
-  * @param {*} [defaultValue]
-  * @return {Command} `this` command for chaining
-  */
+   * Add a required option which must have a value after parsing. This usually means
+   * the option must be specified on the command line. (Otherwise the same as .option().)
+   *
+   * The `flags` string contains the short and/or long flags, separated by comma, a pipe or space.
+   *
+   * @param {string} flags
+   * @param {string} [description]
+   * @param {(Function|*)} [parseArg] - custom option processing function or default value
+   * @param {*} [defaultValue]
+   * @return {Command} `this` command for chaining
+   */
 
   requiredOption(flags, description, parseArg, defaultValue) {
-    return this._optionEx({ mandatory: true }, flags, description, parseArg, defaultValue);
+    return this._optionEx(
+      { mandatory: true },
+      flags,
+      description,
+      parseArg,
+      defaultValue,
+    );
   }
 
   /**
@@ -815,25 +852,33 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   _checkForBrokenPassThrough() {
-    if (this.parent && this._passThroughOptions && !this.parent._enablePositionalOptions) {
-      throw new Error(`passThroughOptions cannot be used for '${this._name}' without turning on enablePositionalOptions for parent command(s)`);
+    if (
+      this.parent &&
+      this._passThroughOptions &&
+      !this.parent._enablePositionalOptions
+    ) {
+      throw new Error(
+        `passThroughOptions cannot be used for '${this._name}' without turning on enablePositionalOptions for parent command(s)`,
+      );
     }
   }
 
   /**
-    * Whether to store option values as properties on command object,
-    * or store separately (specify false). In both cases the option values can be accessed using .opts().
-    *
-    * @param {boolean} [storeAsProperties=true]
-    * @return {Command} `this` command for chaining
-    */
+   * Whether to store option values as properties on command object,
+   * or store separately (specify false). In both cases the option values can be accessed using .opts().
+   *
+   * @param {boolean} [storeAsProperties=true]
+   * @return {Command} `this` command for chaining
+   */
 
   storeOptionsAsProperties(storeAsProperties = true) {
     if (this.options.length) {
       throw new Error('call .storeOptionsAsProperties() before adding options');
     }
     if (Object.keys(this._optionValues).length) {
-      throw new Error('call .storeOptionsAsProperties() before setting option values');
+      throw new Error(
+        'call .storeOptionsAsProperties() before setting option values',
+      );
     }
     this._storeOptionsAsProperties = !!storeAsProperties;
     return this;
@@ -866,13 +911,13 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   /**
-    * Store option value and where the value came from.
-    *
-    * @param {string} key
-    * @param {Object} value
-    * @param {string} source - expected values are default/config/env/cli/implied
-    * @return {Command} `this` command for chaining
-    */
+   * Store option value and where the value came from.
+   *
+   * @param {string} key
+   * @param {Object} value
+   * @param {string} source - expected values are default/config/env/cli/implied
+   * @return {Command} `this` command for chaining
+   */
 
   setOptionValueWithSource(key, value, source) {
     if (this._storeOptionsAsProperties) {
@@ -885,24 +930,24 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   /**
-    * Get source of option value.
-    * Expected values are default | config | env | cli | implied
-    *
-    * @param {string} key
-    * @return {string}
-    */
+   * Get source of option value.
+   * Expected values are default | config | env | cli | implied
+   *
+   * @param {string} key
+   * @return {string}
+   */
 
   getOptionValueSource(key) {
     return this._optionValueSources[key];
   }
 
   /**
-    * Get source of option value. See also .optsWithGlobals().
-    * Expected values are default | config | env | cli | implied
-    *
-    * @param {string} key
-    * @return {string}
-    */
+   * Get source of option value. See also .optsWithGlobals().
+   * Expected values are default | config | env | cli | implied
+   *
+   * @param {string} key
+   * @return {string}
+   */
 
   getOptionValueSourceWithGlobals(key) {
     // global overwrites local, like optsWithGlobals
@@ -958,11 +1003,14 @@ Expecting one of '${allowedValues.join("', '")}'`);
         userArgs = argv.slice(0);
         break;
       default:
-        throw new Error(`unexpected parse option { from: '${parseOptions.from}' }`);
+        throw new Error(
+          `unexpected parse option { from: '${parseOptions.from}' }`,
+        );
     }
 
     // Find default name for program from arguments.
-    if (!this._name && this._scriptPath) this.nameFromFilename(this._scriptPath);
+    if (!this._name && this._scriptPath)
+      this.nameFromFilename(this._scriptPath);
     this._name = this._name || 'program';
 
     return userArgs;
@@ -1038,7 +1086,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
       if (sourceExt.includes(path.extname(baseName))) return undefined;
 
       // Try all the extensions.
-      const foundExt = sourceExt.find(ext => fs.existsSync(`${localBin}${ext}`));
+      const foundExt = sourceExt.find((ext) =>
+        fs.existsSync(`${localBin}${ext}`),
+      );
       if (foundExt) return `${localBin}${foundExt}`;
 
       return undefined;
@@ -1049,7 +1099,8 @@ Expecting one of '${allowedValues.join("', '")}'`);
     this._checkForConflictingOptions();
 
     // executableFile and executableDir might be full path, or just a name
-    let executableFile = subcommand._executableFile || `${this._name}-${subcommand._name}`;
+    let executableFile =
+      subcommand._executableFile || `${this._name}-${subcommand._name}`;
     let executableDir = this._executableDir || '';
     if (this._scriptPath) {
       let resolvedScriptPath; // resolve possible symlink for installed npm binary
@@ -1058,7 +1109,10 @@ Expecting one of '${allowedValues.join("', '")}'`);
       } catch (err) {
         resolvedScriptPath = this._scriptPath;
       }
-      executableDir = path.resolve(path.dirname(resolvedScriptPath), executableDir);
+      executableDir = path.resolve(
+        path.dirname(resolvedScriptPath),
+        executableDir,
+      );
     }
 
     // Look for a local file in preference to a command in PATH.
@@ -1067,9 +1121,15 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
       // Legacy search using prefix of script name instead of command name
       if (!localFile && !subcommand._executableFile && this._scriptPath) {
-        const legacyName = path.basename(this._scriptPath, path.extname(this._scriptPath));
+        const legacyName = path.basename(
+          this._scriptPath,
+          path.extname(this._scriptPath),
+        );
         if (legacyName !== this._name) {
-          localFile = findFile(executableDir, `${legacyName}-${subcommand._name}`);
+          localFile = findFile(
+            executableDir,
+            `${legacyName}-${subcommand._name}`,
+          );
         }
       }
       executableFile = localFile || executableFile;
@@ -1095,7 +1155,8 @@ Expecting one of '${allowedValues.join("', '")}'`);
       proc = childProcess.spawn(process.execPath, args, { stdio: 'inherit' });
     }
 
-    if (!proc.killed) { // testing mainly to avoid leak warnings during unit tests with mocked spawn
+    if (!proc.killed) {
+      // testing mainly to avoid leak warnings during unit tests with mocked spawn
       const signals = ['SIGUSR1', 'SIGUSR2', 'SIGTERM', 'SIGINT', 'SIGHUP'];
       signals.forEach((signal) => {
         process.on(signal, () => {
@@ -1113,11 +1174,17 @@ Expecting one of '${allowedValues.join("', '")}'`);
       if (!exitCallback) {
         process.exit(code);
       } else {
-        exitCallback(new CommanderError(code, 'commander.executeSubCommandAsync', '(close)'));
+        exitCallback(
+          new CommanderError(
+            code,
+            'commander.executeSubCommandAsync',
+            '(close)',
+          ),
+        );
       }
     });
     proc.on('error', (err) => {
-      // @ts-ignore: because err.code is an unknown property  
+      // @ts-ignore: because err.code is an unknown property
       if (err.code === 'ENOENT') {
         const executableDirMessage = executableDir
           ? `searched for local subcommand relative to directory '${executableDir}'`
@@ -1127,14 +1194,18 @@ Expecting one of '${allowedValues.join("', '")}'`);
  - if the default executable name is not suitable, use the executableFile option to supply a custom name or path
  - ${executableDirMessage}`;
         throw new Error(executableMissing);
-      // @ts-ignore: because err.code is an unknown property
+        // @ts-ignore: because err.code is an unknown property
       } else if (err.code === 'EACCES') {
         throw new Error(`'${executableFile}' not executable`);
       }
       if (!exitCallback) {
         process.exit(1);
       } else {
-        const wrappedError = new CommanderError(1, 'commander.executeSubCommandAsync', '(error)');
+        const wrappedError = new CommanderError(
+          1,
+          'commander.executeSubCommandAsync',
+          '(error)',
+        );
         wrappedError.nestedError = err;
         exitCallback(wrappedError);
       }
@@ -1153,7 +1224,11 @@ Expecting one of '${allowedValues.join("', '")}'`);
     if (!subCommand) this.help({ error: true });
 
     let promiseChain;
-    promiseChain = this._chainOrCallSubCommandHook(promiseChain, subCommand, 'preSubcommand');
+    promiseChain = this._chainOrCallSubCommandHook(
+      promiseChain,
+      subCommand,
+      'preSubcommand',
+    );
     promiseChain = this._chainOrCall(promiseChain, () => {
       if (subCommand._executableHandler) {
         this._executeSubCommand(subCommand, operands.concat(unknown));
@@ -1181,9 +1256,11 @@ Expecting one of '${allowedValues.join("', '")}'`);
     }
 
     // Fallback to parsing the help flag to invoke the help.
-    return this._dispatchSubcommand(subcommandName, [], [
-      this._getHelpOption()?.long ?? this._getHelpOption()?.short ?? '--help'
-    ]);
+    return this._dispatchSubcommand(
+      subcommandName,
+      [],
+      [this._getHelpOption()?.long ?? this._getHelpOption()?.short ?? '--help'],
+    );
   }
 
   /**
@@ -1200,7 +1277,10 @@ Expecting one of '${allowedValues.join("', '")}'`);
       }
     });
     // too many
-    if (this.registeredArguments.length > 0 && this.registeredArguments[this.registeredArguments.length - 1].variadic) {
+    if (
+      this.registeredArguments.length > 0 &&
+      this.registeredArguments[this.registeredArguments.length - 1].variadic
+    ) {
       return;
     }
     if (this.args.length > this.registeredArguments.length) {
@@ -1220,7 +1300,12 @@ Expecting one of '${allowedValues.join("', '")}'`);
       let parsedValue = value;
       if (value !== null && argument.parseArg) {
         const invalidValueMessage = `error: command-argument value '${value}' is invalid for argument '${argument.name()}'.`;
-        parsedValue = this._callParseArg(argument, value, previous, invalidValueMessage);
+        parsedValue = this._callParseArg(
+          argument,
+          value,
+          previous,
+          invalidValueMessage,
+        );
       }
       return parsedValue;
     };
@@ -1285,8 +1370,8 @@ Expecting one of '${allowedValues.join("', '")}'`);
     const hooks = [];
     this._getCommandAndAncestors()
       .reverse()
-      .filter(cmd => cmd._lifeCycleHooks[event] !== undefined)
-      .forEach(hookedCommand => {
+      .filter((cmd) => cmd._lifeCycleHooks[event] !== undefined)
+      .forEach((hookedCommand) => {
         hookedCommand._lifeCycleHooks[event].forEach((callback) => {
           hooks.push({ hookedCommand, callback });
         });
@@ -1342,14 +1427,26 @@ Expecting one of '${allowedValues.join("', '")}'`);
     if (operands && this._findCommand(operands[0])) {
       return this._dispatchSubcommand(operands[0], operands.slice(1), unknown);
     }
-    if (this._getHelpCommand() && operands[0] === this._getHelpCommand().name()) {
+    if (
+      this._getHelpCommand() &&
+      operands[0] === this._getHelpCommand().name()
+    ) {
       return this._dispatchHelpCommand(operands[1]);
     }
     if (this._defaultCommandName) {
       this._outputHelpIfRequested(unknown); // Run the help for default command from parent rather than passing to default command
-      return this._dispatchSubcommand(this._defaultCommandName, operands, unknown);
+      return this._dispatchSubcommand(
+        this._defaultCommandName,
+        operands,
+        unknown,
+      );
     }
-    if (this.commands.length && this.args.length === 0 && !this._actionHandler && !this._defaultCommandName) {
+    if (
+      this.commands.length &&
+      this.args.length === 0 &&
+      !this._actionHandler &&
+      !this._defaultCommandName
+    ) {
       // probably missing subcommand and no handler, user needs help (and exit)
       this.help({ error: true });
     }
@@ -1372,7 +1469,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
       let promiseChain;
       promiseChain = this._chainOrCallHooks(promiseChain, 'preAction');
-      promiseChain = this._chainOrCall(promiseChain, () => this._actionHandler(this.processedArgs));
+      promiseChain = this._chainOrCall(promiseChain, () =>
+        this._actionHandler(this.processedArgs),
+      );
       if (this.parent) {
         promiseChain = this._chainOrCall(promiseChain, () => {
           this.parent.emit(commandEvent, operands, unknown); // legacy
@@ -1386,7 +1485,8 @@ Expecting one of '${allowedValues.join("', '")}'`);
       this._processArguments();
       this.parent.emit(commandEvent, operands, unknown); // legacy
     } else if (operands.length) {
-      if (this._findCommand('*')) { // legacy default command
+      if (this._findCommand('*')) {
+        // legacy default command
         return this._dispatchSubcommand('*', operands, unknown);
       }
       if (this.listenerCount('command:*')) {
@@ -1416,7 +1516,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
   _findCommand(name) {
     if (!name) return undefined;
-    return this.commands.find(cmd => cmd._name === name || cmd._aliases.includes(name));
+    return this.commands.find(
+      (cmd) => cmd._name === name || cmd._aliases.includes(name),
+    );
   }
 
   /**
@@ -1428,7 +1530,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
 
   _findOption(arg) {
-    return this.options.find(option => option.is(arg));
+    return this.options.find((option) => option.is(arg));
   }
 
   /**
@@ -1442,7 +1544,10 @@ Expecting one of '${allowedValues.join("', '")}'`);
     // Walk up hierarchy so can call in subcommand after checking for displaying help.
     this._getCommandAndAncestors().forEach((cmd) => {
       cmd.options.forEach((anOption) => {
-        if (anOption.mandatory && (cmd.getOptionValue(anOption.attributeName()) === undefined)) {
+        if (
+          anOption.mandatory &&
+          cmd.getOptionValue(anOption.attributeName()) === undefined
+        ) {
           cmd.missingMandatoryOptionValue(anOption);
         }
       });
@@ -1455,23 +1560,21 @@ Expecting one of '${allowedValues.join("', '")}'`);
    * @private
    */
   _checkForConflictingLocalOptions() {
-    const definedNonDefaultOptions = this.options.filter(
-      (option) => {
-        const optionKey = option.attributeName();
-        if (this.getOptionValue(optionKey) === undefined) {
-          return false;
-        }
-        return this.getOptionValueSource(optionKey) !== 'default';
+    const definedNonDefaultOptions = this.options.filter((option) => {
+      const optionKey = option.attributeName();
+      if (this.getOptionValue(optionKey) === undefined) {
+        return false;
       }
-    );
+      return this.getOptionValueSource(optionKey) !== 'default';
+    });
 
     const optionsWithConflicting = definedNonDefaultOptions.filter(
-      (option) => option.conflictsWith.length > 0
+      (option) => option.conflictsWith.length > 0,
     );
 
     optionsWithConflicting.forEach((option) => {
       const conflictingAndDefined = definedNonDefaultOptions.find((defined) =>
-        option.conflictsWith.includes(defined.attributeName())
+        option.conflictsWith.includes(defined.attributeName()),
       );
       if (conflictingAndDefined) {
         this._conflictingOption(option, conflictingAndDefined);
@@ -1551,7 +1654,8 @@ Expecting one of '${allowedValues.join("', '")}'`);
               value = args.shift();
             }
             this.emit(`option:${option.name()}`, value);
-          } else { // boolean flag
+          } else {
+            // boolean flag
             this.emit(`option:${option.name()}`);
           }
           activeVariadicOption = option.variadic ? option : null;
@@ -1563,7 +1667,10 @@ Expecting one of '${allowedValues.join("', '")}'`);
       if (arg.length > 2 && arg[0] === '-' && arg[1] !== '-') {
         const option = this._findOption(`-${arg[1]}`);
         if (option) {
-          if (option.required || (option.optional && this._combineFlagAndOptionalValue)) {
+          if (
+            option.required ||
+            (option.optional && this._combineFlagAndOptionalValue)
+          ) {
             // option with value following in same argument
             this.emit(`option:${option.name()}`, arg.slice(2));
           } else {
@@ -1594,12 +1701,19 @@ Expecting one of '${allowedValues.join("', '")}'`);
       }
 
       // If using positionalOptions, stop processing our options at subcommand.
-      if ((this._enablePositionalOptions || this._passThroughOptions) && operands.length === 0 && unknown.length === 0) {
+      if (
+        (this._enablePositionalOptions || this._passThroughOptions) &&
+        operands.length === 0 &&
+        unknown.length === 0
+      ) {
         if (this._findCommand(arg)) {
           operands.push(arg);
           if (args.length > 0) unknown.push(...args);
           break;
-        } else if (this._getHelpCommand() && arg === this._getHelpCommand().name()) {
+        } else if (
+          this._getHelpCommand() &&
+          arg === this._getHelpCommand().name()
+        ) {
           operands.push(arg);
           if (args.length > 0) operands.push(...args);
           break;
@@ -1637,7 +1751,8 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
       for (let i = 0; i < len; i++) {
         const key = this.options[i].attributeName();
-        result[key] = key === this._versionOptionName ? this._version : this[key];
+        result[key] =
+          key === this._versionOptionName ? this._version : this[key];
       }
       return result;
     }
@@ -1654,7 +1769,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     // globals overwrite locals
     return this._getCommandAndAncestors().reduce(
       (combinedOptions, cmd) => Object.assign(combinedOptions, cmd.opts()),
-      {}
+      {},
     );
   }
 
@@ -1668,7 +1783,10 @@ Expecting one of '${allowedValues.join("', '")}'`);
    */
   error(message, errorOptions) {
     // output handling
-    this._outputConfiguration.outputError(`${message}\n`, this._outputConfiguration.writeErr);
+    this._outputConfiguration.outputError(
+      `${message}\n`,
+      this._outputConfiguration.writeErr,
+    );
     if (typeof this._showHelpAfterError === 'string') {
       this._outputConfiguration.writeErr(`${this._showHelpAfterError}\n`);
     } else if (this._showHelpAfterError) {
@@ -1694,11 +1812,18 @@ Expecting one of '${allowedValues.join("', '")}'`);
       if (option.envVar && option.envVar in process.env) {
         const optionKey = option.attributeName();
         // Priority check. Do not overwrite cli or options from unknown source (client-code).
-        if (this.getOptionValue(optionKey) === undefined || ['default', 'config', 'env'].includes(this.getOptionValueSource(optionKey))) {
-          if (option.required || option.optional) { // option can take a value
+        if (
+          this.getOptionValue(optionKey) === undefined ||
+          ['default', 'config', 'env'].includes(
+            this.getOptionValueSource(optionKey),
+          )
+        ) {
+          if (option.required || option.optional) {
+            // option can take a value
             // keep very simple, optional always takes value
             this.emit(`optionEnv:${option.name()}`, process.env[option.envVar]);
-          } else { // boolean
+          } else {
+            // boolean
             // keep very simple, only care that envVar defined and not the value
             this.emit(`optionEnv:${option.name()}`);
           }
@@ -1715,17 +1840,30 @@ Expecting one of '${allowedValues.join("', '")}'`);
   _parseOptionsImplied() {
     const dualHelper = new DualOptions(this.options);
     const hasCustomOptionValue = (optionKey) => {
-      return this.getOptionValue(optionKey) !== undefined && !['default', 'implied'].includes(this.getOptionValueSource(optionKey));
+      return (
+        this.getOptionValue(optionKey) !== undefined &&
+        !['default', 'implied'].includes(this.getOptionValueSource(optionKey))
+      );
     };
     this.options
-      .filter(option => (option.implied !== undefined) &&
-        hasCustomOptionValue(option.attributeName()) &&
-        dualHelper.valueFromOption(this.getOptionValue(option.attributeName()), option))
+      .filter(
+        (option) =>
+          option.implied !== undefined &&
+          hasCustomOptionValue(option.attributeName()) &&
+          dualHelper.valueFromOption(
+            this.getOptionValue(option.attributeName()),
+            option,
+          ),
+      )
       .forEach((option) => {
         Object.keys(option.implied)
-          .filter(impliedKey => !hasCustomOptionValue(impliedKey))
-          .forEach(impliedKey => {
-            this.setOptionValueWithSource(impliedKey, option.implied[impliedKey], 'implied');
+          .filter((impliedKey) => !hasCustomOptionValue(impliedKey))
+          .forEach((impliedKey) => {
+            this.setOptionValueWithSource(
+              impliedKey,
+              option.implied[impliedKey],
+              'implied',
+            );
           });
       });
   }
@@ -1779,12 +1917,18 @@ Expecting one of '${allowedValues.join("', '")}'`);
     const findBestOptionFromValue = (option) => {
       const optionKey = option.attributeName();
       const optionValue = this.getOptionValue(optionKey);
-      const negativeOption = this.options.find(target => target.negate && optionKey === target.attributeName());
-      const positiveOption = this.options.find(target => !target.negate && optionKey === target.attributeName());
-      if (negativeOption && (
-        (negativeOption.presetArg === undefined && optionValue === false) ||
-        (negativeOption.presetArg !== undefined && optionValue === negativeOption.presetArg)
-      )) {
+      const negativeOption = this.options.find(
+        (target) => target.negate && optionKey === target.attributeName(),
+      );
+      const positiveOption = this.options.find(
+        (target) => !target.negate && optionKey === target.attributeName(),
+      );
+      if (
+        negativeOption &&
+        ((negativeOption.presetArg === undefined && optionValue === false) ||
+          (negativeOption.presetArg !== undefined &&
+            optionValue === negativeOption.presetArg))
+      ) {
         return negativeOption;
       }
       return positiveOption || option;
@@ -1821,9 +1965,11 @@ Expecting one of '${allowedValues.join("', '")}'`);
       // eslint-disable-next-line @typescript-eslint/no-this-alias
       let command = this;
       do {
-        const moreFlags = command.createHelp().visibleOptions(command)
-          .filter(option => option.long)
-          .map(option => option.long);
+        const moreFlags = command
+          .createHelp()
+          .visibleOptions(command)
+          .filter((option) => option.long)
+          .map((option) => option.long);
         candidateFlags = candidateFlags.concat(moreFlags);
         command = command.parent;
       } while (command && !command._enablePositionalOptions);
@@ -1845,7 +1991,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     if (this._allowExcessArguments) return;
 
     const expected = this.registeredArguments.length;
-    const s = (expected === 1) ? '' : 's';
+    const s = expected === 1 ? '' : 's';
     const forSubcommand = this.parent ? ` for '${this.name()}'` : '';
     const message = `error: too many arguments${forSubcommand}. Expected ${expected} argument${s} but got ${receivedArgs.length}.`;
     this.error(message, { code: 'commander.excessArguments' });
@@ -1863,11 +2009,13 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
     if (this._showSuggestionAfterError) {
       const candidateNames = [];
-      this.createHelp().visibleCommands(this).forEach((command) => {
-        candidateNames.push(command.name());
-        // just visible alias
-        if (command.alias()) candidateNames.push(command.alias());
-      });
+      this.createHelp()
+        .visibleCommands(this)
+        .forEach((command) => {
+          candidateNames.push(command.name());
+          // just visible alias
+          if (command.alias()) candidateNames.push(command.alias());
+        });
       suggestion = suggestSimilar(unknownName, candidateNames);
     }
 
@@ -1912,7 +2060,8 @@ Expecting one of '${allowedValues.join("', '")}'`);
    * @return {(string|Command)}
    */
   description(str, argsDescription) {
-    if (str === undefined && argsDescription === undefined) return this._description;
+    if (str === undefined && argsDescription === undefined)
+      return this._description;
     this._description = str;
     if (argsDescription) {
       this._argsDescription = argsDescription;
@@ -1947,17 +2096,25 @@ Expecting one of '${allowedValues.join("', '")}'`);
     /** @type {Command} */
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     let command = this;
-    if (this.commands.length !== 0 && this.commands[this.commands.length - 1]._executableHandler) {
+    if (
+      this.commands.length !== 0 &&
+      this.commands[this.commands.length - 1]._executableHandler
+    ) {
       // assume adding alias for last added executable subcommand, rather than this
       command = this.commands[this.commands.length - 1];
     }
 
-    if (alias === command._name) throw new Error('Command alias can\'t be the same as its name');
+    if (alias === command._name)
+      throw new Error("Command alias can't be the same as its name");
     const matchingCommand = this.parent?._findCommand(alias);
     if (matchingCommand) {
       // c.f. _registerCommand
-      const existingCmd = [matchingCommand.name()].concat(matchingCommand.aliases()).join('|');
-      throw new Error(`cannot add alias '${alias}' to command '${this.name()}' as already have command '${existingCmd}'`);
+      const existingCmd = [matchingCommand.name()]
+        .concat(matchingCommand.aliases())
+        .join('|');
+      throw new Error(
+        `cannot add alias '${alias}' to command '${this.name()}' as already have command '${existingCmd}'`,
+      );
     }
 
     command._aliases.push(alias);
@@ -1995,11 +2152,13 @@ Expecting one of '${allowedValues.join("', '")}'`);
       const args = this.registeredArguments.map((arg) => {
         return humanReadableArgName(arg);
       });
-      return [].concat(
-        (this.options.length || (this._helpOption !== null) ? '[options]' : []),
-        (this.commands.length ? '[command]' : []),
-        (this.registeredArguments.length ? args : [])
-      ).join(' ');
+      return []
+        .concat(
+          this.options.length || this._helpOption !== null ? '[options]' : [],
+          this.commands.length ? '[command]' : [],
+          this.registeredArguments.length ? args : [],
+        )
+        .join(' ');
     }
 
     this._usage = str;
@@ -2066,7 +2225,10 @@ Expecting one of '${allowedValues.join("', '")}'`);
   helpInformation(contextOptions) {
     const helper = this.createHelp();
     if (helper.helpWidth === undefined) {
-      helper.helpWidth = (contextOptions && contextOptions.error) ? this._outputConfiguration.getErrHelpWidth() : this._outputConfiguration.getOutHelpWidth();
+      helper.helpWidth =
+        contextOptions && contextOptions.error
+          ? this._outputConfiguration.getErrHelpWidth()
+          : this._outputConfiguration.getOutHelpWidth();
     }
     return helper.formatHelp(this, helper);
   }
@@ -2105,13 +2267,18 @@ Expecting one of '${allowedValues.join("', '")}'`);
     }
     const context = this._getHelpContext(contextOptions);
 
-    this._getCommandAndAncestors().reverse().forEach(command => command.emit('beforeAllHelp', context));
+    this._getCommandAndAncestors()
+      .reverse()
+      .forEach((command) => command.emit('beforeAllHelp', context));
     this.emit('beforeHelp', context);
 
     let helpInformation = this.helpInformation(context);
     if (deprecatedCallback) {
       helpInformation = deprecatedCallback(helpInformation);
-      if (typeof helpInformation !== 'string' && !Buffer.isBuffer(helpInformation)) {
+      if (
+        typeof helpInformation !== 'string' &&
+        !Buffer.isBuffer(helpInformation)
+      ) {
         throw new Error('outputHelp callback must return a string or a Buffer');
       }
     }
@@ -2121,7 +2288,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
       this.emit(this._getHelpOption().long); // deprecated
     }
     this.emit('afterHelp', context);
-    this._getCommandAndAncestors().forEach(command => command.emit('afterAllHelp', context));
+    this._getCommandAndAncestors().forEach((command) =>
+      command.emit('afterAllHelp', context),
+    );
   }
 
   /**
@@ -2194,7 +2363,12 @@ Expecting one of '${allowedValues.join("', '")}'`);
   help(contextOptions) {
     this.outputHelp(contextOptions);
     let exitCode = process.exitCode || 0;
-    if (exitCode === 0 && contextOptions && typeof contextOptions !== 'function' && contextOptions.error) {
+    if (
+      exitCode === 0 &&
+      contextOptions &&
+      typeof contextOptions !== 'function' &&
+      contextOptions.error
+    ) {
       exitCode = 1;
     }
     // message: do not have all displayed text available so only passing placeholder.
@@ -2242,7 +2416,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
   _outputHelpIfRequested(args) {
     const helpOption = this._getHelpOption();
-    const helpRequested = helpOption && args.find(arg => helpOption.is(arg));
+    const helpRequested = helpOption && args.find((arg) => helpOption.is(arg));
     if (helpRequested) {
       this.outputHelp();
       // (Do not have all displayed text available so only passing placeholder.)
@@ -2275,7 +2449,9 @@ function incrementNodeInspectorPort(args) {
     if ((match = arg.match(/^(--inspect(-brk)?)$/)) !== null) {
       // e.g. --inspect
       debugOption = match[1];
-    } else if ((match = arg.match(/^(--inspect(-brk|-port)?)=([^:]+)$/)) !== null) {
+    } else if (
+      (match = arg.match(/^(--inspect(-brk|-port)?)=([^:]+)$/)) !== null
+    ) {
       debugOption = match[1];
       if (/^\d+$/.test(match[3])) {
         // e.g. --inspect=1234
@@ -2284,7 +2460,9 @@ function incrementNodeInspectorPort(args) {
         // e.g. --inspect=localhost
         debugHost = match[3];
       }
-    } else if ((match = arg.match(/^(--inspect(-brk|-port)?)=([^:]+):(\d+)$/)) !== null) {
+    } else if (
+      (match = arg.match(/^(--inspect(-brk|-port)?)=([^:]+):(\d+)$/)) !== null
+    ) {
       // e.g. --inspect=localhost:1234
       debugOption = match[1];
       debugHost = match[3];

--- a/lib/help.js
+++ b/lib/help.js
@@ -25,7 +25,7 @@ class Help {
    */
 
   visibleCommands(cmd) {
-    const visibleCommands = cmd.commands.filter(cmd => !cmd._hidden);
+    const visibleCommands = cmd.commands.filter((cmd) => !cmd._hidden);
     const helpCommand = cmd._getHelpCommand();
     if (helpCommand && !helpCommand._hidden) {
       visibleCommands.push(helpCommand);
@@ -49,7 +49,9 @@ class Help {
   compareOptions(a, b) {
     const getSortKey = (option) => {
       // WYSIWYG for order displayed in help. Short used for comparison if present. No special handling for negated.
-      return option.short ? option.short.replace(/^-/, '') : option.long.replace(/^--/, '');
+      return option.short
+        ? option.short.replace(/^-/, '')
+        : option.long.replace(/^--/, '');
     };
     return getSortKey(a).localeCompare(getSortKey(b));
   }
@@ -72,9 +74,13 @@ class Help {
       if (!removeShort && !removeLong) {
         visibleOptions.push(helpOption); // no changes needed
       } else if (helpOption.long && !removeLong) {
-        visibleOptions.push(cmd.createOption(helpOption.long, helpOption.description));
+        visibleOptions.push(
+          cmd.createOption(helpOption.long, helpOption.description),
+        );
       } else if (helpOption.short && !removeShort) {
-        visibleOptions.push(cmd.createOption(helpOption.short, helpOption.description));
+        visibleOptions.push(
+          cmd.createOption(helpOption.short, helpOption.description),
+        );
       }
     }
     if (this.sortOptions) {
@@ -94,8 +100,14 @@ class Help {
     if (!this.showGlobalOptions) return [];
 
     const globalOptions = [];
-    for (let ancestorCmd = cmd.parent; ancestorCmd; ancestorCmd = ancestorCmd.parent) {
-      const visibleOptions = ancestorCmd.options.filter((option) => !option.hidden);
+    for (
+      let ancestorCmd = cmd.parent;
+      ancestorCmd;
+      ancestorCmd = ancestorCmd.parent
+    ) {
+      const visibleOptions = ancestorCmd.options.filter(
+        (option) => !option.hidden,
+      );
       globalOptions.push(...visibleOptions);
     }
     if (this.sortOptions) {
@@ -114,13 +126,14 @@ class Help {
   visibleArguments(cmd) {
     // Side effect! Apply the legacy descriptions before the arguments are displayed.
     if (cmd._argsDescription) {
-      cmd.registeredArguments.forEach(argument => {
-        argument.description = argument.description || cmd._argsDescription[argument.name()] || '';
+      cmd.registeredArguments.forEach((argument) => {
+        argument.description =
+          argument.description || cmd._argsDescription[argument.name()] || '';
       });
     }
 
     // If there are any arguments with a description then return all the arguments.
-    if (cmd.registeredArguments.find(argument => argument.description)) {
+    if (cmd.registeredArguments.find((argument) => argument.description)) {
       return cmd.registeredArguments;
     }
     return [];
@@ -135,11 +148,15 @@ class Help {
 
   subcommandTerm(cmd) {
     // Legacy. Ignores custom usage string, and nested commands.
-    const args = cmd.registeredArguments.map(arg => humanReadableArgName(arg)).join(' ');
-    return cmd._name +
+    const args = cmd.registeredArguments
+      .map((arg) => humanReadableArgName(arg))
+      .join(' ');
+    return (
+      cmd._name +
       (cmd._aliases[0] ? '|' + cmd._aliases[0] : '') +
       (cmd.options.length ? ' [options]' : '') + // simplistic check for non-help option
-      (args ? ' ' + args : '');
+      (args ? ' ' + args : '')
+    );
   }
 
   /**
@@ -234,7 +251,11 @@ class Help {
       cmdName = cmdName + '|' + cmd._aliases[0];
     }
     let ancestorCmdNames = '';
-    for (let ancestorCmd = cmd.parent; ancestorCmd; ancestorCmd = ancestorCmd.parent) {
+    for (
+      let ancestorCmd = cmd.parent;
+      ancestorCmd;
+      ancestorCmd = ancestorCmd.parent
+    ) {
       ancestorCmdNames = ancestorCmd.name() + ' ' + ancestorCmdNames;
     }
     return ancestorCmdNames + cmdName + ' ' + cmd.usage();
@@ -278,15 +299,20 @@ class Help {
     if (option.argChoices) {
       extraInfo.push(
         // use stringify to match the display of the default value
-        `choices: ${option.argChoices.map((choice) => JSON.stringify(choice)).join(', ')}`);
+        `choices: ${option.argChoices.map((choice) => JSON.stringify(choice)).join(', ')}`,
+      );
     }
     if (option.defaultValue !== undefined) {
       // default for boolean and negated more for programmer than end user,
       // but show true/false for boolean option as may be for hand-rolled env or config processing.
-      const showDefault = option.required || option.optional ||
+      const showDefault =
+        option.required ||
+        option.optional ||
         (option.isBoolean() && typeof option.defaultValue === 'boolean');
       if (showDefault) {
-        extraInfo.push(`default: ${option.defaultValueDescription || JSON.stringify(option.defaultValue)}`);
+        extraInfo.push(
+          `default: ${option.defaultValueDescription || JSON.stringify(option.defaultValue)}`,
+        );
       }
     }
     // preset for boolean and negated are more for programmer than end user
@@ -315,10 +341,13 @@ class Help {
     if (argument.argChoices) {
       extraInfo.push(
         // use stringify to match the display of the default value
-        `choices: ${argument.argChoices.map((choice) => JSON.stringify(choice)).join(', ')}`);
+        `choices: ${argument.argChoices.map((choice) => JSON.stringify(choice)).join(', ')}`,
+      );
     }
     if (argument.defaultValue !== undefined) {
-      extraInfo.push(`default: ${argument.defaultValueDescription || JSON.stringify(argument.defaultValue)}`);
+      extraInfo.push(
+        `default: ${argument.defaultValueDescription || JSON.stringify(argument.defaultValue)}`,
+      );
     }
     if (extraInfo.length > 0) {
       const extraDescripton = `(${extraInfo.join(', ')})`;
@@ -346,7 +375,11 @@ class Help {
     function formatItem(term, description) {
       if (description) {
         const fullText = `${term.padEnd(termWidth + itemSeparatorWidth)}${description}`;
-        return helper.wrap(fullText, helpWidth - itemIndentWidth, termWidth + itemSeparatorWidth);
+        return helper.wrap(
+          fullText,
+          helpWidth - itemIndentWidth,
+          termWidth + itemSeparatorWidth,
+        );
       }
       return term;
     }
@@ -360,12 +393,18 @@ class Help {
     // Description
     const commandDescription = helper.commandDescription(cmd);
     if (commandDescription.length > 0) {
-      output = output.concat([helper.wrap(commandDescription, helpWidth, 0), '']);
+      output = output.concat([
+        helper.wrap(commandDescription, helpWidth, 0),
+        '',
+      ]);
     }
 
     // Arguments
     const argumentList = helper.visibleArguments(cmd).map((argument) => {
-      return formatItem(helper.argumentTerm(argument), helper.argumentDescription(argument));
+      return formatItem(
+        helper.argumentTerm(argument),
+        helper.argumentDescription(argument),
+      );
     });
     if (argumentList.length > 0) {
       output = output.concat(['Arguments:', formatList(argumentList), '']);
@@ -373,24 +412,39 @@ class Help {
 
     // Options
     const optionList = helper.visibleOptions(cmd).map((option) => {
-      return formatItem(helper.optionTerm(option), helper.optionDescription(option));
+      return formatItem(
+        helper.optionTerm(option),
+        helper.optionDescription(option),
+      );
     });
     if (optionList.length > 0) {
       output = output.concat(['Options:', formatList(optionList), '']);
     }
 
     if (this.showGlobalOptions) {
-      const globalOptionList = helper.visibleGlobalOptions(cmd).map((option) => {
-        return formatItem(helper.optionTerm(option), helper.optionDescription(option));
-      });
+      const globalOptionList = helper
+        .visibleGlobalOptions(cmd)
+        .map((option) => {
+          return formatItem(
+            helper.optionTerm(option),
+            helper.optionDescription(option),
+          );
+        });
       if (globalOptionList.length > 0) {
-        output = output.concat(['Global Options:', formatList(globalOptionList), '']);
+        output = output.concat([
+          'Global Options:',
+          formatList(globalOptionList),
+          '',
+        ]);
       }
     }
 
     // Commands
     const commandList = helper.visibleCommands(cmd).map((cmd) => {
-      return formatItem(helper.subcommandTerm(cmd), helper.subcommandDescription(cmd));
+      return formatItem(
+        helper.subcommandTerm(cmd),
+        helper.subcommandDescription(cmd),
+      );
     });
     if (commandList.length > 0) {
       output = output.concat(['Commands:', formatList(commandList), '']);
@@ -412,7 +466,7 @@ class Help {
       helper.longestOptionTermLength(cmd, helper),
       helper.longestGlobalOptionTermLength(cmd, helper),
       helper.longestSubcommandTermLength(cmd, helper),
-      helper.longestArgumentTermLength(cmd, helper)
+      helper.longestArgumentTermLength(cmd, helper),
     );
   }
 
@@ -430,7 +484,8 @@ class Help {
 
   wrap(str, width, indent, minColumnWidth = 40) {
     // Full \s characters, minus the linefeeds.
-    const indents = ' \\f\\t\\v\u00a0\u1680\u2000-\u200a\u202f\u205f\u3000\ufeff';
+    const indents =
+      ' \\f\\t\\v\u00a0\u1680\u2000-\u200a\u202f\u205f\u3000\ufeff';
     // Detect manually wrapped and indented strings by searching for line break followed by spaces.
     const manualIndent = new RegExp(`[\\n][${indents}]+`);
     if (str.match(manualIndent)) return str;
@@ -445,12 +500,20 @@ class Help {
     const breaks = `\\s${zeroWidthSpace}`;
     // Match line end (so empty lines don't collapse),
     // or as much text as will fit in column, or excess text up to first break.
-    const regex = new RegExp(`\n|.{1,${columnWidth - 1}}([${breaks}]|$)|[^${breaks}]+?([${breaks}]|$)`, 'g');
+    const regex = new RegExp(
+      `\n|.{1,${columnWidth - 1}}([${breaks}]|$)|[^${breaks}]+?([${breaks}]|$)`,
+      'g',
+    );
     const lines = columnText.match(regex) || [];
-    return leadingStr + lines.map((line, i) => {
-      if (line === '\n') return ''; // preserve empty lines
-      return ((i > 0) ? indentString : '') + line.trimEnd();
-    }).join('\n');
+    return (
+      leadingStr +
+      lines
+        .map((line, i) => {
+          if (line === '\n') return ''; // preserve empty lines
+          return (i > 0 ? indentString : '') + line.trimEnd();
+        })
+        .join('\n')
+    );
   }
 }
 

--- a/lib/option.js
+++ b/lib/option.js
@@ -180,7 +180,9 @@ class Option {
     this.argChoices = values.slice();
     this.parseArg = (arg, previous) => {
       if (!this.argChoices.includes(arg)) {
-        throw new InvalidArgumentError(`Allowed choices are ${this.argChoices.join(', ')}.`);
+        throw new InvalidArgumentError(
+          `Allowed choices are ${this.argChoices.join(', ')}.`,
+        );
       }
       if (this.variadic) {
         return this._concatValue(arg, previous);
@@ -255,7 +257,7 @@ class DualOptions {
     this.positiveOptions = new Map();
     this.negativeOptions = new Map();
     this.dualOptions = new Set();
-    options.forEach(option => {
+    options.forEach((option) => {
       if (option.negate) {
         this.negativeOptions.set(option.attributeName(), option);
       } else {
@@ -282,7 +284,7 @@ class DualOptions {
 
     // Use the value to deduce if (probably) came from the option.
     const preset = this.negativeOptions.get(optionKey).presetArg;
-    const negativeValue = (preset !== undefined) ? preset : false;
+    const negativeValue = preset !== undefined ? preset : false;
     return option.negate === (negativeValue === value);
   }
 }
@@ -313,7 +315,8 @@ function splitOptionFlags(flags) {
   // Use original very loose parsing to maintain backwards compatibility for now,
   // which allowed for example unintended `-sw, --short-word` [sic].
   const flagParts = flags.split(/[ |,]+/);
-  if (flagParts.length > 1 && !/^[[<]/.test(flagParts[1])) shortFlag = flagParts.shift();
+  if (flagParts.length > 1 && !/^[[<]/.test(flagParts[1]))
+    shortFlag = flagParts.shift();
   longFlag = flagParts.shift();
   // Add support for lone short flag without significantly changing parsing!
   if (!shortFlag && /^-[^-]$/.test(longFlag)) {

--- a/lib/suggestSimilar.js
+++ b/lib/suggestSimilar.js
@@ -6,7 +6,8 @@ function editDistance(a, b) {
   // (Simple implementation.)
 
   // Quick early exit, return worst case.
-  if (Math.abs(a.length - b.length) > maxDistance) return Math.max(a.length, b.length);
+  if (Math.abs(a.length - b.length) > maxDistance)
+    return Math.max(a.length, b.length);
 
   // distance between prefix substrings of a and b
   const d = [];
@@ -32,7 +33,7 @@ function editDistance(a, b) {
       d[i][j] = Math.min(
         d[i - 1][j] + 1, // deletion
         d[i][j - 1] + 1, // insertion
-        d[i - 1][j - 1] + cost // substitution
+        d[i - 1][j - 1] + cost, // substitution
       );
       // transposition
       if (i > 1 && j > 1 && a[i - 1] === b[j - 2] && a[i - 2] === b[j - 1]) {
@@ -60,7 +61,7 @@ function suggestSimilar(word, candidates) {
   const searchingOptions = word.startsWith('--');
   if (searchingOptions) {
     word = word.slice(2);
-    candidates = candidates.map(candidate => candidate.slice(2));
+    candidates = candidates.map((candidate) => candidate.slice(2));
   }
 
   let similar = [];
@@ -85,7 +86,7 @@ function suggestSimilar(word, candidates) {
 
   similar.sort((a, b) => a.localeCompare(b));
   if (searchingOptions) {
-    similar = similar.map(candidate => `--${candidate}`);
+    similar = similar.map((candidate) => `--${candidate}`);
   }
 
   if (similar.length > 1) {

--- a/tests/args.variadic.test.js
+++ b/tests/args.variadic.test.js
@@ -6,9 +6,7 @@ describe('variadic argument', () => {
   test('when no extra arguments specified for program then variadic arg is empty array', () => {
     const actionMock = jest.fn();
     const program = new commander.Command();
-    program
-      .arguments('<id> [variadicArg...]')
-      .action(actionMock);
+    program.arguments('<id> [variadicArg...]').action(actionMock);
 
     program.parse(['node', 'test', 'id']);
 
@@ -18,22 +16,23 @@ describe('variadic argument', () => {
   test('when extra arguments specified for program then variadic arg is array of values', () => {
     const actionMock = jest.fn();
     const program = new commander.Command();
-    program
-      .arguments('<id> [variadicArg...]')
-      .action(actionMock);
+    program.arguments('<id> [variadicArg...]').action(actionMock);
     const extraArguments = ['a', 'b', 'c'];
 
     program.parse(['node', 'test', 'id', ...extraArguments]);
 
-    expect(actionMock).toHaveBeenCalledWith('id', extraArguments, program.opts(), program);
+    expect(actionMock).toHaveBeenCalledWith(
+      'id',
+      extraArguments,
+      program.opts(),
+      program,
+    );
   });
 
   test('when no extra arguments specified for command then variadic arg is empty array', () => {
     const actionMock = jest.fn();
     const program = new commander.Command();
-    const cmd = program
-      .command('sub [variadicArg...]')
-      .action(actionMock);
+    const cmd = program.command('sub [variadicArg...]').action(actionMock);
 
     program.parse(['node', 'test', 'sub']);
 
@@ -43,9 +42,7 @@ describe('variadic argument', () => {
   test('when extra arguments specified for command then variadic arg is array of values', () => {
     const actionMock = jest.fn();
     const program = new commander.Command();
-    const cmd = program
-      .command('sub [variadicArg...]')
-      .action(actionMock);
+    const cmd = program.command('sub [variadicArg...]').action(actionMock);
     const extraArguments = ['a', 'b', 'c'];
 
     program.parse(['node', 'test', 'sub', ...extraArguments]);
@@ -71,9 +68,7 @@ describe('variadic argument', () => {
 
   test('when variadic argument then usage shows variadic', () => {
     const program = new commander.Command();
-    program
-      .name('foo')
-      .arguments('[args...]');
+    program.name('foo').arguments('[args...]');
 
     expect(program.usage()).toBe('[options] [args...]');
   });

--- a/tests/argument.chain.test.js
+++ b/tests/argument.chain.test.js
@@ -9,7 +9,7 @@ describe('Argument methods that should return this for chaining', () => {
 
   test('when call .argParser() then returns this', () => {
     const argument = new Argument('<value>');
-    const result = argument.argParser(() => { });
+    const result = argument.argParser(() => {});
     expect(result).toBe(argument);
   });
 

--- a/tests/argument.choices.test.js
+++ b/tests/argument.choices.test.js
@@ -6,7 +6,9 @@ test('when command argument in choices then argument set', () => {
   program
     .exitOverride()
     .addArgument(new commander.Argument('<shade>').choices(['red', 'blue']))
-    .action((shadeParam) => { shade = shadeParam; });
+    .action((shadeParam) => {
+      shade = shadeParam;
+    });
   program.parse(['red'], { from: 'user' });
   expect(shade).toBe('red');
 });
@@ -17,7 +19,7 @@ test('when command argument is not in choices then error', () => {
   program
     .exitOverride()
     .configureOutput({
-      writeErr: () => {}
+      writeErr: () => {},
     })
     .addArgument(new commander.Argument('<shade>').choices(['red', 'blue']));
   expect(() => {
@@ -48,7 +50,7 @@ describe('choices parameter is treated as readonly, per TypeScript declaration',
     program
       .exitOverride()
       .configureOutput({
-        writeErr: () => {}
+        writeErr: () => {},
       })
       .addArgument(new commander.Argument('<shade>').choices(param));
     param.push('orange');

--- a/tests/argument.custom-processing.test.js
+++ b/tests/argument.custom-processing.test.js
@@ -6,9 +6,7 @@ const commander = require('../');
 test('when argument not specified then callback not called', () => {
   const mockCoercion = jest.fn();
   const program = new commander.Command();
-  program
-    .argument('[n]', 'number', mockCoercion)
-    .action(() => {});
+  program.argument('[n]', 'number', mockCoercion).action(() => {});
   program.parse([], { from: 'user' });
   expect(mockCoercion).not.toHaveBeenCalled();
 });
@@ -16,11 +14,9 @@ test('when argument not specified then callback not called', () => {
 test('when argument not specified then action argument undefined', () => {
   let actionValue = 'foo';
   const program = new commander.Command();
-  program
-    .argument('[n]', 'number', parseFloat)
-    .action((arg) => {
-      actionValue = arg;
-    });
+  program.argument('[n]', 'number', parseFloat).action((arg) => {
+    actionValue = arg;
+  });
   program.parse([], { from: 'user' });
   expect(actionValue).toBeUndefined();
 });
@@ -28,9 +24,7 @@ test('when argument not specified then action argument undefined', () => {
 test('when custom with starting value and argument not specified then callback not called', () => {
   const mockCoercion = jest.fn();
   const program = new commander.Command();
-  program
-    .argument('[n]', 'number', parseFloat, 1)
-    .action(() => {});
+  program.argument('[n]', 'number', parseFloat, 1).action(() => {});
   program.parse([], { from: 'user' });
   expect(mockCoercion).not.toHaveBeenCalled();
 });
@@ -39,11 +33,9 @@ test('when custom with starting value and argument not specified with action han
   const startingValue = 1;
   let actionValue;
   const program = new commander.Command();
-  program
-    .argument('[n]', 'number', parseFloat, startingValue)
-    .action((arg) => {
-      actionValue = arg;
-    });
+  program.argument('[n]', 'number', parseFloat, startingValue).action((arg) => {
+    actionValue = arg;
+  });
   program.parse([], { from: 'user' });
   expect(actionValue).toEqual(startingValue);
   expect(program.processedArgs).toEqual([startingValue]);
@@ -52,8 +44,7 @@ test('when custom with starting value and argument not specified with action han
 test('when custom with starting value and argument not specified without action handler then .processedArgs has starting value', () => {
   const startingValue = 1;
   const program = new commander.Command();
-  program
-    .argument('[n]', 'number', parseFloat, startingValue);
+  program.argument('[n]', 'number', parseFloat, startingValue);
   program.parse([], { from: 'user' });
   expect(program.processedArgs).toEqual([startingValue]);
 });
@@ -62,11 +53,9 @@ test('when default value is defined (without custom processing) and argument not
   const defaultValue = 1;
   let actionValue;
   const program = new commander.Command();
-  program
-    .argument('[n]', 'number', defaultValue)
-    .action((arg) => {
-      actionValue = arg;
-    });
+  program.argument('[n]', 'number', defaultValue).action((arg) => {
+    actionValue = arg;
+  });
   program.parse([], { from: 'user' });
   expect(actionValue).toEqual(defaultValue);
   expect(program.processedArgs).toEqual([defaultValue]);
@@ -75,8 +64,7 @@ test('when default value is defined (without custom processing) and argument not
 test('when default value is defined (without custom processing) and argument not specified without action handler then .processedArgs is default value', () => {
   const defaultValue = 1;
   const program = new commander.Command();
-  program
-    .argument('[n]', 'number', defaultValue);
+  program.argument('[n]', 'number', defaultValue);
   program.parse([], { from: 'user' });
   expect(program.processedArgs).toEqual([defaultValue]);
 });
@@ -85,9 +73,7 @@ test('when argument specified then callback called with value', () => {
   const mockCoercion = jest.fn();
   const value = '1';
   const program = new commander.Command();
-  program
-    .argument('[n]', 'number', mockCoercion)
-    .action(() => {});
+  program.argument('[n]', 'number', mockCoercion).action(() => {});
   program.parse([value], { from: 'user' });
   expect(mockCoercion).toHaveBeenCalledWith(value, undefined);
 });
@@ -111,10 +97,9 @@ test('when argument specified with action handler then action value is as return
 test('when argument specified without action handler then .processedArgs is as returned from callback', () => {
   const callbackResult = 2;
   const program = new commander.Command();
-  program
-    .argument('[n]', 'number', () => {
-      return callbackResult;
-    });
+  program.argument('[n]', 'number', () => {
+    return callbackResult;
+  });
   program.parse(['node', 'test', 'alpha']);
   expect(program.processedArgs).toEqual([callbackResult]);
 });
@@ -148,9 +133,7 @@ test('when variadic argument specified multiple times then callback called with 
     return 'callback';
   });
   const program = new commander.Command();
-  program
-    .argument('<n...>', 'number', mockCoercion)
-    .action(() => {});
+  program.argument('<n...>', 'number', mockCoercion).action(() => {});
   program.parse(['1', '2'], { from: 'user' });
   expect(mockCoercion).toHaveBeenCalledTimes(2);
   expect(mockCoercion).toHaveBeenNthCalledWith(1, '1', undefined);
@@ -159,8 +142,7 @@ test('when variadic argument specified multiple times then callback called with 
 
 test('when variadic argument without action handler then .processedArg has array', () => {
   const program = new commander.Command();
-  program
-    .argument('<n...>', 'number');
+  program.argument('<n...>', 'number');
   program.parse(['1', '2'], { from: 'user' });
   expect(program.processedArgs).toEqual([['1', '2']]);
 });
@@ -168,11 +150,9 @@ test('when variadic argument without action handler then .processedArg has array
 test('when parseFloat "1e2" then action argument is 100', () => {
   let actionValue;
   const program = new commander.Command();
-  program
-    .argument('<number>', 'float argument', parseFloat)
-    .action((arg) => {
-      actionValue = arg;
-    });
+  program.argument('<number>', 'float argument', parseFloat).action((arg) => {
+    actionValue = arg;
+  });
   program.parse(['1e2'], { from: 'user' });
   expect(actionValue).toEqual(100);
   expect(program.processedArgs).toEqual([actionValue]);

--- a/tests/argument.variadic.test.js
+++ b/tests/argument.variadic.test.js
@@ -6,10 +6,7 @@ describe('variadic argument', () => {
   test('when no extra arguments specified for program then variadic arg is empty array', () => {
     const actionMock = jest.fn();
     const program = new commander.Command();
-    program
-      .argument('<id>')
-      .argument('[variadicArg...]')
-      .action(actionMock);
+    program.argument('<id>').argument('[variadicArg...]').action(actionMock);
 
     program.parse(['node', 'test', 'id']);
 
@@ -27,15 +24,18 @@ describe('variadic argument', () => {
 
     program.parse(['node', 'test', 'id', ...extraArguments]);
 
-    expect(actionMock).toHaveBeenCalledWith('id', extraArguments, program.opts(), program);
+    expect(actionMock).toHaveBeenCalledWith(
+      'id',
+      extraArguments,
+      program.opts(),
+      program,
+    );
   });
 
   test('when no extra arguments specified for command then variadic arg is empty array', () => {
     const actionMock = jest.fn();
     const program = new commander.Command();
-    const cmd = program
-      .command('sub [variadicArg...]')
-      .action(actionMock);
+    const cmd = program.command('sub [variadicArg...]').action(actionMock);
 
     program.parse(['node', 'test', 'sub']);
 
@@ -45,9 +45,7 @@ describe('variadic argument', () => {
   test('when extra arguments specified for command then variadic arg is array of values', () => {
     const actionMock = jest.fn();
     const program = new commander.Command();
-    const cmd = program
-      .command('sub [variadicArg...]')
-      .action(actionMock);
+    const cmd = program.command('sub [variadicArg...]').action(actionMock);
     const extraArguments = ['a', 'b', 'c'];
 
     program.parse(['node', 'test', 'sub', ...extraArguments]);
@@ -59,9 +57,7 @@ describe('variadic argument', () => {
     const program = new commander.Command();
 
     expect(() => {
-      program
-        .argument('<variadicArg...>')
-        .argument('[optionalArg]');
+      program.argument('<variadicArg...>').argument('[optionalArg]');
     }).toThrow("only the last argument can be variadic 'variadicArg'");
   });
 
@@ -75,9 +71,7 @@ describe('variadic argument', () => {
 
   test('when variadic argument then usage shows variadic', () => {
     const program = new commander.Command();
-    program
-      .name('foo')
-      .argument('[args...]');
+    program.name('foo').argument('[args...]');
 
     expect(program.usage()).toBe('[options] [args...]');
   });
@@ -87,7 +81,9 @@ describe('variadic argument', () => {
     let passedArg;
     program
       .addArgument(new commander.Argument('<value...>').choices(['one', 'two']))
-      .action((value) => { passedArg = value; });
+      .action((value) => {
+        passedArg = value;
+      });
 
     program.parse(['one'], { from: 'user' });
     expect(passedArg).toEqual(['one']);
@@ -98,7 +94,9 @@ describe('variadic argument', () => {
     let passedArg;
     program
       .addArgument(new commander.Argument('<value...>').choices(['one', 'two']))
-      .action((value) => { passedArg = value; });
+      .action((value) => {
+        passedArg = value;
+      });
 
     program.parse(['one', 'two'], { from: 'user' });
     expect(passedArg).toEqual(['one', 'two']);

--- a/tests/command.action.test.js
+++ b/tests/command.action.test.js
@@ -5,9 +5,7 @@ const commander = require('../');
 test('when .action called then command passed to action', () => {
   const actionMock = jest.fn();
   const program = new commander.Command();
-  const cmd = program
-    .command('info')
-    .action(actionMock);
+  const cmd = program.command('info').action(actionMock);
   program.parse(['node', 'test', 'info']);
   expect(actionMock).toHaveBeenCalledWith(cmd.opts(), cmd);
 });
@@ -15,9 +13,9 @@ test('when .action called then command passed to action', () => {
 test('when .action called then this is set to command', () => {
   const program = new commander.Command();
   let actionThis;
-  const cmd = program
-    .command('info')
-    .action(function() { actionThis = this; });
+  const cmd = program.command('info').action(function () {
+    actionThis = this;
+  });
   program.parse(['node', 'test', 'info']);
   expect(actionThis).toBe(cmd);
 });
@@ -26,87 +24,100 @@ test('when .action called then program.args only contains args', () => {
   // At one time program.args was being modified to contain the same args as the call to .action
   // and so included the command as an extra and unexpected complex item in array.
   const program = new commander.Command();
-  program
-    .command('info <file>')
-    .action(() => {});
+  program.command('info <file>').action(() => {});
   program.parse(['node', 'test', 'info', 'my-file']);
   expect(program.args).toEqual(['info', 'my-file']);
 });
 
-test.each(getTestCases('<file>'))('when .action on program with required argument via %s and argument supplied then action called', (methodName, program) => {
-  const actionMock = jest.fn();
-  program.action(actionMock);
-  program.parse(['node', 'test', 'my-file']);
-  expect(actionMock).toHaveBeenCalledWith('my-file', program.opts(), program);
-});
+test.each(getTestCases('<file>'))(
+  'when .action on program with required argument via %s and argument supplied then action called',
+  (methodName, program) => {
+    const actionMock = jest.fn();
+    program.action(actionMock);
+    program.parse(['node', 'test', 'my-file']);
+    expect(actionMock).toHaveBeenCalledWith('my-file', program.opts(), program);
+  },
+);
 
-test.each(getTestCases('<file>'))('when .action on program with required argument via %s and argument not supplied then action not called', (methodName, program) => {
-  const actionMock = jest.fn();
-  program
-    .exitOverride()
-    .configureOutput({ writeErr: () => {} })
-    .action(actionMock);
-  expect(() => {
-    program.parse(['node', 'test']);
-  }).toThrow();
-  expect(actionMock).not.toHaveBeenCalled();
-});
+test.each(getTestCases('<file>'))(
+  'when .action on program with required argument via %s and argument not supplied then action not called',
+  (methodName, program) => {
+    const actionMock = jest.fn();
+    program
+      .exitOverride()
+      .configureOutput({ writeErr: () => {} })
+      .action(actionMock);
+    expect(() => {
+      program.parse(['node', 'test']);
+    }).toThrow();
+    expect(actionMock).not.toHaveBeenCalled();
+  },
+);
 
 // Changes made in #729 to call program action handler
 test('when .action on program and no arguments then action called', () => {
   const actionMock = jest.fn();
   const program = new commander.Command();
-  program
-    .action(actionMock);
+  program.action(actionMock);
   program.parse(['node', 'test']);
   expect(actionMock).toHaveBeenCalledWith(program.opts(), program);
 });
 
-test.each(getTestCases('[file]'))('when .action on program with optional argument via %s supplied then action called', (methodName, program) => {
-  const actionMock = jest.fn();
-  program.action(actionMock);
-  program.parse(['node', 'test', 'my-file']);
-  expect(actionMock).toHaveBeenCalledWith('my-file', program.opts(), program);
-});
+test.each(getTestCases('[file]'))(
+  'when .action on program with optional argument via %s supplied then action called',
+  (methodName, program) => {
+    const actionMock = jest.fn();
+    program.action(actionMock);
+    program.parse(['node', 'test', 'my-file']);
+    expect(actionMock).toHaveBeenCalledWith('my-file', program.opts(), program);
+  },
+);
 
-test.each(getTestCases('[file]'))('when .action on program without optional argument supplied then action called', (methodName, program) => {
-  const actionMock = jest.fn();
-  program.action(actionMock);
-  program.parse(['node', 'test']);
-  expect(actionMock).toHaveBeenCalledWith(undefined, program.opts(), program);
-});
+test.each(getTestCases('[file]'))(
+  'when .action on program without optional argument supplied then action called',
+  (methodName, program) => {
+    const actionMock = jest.fn();
+    program.action(actionMock);
+    program.parse(['node', 'test']);
+    expect(actionMock).toHaveBeenCalledWith(undefined, program.opts(), program);
+  },
+);
 
-test.each(getTestCases('[file]'))('when .action on program with optional argument via %s and subcommand and program argument then program action called', (methodName, program) => {
-  const actionMock = jest.fn();
-  program.action(actionMock);
-  program
-    .command('subcommand');
+test.each(getTestCases('[file]'))(
+  'when .action on program with optional argument via %s and subcommand and program argument then program action called',
+  (methodName, program) => {
+    const actionMock = jest.fn();
+    program.action(actionMock);
+    program.command('subcommand');
 
-  program.parse(['node', 'test', 'a']);
+    program.parse(['node', 'test', 'a']);
 
-  expect(actionMock).toHaveBeenCalledWith('a', program.opts(), program);
-});
+    expect(actionMock).toHaveBeenCalledWith('a', program.opts(), program);
+  },
+);
 
 // Changes made in #1062 to allow this case
-test.each(getTestCases('[file]'))('when .action on program with optional argument via %s and subcommand and no program argument then program action called', (methodName, program) => {
-  const actionMock = jest.fn();
-  program.action(actionMock);
-  program.command('subcommand');
+test.each(getTestCases('[file]'))(
+  'when .action on program with optional argument via %s and subcommand and no program argument then program action called',
+  (methodName, program) => {
+    const actionMock = jest.fn();
+    program.action(actionMock);
+    program.command('subcommand');
 
-  program.parse(['node', 'test']);
+    program.parse(['node', 'test']);
 
-  expect(actionMock).toHaveBeenCalledWith(undefined, program.opts(), program);
-});
+    expect(actionMock).toHaveBeenCalledWith(undefined, program.opts(), program);
+  },
+);
 
-test('when action is async then can await parseAsync', async() => {
+test('when action is async then can await parseAsync', async () => {
   let asyncFinished = false;
   async function delay() {
-    await new Promise(resolve => setTimeout(resolve, 100));
+    await new Promise((resolve) => setTimeout(resolve, 100));
     asyncFinished = true;
   }
   const program = new commander.Command();
-  program
-    .action(delay);
+  program.action(delay);
 
   const later = program.parseAsync(['node', 'test']);
   expect(asyncFinished).toBe(false);
@@ -117,6 +128,12 @@ test('when action is async then can await parseAsync', async() => {
 function getTestCases(arg) {
   const withArguments = new commander.Command().arguments(arg);
   const withArgument = new commander.Command().argument(arg);
-  const withAddArgument = new commander.Command().addArgument(new commander.Argument(arg));
-  return [['.arguments', withArguments], ['.argument', withArgument], ['.addArgument', withAddArgument]];
+  const withAddArgument = new commander.Command().addArgument(
+    new commander.Argument(arg),
+  );
+  return [
+    ['.arguments', withArguments],
+    ['.argument', withArgument],
+    ['.addArgument', withAddArgument],
+  ];
 }

--- a/tests/command.addCommand.test.js
+++ b/tests/command.addCommand.test.js
@@ -5,11 +5,8 @@ test('when addCommand and specify subcommand then called', () => {
   const program = new commander.Command();
   const leafAction = jest.fn();
   const sub = new commander.Command();
-  sub
-    .name('sub')
-    .action(leafAction);
-  program
-    .addCommand(sub);
+  sub.name('sub').action(leafAction);
+  program.addCommand(sub);
 
   program.parse('node test.js sub'.split(' '));
   expect(leafAction).toHaveBeenCalled();

--- a/tests/command.addHelpOption.test.js
+++ b/tests/command.addHelpOption.test.js
@@ -8,8 +8,10 @@ describe('addHelpOption', () => {
 
   beforeAll(() => {
     // Optional. Suppress expected output to keep test output clean.
-    writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => { });
-    writeErrorSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => { });
+    writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => {});
+    writeErrorSpy = jest
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -24,9 +26,7 @@ describe('addHelpOption', () => {
 
   test('when addHelpOption has custom flags then custom short flag invokes help', () => {
     const program = new Command();
-    program
-      .exitOverride()
-      .addHelpOption(new Option('-c,--custom-help'));
+    program.exitOverride().addHelpOption(new Option('-c,--custom-help'));
 
     expect(() => {
       program.parse(['-c'], { from: 'user' });
@@ -35,9 +35,7 @@ describe('addHelpOption', () => {
 
   test('when addHelpOption has custom flags then custom long flag invokes help', () => {
     const program = new Command();
-    program
-      .exitOverride()
-      .addHelpOption(new Option('-c,--custom-help'));
+    program.exitOverride().addHelpOption(new Option('-c,--custom-help'));
 
     expect(() => {
       program.parse(['--custom-help'], { from: 'user' });
@@ -46,8 +44,9 @@ describe('addHelpOption', () => {
 
   test('when addHelpOption with hidden help option then help does not include help option', () => {
     const program = new Command();
-    program
-      .addHelpOption(new Option('-c,--custom-help', 'help help help').hideHelp());
+    program.addHelpOption(
+      new Option('-c,--custom-help', 'help help help').hideHelp(),
+    );
     const helpInfo = program.helpInformation();
     expect(helpInfo).not.toMatch(/help/);
   });

--- a/tests/command.addHelpText.test.js
+++ b/tests/command.addHelpText.test.js
@@ -6,7 +6,7 @@ describe('program calls to addHelpText', () => {
   let writeSpy;
 
   beforeAll(() => {
-    writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => { });
+    writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -35,7 +35,7 @@ describe('program calls to addHelpText', () => {
 
   test('when "before" function returns nothing then no effect', () => {
     const program = new commander.Command();
-    program.addHelpText('before', () => { });
+    program.addHelpText('before', () => {});
     program.outputHelp();
     expect(writeSpy).toHaveBeenNthCalledWith(1, program.helpInformation());
   });
@@ -90,7 +90,7 @@ describe('program and subcommand calls to addHelpText', () => {
   let writeSpy;
 
   beforeAll(() => {
-    writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => { });
+    writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -143,8 +143,12 @@ describe('context checks with full parse', () => {
   let stderrSpy;
 
   beforeAll(() => {
-    stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => { });
-    stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => { });
+    stdoutSpy = jest
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => {});
+    stderrSpy = jest
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -159,9 +163,7 @@ describe('context checks with full parse', () => {
 
   test('when help requested then text is on stdout', () => {
     const program = new commander.Command();
-    program
-      .exitOverride()
-      .addHelpText('before', 'text');
+    program.exitOverride().addHelpText('before', 'text');
     expect(() => {
       program.parse(['--help'], { from: 'user' });
     }).toThrow();
@@ -170,10 +172,7 @@ describe('context checks with full parse', () => {
 
   test('when help for error then text is on stderr', () => {
     const program = new commander.Command();
-    program
-      .exitOverride()
-      .addHelpText('before', 'text')
-      .command('sub');
+    program.exitOverride().addHelpText('before', 'text').command('sub');
     expect(() => {
       program.parse([], { from: 'user' });
     }).toThrow();
@@ -183,9 +182,9 @@ describe('context checks with full parse', () => {
   test('when help requested then context.error is false', () => {
     let context;
     const program = new commander.Command();
-    program
-      .exitOverride()
-      .addHelpText('before', (contextParam) => { context = contextParam; });
+    program.exitOverride().addHelpText('before', (contextParam) => {
+      context = contextParam;
+    });
     expect(() => {
       program.parse(['--help'], { from: 'user' });
     }).toThrow();
@@ -197,7 +196,9 @@ describe('context checks with full parse', () => {
     const program = new commander.Command();
     program
       .exitOverride()
-      .addHelpText('before', (contextParam) => { context = contextParam; })
+      .addHelpText('before', (contextParam) => {
+        context = contextParam;
+      })
       .command('sub');
     expect(() => {
       program.parse([], { from: 'user' });
@@ -208,9 +209,9 @@ describe('context checks with full parse', () => {
   test('when help on program then context.command is program', () => {
     let context;
     const program = new commander.Command();
-    program
-      .exitOverride()
-      .addHelpText('before', (contextParam) => { context = contextParam; });
+    program.exitOverride().addHelpText('before', (contextParam) => {
+      context = contextParam;
+    });
     expect(() => {
       program.parse(['--help'], { from: 'user' });
     }).toThrow();
@@ -220,10 +221,10 @@ describe('context checks with full parse', () => {
   test('when help on subcommand and "before" subcommand then context.command is subcommand', () => {
     let context;
     const program = new commander.Command();
-    program
-      .exitOverride();
-    const sub = program.command('sub')
-      .addHelpText('before', (contextParam) => { context = contextParam; });
+    program.exitOverride();
+    const sub = program.command('sub').addHelpText('before', (contextParam) => {
+      context = contextParam;
+    });
     expect(() => {
       program.parse(['sub', '--help'], { from: 'user' });
     }).toThrow();
@@ -233,9 +234,9 @@ describe('context checks with full parse', () => {
   test('when help on subcommand and "beforeAll" on program then context.command is subcommand', () => {
     let context;
     const program = new commander.Command();
-    program
-      .exitOverride()
-      .addHelpText('beforeAll', (contextParam) => { context = contextParam; });
+    program.exitOverride().addHelpText('beforeAll', (contextParam) => {
+      context = contextParam;
+    });
     const sub = program.command('sub');
     expect(() => {
       program.parse(['sub', '--help'], { from: 'user' });

--- a/tests/command.alias.test.js
+++ b/tests/command.alias.test.js
@@ -5,28 +5,21 @@ const commander = require('../');
 
 test('when command has alias then appears in help', () => {
   const program = new commander.Command();
-  program
-    .command('info [thing]')
-    .alias('i');
+  program.command('info [thing]').alias('i');
   const helpInformation = program.helpInformation();
   expect(helpInformation).toMatch('info|i');
 });
 
 test('when command has aliases added separately then only first appears in help', () => {
   const program = new commander.Command();
-  program
-    .command('list [thing]')
-    .alias('ls')
-    .alias('dir');
+  program.command('list [thing]').alias('ls').alias('dir');
   const helpInformation = program.helpInformation();
   expect(helpInformation).toMatch('list|ls ');
 });
 
 test('when command has aliases then only first appears in help', () => {
   const program = new commander.Command();
-  program
-    .command('list [thing]')
-    .aliases(['ls', 'dir']);
+  program.command('list [thing]').aliases(['ls', 'dir']);
   const helpInformation = program.helpInformation();
   expect(helpInformation).toMatch('list|ls ');
 });
@@ -34,19 +27,14 @@ test('when command has aliases then only first appears in help', () => {
 test('when command name = alias then error', () => {
   const program = new commander.Command();
   expect(() => {
-    program
-      .command('fail')
-      .alias('fail');
+    program.command('fail').alias('fail');
   }).toThrow("Command alias can't be the same as its name");
 });
 
 test('when use alias then action handler called', () => {
   const program = new commander.Command();
   const actionMock = jest.fn();
-  program
-    .command('list')
-    .alias('ls')
-    .action(actionMock);
+  program.command('list').alias('ls').action(actionMock);
   program.parse(['ls'], { from: 'user' });
   expect(actionMock).toHaveBeenCalled();
 });
@@ -54,11 +42,7 @@ test('when use alias then action handler called', () => {
 test('when use second alias added separately then action handler called', () => {
   const program = new commander.Command();
   const actionMock = jest.fn();
-  program
-    .command('list')
-    .alias('ls')
-    .alias('dir')
-    .action(actionMock);
+  program.command('list').alias('ls').alias('dir').action(actionMock);
   program.parse(['dir'], { from: 'user' });
   expect(actionMock).toHaveBeenCalled();
 });
@@ -66,10 +50,7 @@ test('when use second alias added separately then action handler called', () => 
 test('when use second of aliases then action handler called', () => {
   const program = new commander.Command();
   const actionMock = jest.fn();
-  program
-    .command('list')
-    .aliases(['ls', 'dir'])
-    .action(actionMock);
+  program.command('list').aliases(['ls', 'dir']).action(actionMock);
   program.parse(['dir'], { from: 'user' });
   expect(actionMock).toHaveBeenCalled();
 });
@@ -91,9 +72,7 @@ test('when set aliases then can get aliases', () => {
 test('when set alias on executable then can get alias', () => {
   const program = new commander.Command();
   const alias = 'abcde';
-  program
-    .command('external', 'external command')
-    .alias(alias);
+  program.command('external', 'external command').alias(alias);
   expect(program.commands[0].alias()).toEqual(alias);
 });
 

--- a/tests/command.allowExcessArguments.test.js
+++ b/tests/command.allowExcessArguments.test.js
@@ -2,128 +2,115 @@ const commander = require('../');
 
 // Not testing output, just testing whether an error is detected.
 
-describe.each([true, false])('allowExcessArguments when action handler: %s', (hasActionHandler) => {
-  function configureCommand(cmd) {
-    cmd
-      .exitOverride()
-      .configureOutput({
-        writeErr: () => {}
+describe.each([true, false])(
+  'allowExcessArguments when action handler: %s',
+  (hasActionHandler) => {
+    function configureCommand(cmd) {
+      cmd.exitOverride().configureOutput({
+        writeErr: () => {},
       });
-    if (hasActionHandler) {
-      cmd.action(() => {});
+      if (hasActionHandler) {
+        cmd.action(() => {});
+      }
     }
-  }
 
-  test('when specify excess program argument then no error by default', () => {
-    const program = new commander.Command();
-    configureCommand(program);
+    test('when specify excess program argument then no error by default', () => {
+      const program = new commander.Command();
+      configureCommand(program);
 
-    expect(() => {
-      program.parse(['excess'], { from: 'user' });
-    }).not.toThrow();
-  });
+      expect(() => {
+        program.parse(['excess'], { from: 'user' });
+      }).not.toThrow();
+    });
 
-  test('when specify excess program argument and allowExcessArguments(false) then error', () => {
-    const program = new commander.Command();
-    configureCommand(program);
-    program
-      .allowExcessArguments(false);
+    test('when specify excess program argument and allowExcessArguments(false) then error', () => {
+      const program = new commander.Command();
+      configureCommand(program);
+      program.allowExcessArguments(false);
 
-    expect(() => {
-      program.parse(['excess'], { from: 'user' });
-    }).toThrow();
-  });
+      expect(() => {
+        program.parse(['excess'], { from: 'user' });
+      }).toThrow();
+    });
 
-  test('when specify excess program argument and allowExcessArguments() then no error', () => {
-    const program = new commander.Command();
-    configureCommand(program);
-    program
-      .allowExcessArguments();
+    test('when specify excess program argument and allowExcessArguments() then no error', () => {
+      const program = new commander.Command();
+      configureCommand(program);
+      program.allowExcessArguments();
 
-    expect(() => {
-      program.parse(['excess'], { from: 'user' });
-    }).not.toThrow();
-  });
+      expect(() => {
+        program.parse(['excess'], { from: 'user' });
+      }).not.toThrow();
+    });
 
-  test('when specify excess program argument and allowExcessArguments(true) then no error', () => {
-    const program = new commander.Command();
-    configureCommand(program);
-    program
-      .allowExcessArguments(true);
+    test('when specify excess program argument and allowExcessArguments(true) then no error', () => {
+      const program = new commander.Command();
+      configureCommand(program);
+      program.allowExcessArguments(true);
 
-    expect(() => {
-      program.parse(['excess'], { from: 'user' });
-    }).not.toThrow();
-  });
+      expect(() => {
+        program.parse(['excess'], { from: 'user' });
+      }).not.toThrow();
+    });
 
-  test('when specify excess command argument then no error (by default)', () => {
-    const program = new commander.Command();
-    const sub = program
-      .command('sub');
-    configureCommand(sub);
+    test('when specify excess command argument then no error (by default)', () => {
+      const program = new commander.Command();
+      const sub = program.command('sub');
+      configureCommand(sub);
 
-    expect(() => {
-      program.parse(['sub', 'excess'], { from: 'user' });
-    }).not.toThrow();
-  });
+      expect(() => {
+        program.parse(['sub', 'excess'], { from: 'user' });
+      }).not.toThrow();
+    });
 
-  test('when specify excess command argument and allowExcessArguments(false) then error', () => {
-    const program = new commander.Command();
-    const sub = program
-      .command('sub')
-      .allowExcessArguments(false);
-    configureCommand(sub);
+    test('when specify excess command argument and allowExcessArguments(false) then error', () => {
+      const program = new commander.Command();
+      const sub = program.command('sub').allowExcessArguments(false);
+      configureCommand(sub);
 
-    expect(() => {
-      program.parse(['sub', 'excess'], { from: 'user' });
-    }).toThrow();
-  });
+      expect(() => {
+        program.parse(['sub', 'excess'], { from: 'user' });
+      }).toThrow();
+    });
 
-  test('when specify expected arg and allowExcessArguments(false) then no error', () => {
-    const program = new commander.Command();
-    configureCommand(program);
-    program
-      .argument('<file>')
-      .allowExcessArguments(false);
+    test('when specify expected arg and allowExcessArguments(false) then no error', () => {
+      const program = new commander.Command();
+      configureCommand(program);
+      program.argument('<file>').allowExcessArguments(false);
 
-    expect(() => {
-      program.parse(['file'], { from: 'user' });
-    }).not.toThrow();
-  });
+      expect(() => {
+        program.parse(['file'], { from: 'user' });
+      }).not.toThrow();
+    });
 
-  test('when specify excess after <arg> and allowExcessArguments(false) then error', () => {
-    const program = new commander.Command();
-    configureCommand(program);
-    program
-      .argument('<file>')
-      .allowExcessArguments(false);
+    test('when specify excess after <arg> and allowExcessArguments(false) then error', () => {
+      const program = new commander.Command();
+      configureCommand(program);
+      program.argument('<file>').allowExcessArguments(false);
 
-    expect(() => {
-      program.parse(['file', 'excess'], { from: 'user' });
-    }).toThrow();
-  });
+      expect(() => {
+        program.parse(['file', 'excess'], { from: 'user' });
+      }).toThrow();
+    });
 
-  test('when specify excess after [arg] and allowExcessArguments(false) then error', () => {
-    const program = new commander.Command();
-    configureCommand(program);
-    program
-      .argument('[file]')
-      .allowExcessArguments(false);
+    test('when specify excess after [arg] and allowExcessArguments(false) then error', () => {
+      const program = new commander.Command();
+      configureCommand(program);
+      program.argument('[file]').allowExcessArguments(false);
 
-    expect(() => {
-      program.parse(['file', 'excess'], { from: 'user' });
-    }).toThrow();
-  });
+      expect(() => {
+        program.parse(['file', 'excess'], { from: 'user' });
+      }).toThrow();
+    });
 
-  test('when specify args for [args...] and allowExcessArguments(false) then no error', () => {
-    const program = new commander.Command();
-    configureCommand(program);
-    program
-      .argument('[files...]')
-      .allowExcessArguments(false);
+    test('when specify args for [args...] and allowExcessArguments(false) then no error', () => {
+      const program = new commander.Command();
+      configureCommand(program);
+      program.argument('[files...]').allowExcessArguments(false);
 
-    expect(() => {
-      program.parse(['file1', 'file2', 'file3'], { from: 'user' });
-    }).not.toThrow();
-  });
-});
+      expect(() => {
+        program.parse(['file1', 'file2', 'file3'], { from: 'user' });
+      }).not.toThrow();
+    });
+  },
+);

--- a/tests/command.allowUnknownOption.test.js
+++ b/tests/command.allowUnknownOption.test.js
@@ -7,7 +7,9 @@ describe('allowUnknownOption', () => {
   let writeErrorSpy;
 
   beforeAll(() => {
-    writeErrorSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => { });
+    writeErrorSpy = jest
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -20,9 +22,7 @@ describe('allowUnknownOption', () => {
 
   test('when specify unknown program option then error', () => {
     const program = new commander.Command();
-    program
-      .exitOverride()
-      .option('-p, --pepper', 'add pepper');
+    program.exitOverride().option('-p, --pepper', 'add pepper');
 
     expect(() => {
       program.parse(['node', 'test', '-m']);
@@ -71,7 +71,7 @@ describe('allowUnknownOption', () => {
       .exitOverride()
       .command('sub')
       .option('-p, --pepper', 'add pepper')
-      .action(() => { });
+      .action(() => {});
 
     expect(() => {
       program.parse(['node', 'test', 'sub', '-m']);
@@ -86,7 +86,7 @@ describe('allowUnknownOption', () => {
       .argument('[args...]') // unknown option will be passed as an argument
       .allowUnknownOption()
       .option('-p, --pepper', 'add pepper')
-      .action(() => { });
+      .action(() => {});
 
     expect(() => {
       program.parse(['node', 'test', 'sub', '-m']);

--- a/tests/command.argumentVariations.test.js
+++ b/tests/command.argumentVariations.test.js
@@ -3,92 +3,123 @@ const commander = require('../');
 // Do some low-level checks that the multiple ways of specifying command arguments produce same internal result,
 // and not exhaustively testing all methods elsewhere.
 
-test.each(getSingleArgCases('<explicit-required>'))('when add "<arg>" using %s then argument required', (methodName, cmd) => {
-  const argument = cmd.registeredArguments[0];
-  const expectedShape = {
-    _name: 'explicit-required',
-    required: true,
-    variadic: false,
-    description: ''
-  };
-  expect(argument).toEqual(expectedShape);
-});
+test.each(getSingleArgCases('<explicit-required>'))(
+  'when add "<arg>" using %s then argument required',
+  (methodName, cmd) => {
+    const argument = cmd.registeredArguments[0];
+    const expectedShape = {
+      _name: 'explicit-required',
+      required: true,
+      variadic: false,
+      description: '',
+    };
+    expect(argument).toEqual(expectedShape);
+  },
+);
 
-test.each(getSingleArgCases('implicit-required'))('when add "arg" using %s then argument required', (methodName, cmd) => {
-  const argument = cmd.registeredArguments[0];
-  const expectedShape = {
-    _name: 'implicit-required',
-    required: true,
-    variadic: false,
-    description: ''
-  };
-  expect(argument).toEqual(expectedShape);
-});
+test.each(getSingleArgCases('implicit-required'))(
+  'when add "arg" using %s then argument required',
+  (methodName, cmd) => {
+    const argument = cmd.registeredArguments[0];
+    const expectedShape = {
+      _name: 'implicit-required',
+      required: true,
+      variadic: false,
+      description: '',
+    };
+    expect(argument).toEqual(expectedShape);
+  },
+);
 
-test.each(getSingleArgCases('[optional]'))('when add "[arg]" using %s then argument optional', (methodName, cmd) => {
-  const argument = cmd.registeredArguments[0];
-  const expectedShape = {
-    _name: 'optional',
-    required: false,
-    variadic: false,
-    description: ''
-  };
-  expect(argument).toEqual(expectedShape);
-});
+test.each(getSingleArgCases('[optional]'))(
+  'when add "[arg]" using %s then argument optional',
+  (methodName, cmd) => {
+    const argument = cmd.registeredArguments[0];
+    const expectedShape = {
+      _name: 'optional',
+      required: false,
+      variadic: false,
+      description: '',
+    };
+    expect(argument).toEqual(expectedShape);
+  },
+);
 
-test.each(getSingleArgCases('<explicit-required...>'))('when add "<arg...>" using %s then argument required and variadic', (methodName, cmd) => {
-  const argument = cmd.registeredArguments[0];
-  const expectedShape = {
-    _name: 'explicit-required',
-    required: true,
-    variadic: true,
-    description: ''
-  };
-  expect(argument).toEqual(expectedShape);
-});
+test.each(getSingleArgCases('<explicit-required...>'))(
+  'when add "<arg...>" using %s then argument required and variadic',
+  (methodName, cmd) => {
+    const argument = cmd.registeredArguments[0];
+    const expectedShape = {
+      _name: 'explicit-required',
+      required: true,
+      variadic: true,
+      description: '',
+    };
+    expect(argument).toEqual(expectedShape);
+  },
+);
 
-test.each(getSingleArgCases('implicit-required...'))('when add "arg..." using %s then argument required and variadic', (methodName, cmd) => {
-  const argument = cmd.registeredArguments[0];
-  const expectedShape = {
-    _name: 'implicit-required',
-    required: true,
-    variadic: true,
-    description: ''
-  };
-  expect(argument).toEqual(expectedShape);
-});
+test.each(getSingleArgCases('implicit-required...'))(
+  'when add "arg..." using %s then argument required and variadic',
+  (methodName, cmd) => {
+    const argument = cmd.registeredArguments[0];
+    const expectedShape = {
+      _name: 'implicit-required',
+      required: true,
+      variadic: true,
+      description: '',
+    };
+    expect(argument).toEqual(expectedShape);
+  },
+);
 
-test.each(getSingleArgCases('[optional...]'))('when add "[arg...]" using %s then argument optional and variadic', (methodName, cmd) => {
-  const argument = cmd.registeredArguments[0];
-  const expectedShape = {
-    _name: 'optional',
-    required: false,
-    variadic: true,
-    description: ''
-  };
-  expect(argument).toEqual(expectedShape);
-});
+test.each(getSingleArgCases('[optional...]'))(
+  'when add "[arg...]" using %s then argument optional and variadic',
+  (methodName, cmd) => {
+    const argument = cmd.registeredArguments[0];
+    const expectedShape = {
+      _name: 'optional',
+      required: false,
+      variadic: true,
+      description: '',
+    };
+    expect(argument).toEqual(expectedShape);
+  },
+);
 
 function getSingleArgCases(arg) {
   return [
     ['.arguments', new commander.Command().arguments(arg)],
     ['.argument', new commander.Command().argument(arg)],
-    ['.addArgument', new commander.Command('add-argument').addArgument(new commander.Argument(arg))],
-    ['.command', new commander.Command().command(`command ${arg}`)]
+    [
+      '.addArgument',
+      new commander.Command('add-argument').addArgument(
+        new commander.Argument(arg),
+      ),
+    ],
+    ['.command', new commander.Command().command(`command ${arg}`)],
   ];
 }
 
-test.each(getMultipleArgCases('<first>', '[second]'))('when add two arguments using %s then two arguments', (methodName, cmd) => {
-  expect(cmd.registeredArguments[0].name()).toEqual('first');
-  expect(cmd.registeredArguments[1].name()).toEqual('second');
-});
+test.each(getMultipleArgCases('<first>', '[second]'))(
+  'when add two arguments using %s then two arguments',
+  (methodName, cmd) => {
+    expect(cmd.registeredArguments[0].name()).toEqual('first');
+    expect(cmd.registeredArguments[1].name()).toEqual('second');
+  },
+);
 
 function getMultipleArgCases(arg1, arg2) {
   return [
     ['.arguments', new commander.Command().arguments(`${arg1} ${arg2}`)],
     ['.argument', new commander.Command().argument(arg1).argument(arg2)],
-    ['.addArgument', new commander.Command('add-argument').addArgument(new commander.Argument(arg1)).addArgument(new commander.Argument(arg2))],
-    ['.command', new commander.Command().command(`command ${arg1} ${arg2}`)]
+    [
+      '.addArgument',
+      new commander.Command('add-argument')
+        .addArgument(new commander.Argument(arg1))
+        .addArgument(new commander.Argument(arg2)),
+    ],
+    ['.command', new commander.Command().command(`command ${arg1} ${arg2}`)],
   ];
 }
 
@@ -99,6 +130,6 @@ test('when add arguments using multiple methods then all added', () => {
   cmd.arguments('<arg3> <arg4>');
   cmd.argument('<arg5>');
   cmd.addArgument(new commander.Argument('arg6'));
-  const argNames = cmd.registeredArguments.map(arg => arg.name());
+  const argNames = cmd.registeredArguments.map((arg) => arg.name());
   expect(argNames).toEqual(['arg1', 'arg2', 'arg3', 'arg4', 'arg5', 'arg6']);
 });

--- a/tests/command.asterisk.test.js
+++ b/tests/command.asterisk.test.js
@@ -12,7 +12,9 @@ const commander = require('../');
 
 describe(".command('*')", () => {
   test('when no arguments then asterisk action not called', () => {
-    const writeMock = jest.spyOn(process.stderr, 'write').mockImplementation(() => { });
+    const writeMock = jest
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => {});
     const mockAction = jest.fn();
     const program = new commander.Command();
     program
@@ -21,7 +23,9 @@ describe(".command('*')", () => {
       .action(mockAction);
     try {
       program.parse(['node', 'test']);
-    } catch (err) {  /* empty */ }
+    } catch (err) {
+      /* empty */
+    }
     expect(mockAction).not.toHaveBeenCalled();
     writeMock.mockRestore();
   });
@@ -29,10 +33,7 @@ describe(".command('*')", () => {
   test('when unrecognised argument then asterisk action called', () => {
     const mockAction = jest.fn();
     const program = new commander.Command();
-    program
-      .command('*')
-      .argument('[args...]')
-      .action(mockAction);
+    program.command('*').argument('[args...]').action(mockAction);
     program.parse(['node', 'test', 'unrecognised-command']);
     expect(mockAction).toHaveBeenCalled();
   });
@@ -40,12 +41,8 @@ describe(".command('*')", () => {
   test('when recognised command then asterisk action not called', () => {
     const mockAction = jest.fn();
     const program = new commander.Command();
-    program
-      .command('install')
-      .action(() => { });
-    program
-      .command('*')
-      .action(mockAction);
+    program.command('install').action(() => {});
+    program.command('*').action(mockAction);
     program.parse(['node', 'test', 'install']);
     expect(mockAction).not.toHaveBeenCalled();
   });
@@ -53,12 +50,8 @@ describe(".command('*')", () => {
   test('when unrecognised command/argument then asterisk action called', () => {
     const mockAction = jest.fn();
     const program = new commander.Command();
-    program
-      .command('install');
-    program
-      .command('*')
-      .argument('[args...]')
-      .action(mockAction);
+    program.command('install');
+    program.command('*').argument('[args...]').action(mockAction);
     program.parse(['node', 'test', 'unrecognised-command']);
     expect(mockAction).toHaveBeenCalled();
   });
@@ -67,8 +60,7 @@ describe(".command('*')", () => {
     // This tests for a regression between v4 and v5. Known default option should not be rejected by program.
     const mockAction = jest.fn();
     const program = new commander.Command();
-    program
-      .command('install');
+    program.command('install');
     const star = program
       .command('*')
       .argument('[args...]')
@@ -86,13 +78,10 @@ describe(".command('*')", () => {
     program
       .exitOverride()
       .configureOutput({
-        writeErr: () => {}
+        writeErr: () => {},
       })
       .command('install');
-    program
-      .command('*')
-      .argument('[args...]')
-      .action(mockAction);
+    program.command('*').argument('[args...]').action(mockAction);
     let caughtErr;
     try {
       program.parse(['node', 'test', 'some-argument', '--unknown']);
@@ -108,8 +97,7 @@ describe(".on('command:*')", () => {
   test('when no arguments then listener not called', () => {
     const mockAction = jest.fn();
     const program = new commander.Command();
-    program
-      .on('command:*', mockAction);
+    program.on('command:*', mockAction);
     program.parse(['node', 'test']);
     expect(mockAction).not.toHaveBeenCalled();
   });
@@ -117,8 +105,7 @@ describe(".on('command:*')", () => {
   test('when unrecognised argument then listener called', () => {
     const mockAction = jest.fn();
     const program = new commander.Command();
-    program
-      .on('command:*', mockAction);
+    program.on('command:*', mockAction);
     program.parse(['node', 'test', 'unrecognised-command']);
     expect(mockAction).toHaveBeenCalled();
   });
@@ -126,11 +113,8 @@ describe(".on('command:*')", () => {
   test('when recognised command then listener not called', () => {
     const mockAction = jest.fn();
     const program = new commander.Command();
-    program
-      .command('install')
-      .action(() => { });
-    program
-      .on('command:*', mockAction);
+    program.command('install').action(() => {});
+    program.on('command:*', mockAction);
     program.parse(['node', 'test', 'install']);
     expect(mockAction).not.toHaveBeenCalled();
   });
@@ -138,10 +122,8 @@ describe(".on('command:*')", () => {
   test('when unrecognised command/argument then listener called', () => {
     const mockAction = jest.fn();
     const program = new commander.Command();
-    program
-      .command('install');
-    program
-      .on('command:*', mockAction);
+    program.command('install');
+    program.on('command:*', mockAction);
     program.parse(['node', 'test', 'unrecognised-command']);
     expect(mockAction).toHaveBeenCalled();
   });
@@ -152,10 +134,8 @@ describe(".on('command:*')", () => {
     // Regression identified in https://github.com/tj/commander.js/issues/1460#issuecomment-772313494
     const mockAction = jest.fn();
     const program = new commander.Command();
-    program
-      .command('install');
-    program
-      .on('command:*', mockAction);
+    program.command('install');
+    program.on('command:*', mockAction);
     program.parse(['node', 'test', 'intsall', '--unknown']);
     expect(mockAction).toHaveBeenCalled();
   });

--- a/tests/command.chain.test.js
+++ b/tests/command.chain.test.js
@@ -84,13 +84,13 @@ describe('Command methods that should return this for chaining', () => {
 
   test('when call .exitOverride() then returns this', () => {
     const program = new Command();
-    const result = program.exitOverride(() => { });
+    const result = program.exitOverride(() => {});
     expect(result).toBe(program);
   });
 
   test('when call .action() then returns this', () => {
     const program = new Command();
-    const result = program.action(() => { });
+    const result = program.action(() => {});
     expect(result).toBe(program);
   });
 
@@ -193,13 +193,13 @@ describe('Command methods that should return this for chaining', () => {
 
   test('when call .configureHelp() then returns this', () => {
     const program = new Command();
-    const result = program.configureHelp({ });
+    const result = program.configureHelp({});
     expect(result).toBe(program);
   });
 
   test('when call .configureOutput() then returns this', () => {
     const program = new Command();
-    const result = program.configureOutput({ });
+    const result = program.configureOutput({});
     expect(result).toBe(program);
   });
 

--- a/tests/command.commandHelp.test.js
+++ b/tests/command.commandHelp.test.js
@@ -4,16 +4,14 @@ const commander = require('../');
 
 test('when program has command then appears in help', () => {
   const program = new commander.Command();
-  program
-    .command('bare');
+  program.command('bare');
   const commandHelp = program.helpInformation();
   expect(commandHelp).toMatch(/Commands:\n +bare\n/);
 });
 
 test('when program has command with optional arg then appears in help', () => {
   const program = new commander.Command();
-  program
-    .command('bare [bare-arg]');
+  program.command('bare [bare-arg]');
   const commandHelp = program.helpInformation();
   expect(commandHelp).toMatch(/Commands:\n +bare \[bare-arg\]\n/);
 });

--- a/tests/command.configureHelp.test.js
+++ b/tests/command.configureHelp.test.js
@@ -2,13 +2,21 @@ const commander = require('../');
 
 test('when configure program then affects program helpInformation', () => {
   const program = new commander.Command();
-  program.configureHelp({ formatHelp: () => { return 'custom'; } });
+  program.configureHelp({
+    formatHelp: () => {
+      return 'custom';
+    },
+  });
   expect(program.helpInformation()).toEqual('custom');
 });
 
 test('when configure program then affects subcommand helpInformation', () => {
   const program = new commander.Command();
-  program.configureHelp({ formatHelp: () => { return 'custom'; } });
+  program.configureHelp({
+    formatHelp: () => {
+      return 'custom';
+    },
+  });
   const sub = program.command('sub');
   expect(sub.helpInformation()).toEqual('custom');
 });
@@ -25,7 +33,7 @@ test('when configure with unknown property then helper passed to formatHelp has 
     mySecretValue: 'secret',
     formatHelp: (cmd, helper) => {
       return helper.mySecretValue;
-    }
+    },
   });
   expect(program.helpInformation()).toEqual('secret');
 });

--- a/tests/command.configureOutput.test.js
+++ b/tests/command.configureOutput.test.js
@@ -1,29 +1,35 @@
 const commander = require('../');
 
 test('when default writeErr() then error on stderr', () => {
-  const writeSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => { });
+  const writeSpy = jest
+    .spyOn(process.stderr, 'write')
+    .mockImplementation(() => {});
   const program = new commander.Command();
   program.exitOverride();
 
   try {
     program.parse(['--unknown'], { from: 'user' });
-  } catch (err) {  /* empty */ }
+  } catch (err) {
+    /* empty */
+  }
 
   expect(writeSpy).toHaveBeenCalledTimes(1);
   writeSpy.mockRestore();
 });
 
 test('when custom writeErr() then error on custom output', () => {
-  const writeSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => { });
+  const writeSpy = jest
+    .spyOn(process.stderr, 'write')
+    .mockImplementation(() => {});
   const customWrite = jest.fn();
   const program = new commander.Command();
-  program
-    .exitOverride()
-    .configureOutput({ writeErr: customWrite });
+  program.exitOverride().configureOutput({ writeErr: customWrite });
 
   try {
     program.parse(['--unknown'], { from: 'user' });
-  } catch (err) {  /* empty */ }
+  } catch (err) {
+    /* empty */
+  }
 
   expect(writeSpy).toHaveBeenCalledTimes(0);
   expect(customWrite).toHaveBeenCalledTimes(1);
@@ -31,11 +37,11 @@ test('when custom writeErr() then error on custom output', () => {
 });
 
 test('when default write() then version on stdout', () => {
-  const writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => { });
+  const writeSpy = jest
+    .spyOn(process.stdout, 'write')
+    .mockImplementation(() => {});
   const program = new commander.Command();
-  program
-    .exitOverride()
-    .version('1.2.3');
+  program.exitOverride().version('1.2.3');
 
   expect(() => {
     program.parse(['--version'], { from: 'user' });
@@ -46,7 +52,9 @@ test('when default write() then version on stdout', () => {
 });
 
 test('when custom write() then version on custom output', () => {
-  const writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => { });
+  const writeSpy = jest
+    .spyOn(process.stdout, 'write')
+    .mockImplementation(() => {});
   const customWrite = jest.fn();
   const program = new commander.Command();
   program
@@ -64,7 +72,9 @@ test('when custom write() then version on custom output', () => {
 });
 
 test('when default write() then help on stdout', () => {
-  const writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => { });
+  const writeSpy = jest
+    .spyOn(process.stdout, 'write')
+    .mockImplementation(() => {});
   const program = new commander.Command();
   program.outputHelp();
 
@@ -73,7 +83,9 @@ test('when default write() then help on stdout', () => {
 });
 
 test('when custom write() then help error on custom output', () => {
-  const writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => { });
+  const writeSpy = jest
+    .spyOn(process.stdout, 'write')
+    .mockImplementation(() => {});
   const customWrite = jest.fn();
   const program = new commander.Command();
   program.configureOutput({ writeOut: customWrite });
@@ -85,7 +97,9 @@ test('when custom write() then help error on custom output', () => {
 });
 
 test('when default writeErr then help error on stderr', () => {
-  const writeSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => { });
+  const writeSpy = jest
+    .spyOn(process.stderr, 'write')
+    .mockImplementation(() => {});
   const program = new commander.Command();
   program.outputHelp({ error: true });
 
@@ -94,7 +108,9 @@ test('when default writeErr then help error on stderr', () => {
 });
 
 test('when custom writeErr then help error on custom output', () => {
-  const writeSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => { });
+  const writeSpy = jest
+    .spyOn(process.stderr, 'write')
+    .mockImplementation(() => {});
   const customWrite = jest.fn();
   const program = new commander.Command();
   program.configureOutput({ writeErr: customWrite });
@@ -115,13 +131,12 @@ test('when default getOutHelpWidth then help helpWidth from stdout', () => {
   process.stdout.columns = expectedColumns;
   process.stdout.isTTY = true;
   const program = new commander.Command();
-  program
-    .configureHelp({
-      formatHelp: (cmd, helper) => {
-        helpWidth = helper.helpWidth;
-        return '';
-      }
-    });
+  program.configureHelp({
+    formatHelp: (cmd, helper) => {
+      helpWidth = helper.helpWidth;
+      return '';
+    },
+  });
   program.outputHelp();
 
   expect(helpWidth).toBe(expectedColumns);
@@ -139,9 +154,10 @@ test('when custom getOutHelpWidth then help helpWidth custom', () => {
       formatHelp: (cmd, helper) => {
         helpWidth = helper.helpWidth;
         return '';
-      }
-    }).configureOutput({
-      getOutHelpWidth: () => expectedColumns
+      },
+    })
+    .configureOutput({
+      getOutHelpWidth: () => expectedColumns,
     });
   program.outputHelp();
 
@@ -157,13 +173,12 @@ test('when default getErrHelpWidth then help error helpWidth from stderr', () =>
   process.stderr.isTTY = true;
   process.stderr.columns = expectedColumns;
   const program = new commander.Command();
-  program
-    .configureHelp({
-      formatHelp: (cmd, helper) => {
-        helpWidth = helper.helpWidth;
-        return '';
-      }
-    });
+  program.configureHelp({
+    formatHelp: (cmd, helper) => {
+      helpWidth = helper.helpWidth;
+      return '';
+    },
+  });
   program.outputHelp({ error: true });
 
   expect(helpWidth).toBe(expectedColumns);
@@ -181,9 +196,10 @@ test('when custom getErrHelpWidth then help error helpWidth custom', () => {
       formatHelp: (cmd, helper) => {
         helpWidth = helper.helpWidth;
         return '';
-      }
-    }).configureOutput({
-      getErrHelpWidth: () => expectedColumns
+      },
+    })
+    .configureOutput({
+      getErrHelpWidth: () => expectedColumns,
     });
   program.outputHelp({ error: true });
 
@@ -201,9 +217,10 @@ test('when custom getOutHelpWidth and configureHelp:helpWidth then help helpWidt
         helpWidth = helper.helpWidth;
         return '';
       },
-      helpWidth: expectedColumns
-    }).configureOutput({
-      getOutHelpWidth: () => 999
+      helpWidth: expectedColumns,
+    })
+    .configureOutput({
+      getOutHelpWidth: () => 999,
     });
   program.outputHelp();
 
@@ -221,9 +238,10 @@ test('when custom getErrHelpWidth and configureHelp:helpWidth then help error he
         helpWidth = helper.helpWidth;
         return '';
       },
-      helpWidth: expectedColumns
-    }).configureOutput({
-      getErrHelpWidth: () => 999
+      helpWidth: expectedColumns,
+    })
+    .configureOutput({
+      getErrHelpWidth: () => 999,
     });
   program.outputHelp({ error: true });
 
@@ -236,7 +254,7 @@ test('when set configureOutput then get configureOutput', () => {
     writeErr: jest.fn(),
     getOutHelpWidth: jest.fn(),
     getErrHelpWidth: jest.fn(),
-    outputError: jest.fn()
+    outputError: jest.fn(),
   };
   const program = new commander.Command();
   program.configureOutput(outputOptions);
@@ -246,28 +264,30 @@ test('when set configureOutput then get configureOutput', () => {
 test('when custom outputErr and error then outputErr called', () => {
   const outputError = jest.fn();
   const program = new commander.Command();
-  program
-    .exitOverride()
-    .configureOutput({
-      outputError
-    });
+  program.exitOverride().configureOutput({
+    outputError,
+  });
 
   expect(() => {
     program.parse(['--unknownOption'], { from: 'user' });
   }).toThrow();
-  expect(outputError).toHaveBeenCalledWith("error: unknown option '--unknownOption'\n", program._outputConfiguration.writeErr);
+  expect(outputError).toHaveBeenCalledWith(
+    "error: unknown option '--unknownOption'\n",
+    program._outputConfiguration.writeErr,
+  );
 });
 
 test('when custom outputErr and writeErr and error then outputErr passed writeErr', () => {
   const writeErr = () => jest.fn();
   const outputError = jest.fn();
   const program = new commander.Command();
-  program
-    .exitOverride()
-    .configureOutput({ writeErr, outputError });
+  program.exitOverride().configureOutput({ writeErr, outputError });
 
   expect(() => {
     program.parse(['--unknownOption'], { from: 'user' });
   }).toThrow();
-  expect(outputError).toHaveBeenCalledWith("error: unknown option '--unknownOption'\n", writeErr);
+  expect(outputError).toHaveBeenCalledWith(
+    "error: unknown option '--unknownOption'\n",
+    writeErr,
+  );
 });

--- a/tests/command.default.test.js
+++ b/tests/command.default.test.js
@@ -9,17 +9,17 @@ describe('default executable command', () => {
   // Calling node explicitly so pm works without file suffix cross-platform.
   const pm = path.join(__dirname, './fixtures/pm');
 
-  test('when default subcommand and no command then call default', async() => {
+  test('when default subcommand and no command then call default', async () => {
     const { stdout } = await execFileAsync('node', [pm]);
     expect(stdout).toBe('default\n');
   });
 
-  test('when default subcommand and unrecognised argument then call default with argument', async() => {
+  test('when default subcommand and unrecognised argument then call default with argument', async () => {
     const { stdout } = await execFileAsync('node', [pm, 'an-argument']);
     expect(stdout).toBe("default\n[ 'an-argument' ]\n");
   });
 
-  test('when default subcommand and unrecognised option then call default with option', async() => {
+  test('when default subcommand and unrecognised option then call default with option', async () => {
     const { stdout } = await execFileAsync('node', [pm, '--an-option']);
     expect(stdout).toBe("default\n[ '--an-option' ]\n");
   });
@@ -29,8 +29,7 @@ describe('default action command', () => {
   function makeProgram() {
     const program = new commander.Command();
     const actionMock = jest.fn();
-    program
-      .command('other');
+    program.command('other');
     program
       .command('default', { isDefault: true })
       .allowUnknownOption()
@@ -67,10 +66,8 @@ describe('default added command', () => {
       .action(actionMock);
 
     const program = new commander.Command();
-    program
-      .command('other');
-    program
-      .addCommand(defaultCmd, { isDefault: true });
+    program.command('other');
+    program.addCommand(defaultCmd, { isDefault: true });
     return { program, actionMock };
   }
 

--- a/tests/command.error.test.js
+++ b/tests/command.error.test.js
@@ -1,8 +1,10 @@
 const commander = require('../');
 
 test('when error called with message then message displayed on stderr', () => {
-  const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => { });
-  const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => { });
+  const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});
+  const stderrSpy = jest
+    .spyOn(process.stderr, 'write')
+    .mockImplementation(() => {});
 
   const program = new commander.Command();
   const message = 'Goodbye';
@@ -14,11 +16,11 @@ test('when error called with message then message displayed on stderr', () => {
 });
 
 test('when error called with no exitCode then process.exit(1)', () => {
-  const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => { });
+  const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});
 
   const program = new commander.Command();
   program.configureOutput({
-    writeErr: () => {}
+    writeErr: () => {},
   });
 
   program.error('Goodbye');
@@ -28,11 +30,11 @@ test('when error called with no exitCode then process.exit(1)', () => {
 });
 
 test('when error called with exitCode 2 then process.exit(2)', () => {
-  const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => { });
+  const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});
 
   const program = new commander.Command();
   program.configureOutput({
-    writeErr: () => {}
+    writeErr: () => {},
   });
   program.error('Goodbye', { exitCode: 2 });
 
@@ -44,9 +46,12 @@ test('when error called with code and exitOverride then throws with code', () =>
   const program = new commander.Command();
   let errorThrown;
   program
-    .exitOverride((err) => { errorThrown = err; throw err; })
+    .exitOverride((err) => {
+      errorThrown = err;
+      throw err;
+    })
     .configureOutput({
-      writeErr: () => {}
+      writeErr: () => {},
     });
 
   const code = 'commander.test';

--- a/tests/command.executableSubcommand.inspect.test.js
+++ b/tests/command.executableSubcommand.inspect.test.js
@@ -9,48 +9,76 @@ const execFileAsync = util.promisify(childProcess.execFile);
 
 const inspectCommand = path.join(__dirname, './fixtures', 'inspect.js');
 
-test('when execArgv empty then spawn execArgs empty', async() => {
+test('when execArgv empty then spawn execArgs empty', async () => {
   const { stdout } = await execFileAsync('node', [inspectCommand, 'sub']);
   expect(stdout).toBe('[]\n');
 });
 
-test('when execArgv --harmony then spawn execArgs --harmony', async() => {
-  const { stdout } = await execFileAsync('node', ['--harmony', inspectCommand, 'sub']);
+test('when execArgv --harmony then spawn execArgs --harmony', async () => {
+  const { stdout } = await execFileAsync('node', [
+    '--harmony',
+    inspectCommand,
+    'sub',
+  ]);
   expect(stdout).toBe("[ '--harmony' ]\n");
 });
 
 // --inspect defaults to 127.0.0.1:9229, port should be incremented
-test('when execArgv --inspect then spawn execArgs using port 9230', async() => {
-  const { stdout } = await execFileAsync('node', ['--inspect', inspectCommand, 'sub']);
+test('when execArgv --inspect then spawn execArgs using port 9230', async () => {
+  const { stdout } = await execFileAsync('node', [
+    '--inspect',
+    inspectCommand,
+    'sub',
+  ]);
   expect(stdout).toBe("[ '--inspect=127.0.0.1:9230' ]\n");
 });
 
 // custom port
-test('when execArgv --inspect=9240 then spawn execArgs using port 9241', async() => {
-  const { stdout } = await execFileAsync('node', ['--inspect=9240', inspectCommand, 'sub']);
+test('when execArgv --inspect=9240 then spawn execArgs using port 9241', async () => {
+  const { stdout } = await execFileAsync('node', [
+    '--inspect=9240',
+    inspectCommand,
+    'sub',
+  ]);
   expect(stdout).toBe("[ '--inspect=127.0.0.1:9241' ]\n");
 });
 
 // zero is special, random port
-test('when execArgv --inspect=0 then spawn execArgs --inspect=0', async() => {
-  const { stdout } = await execFileAsync('node', ['--inspect=0', inspectCommand, 'sub']);
+test('when execArgv --inspect=0 then spawn execArgs --inspect=0', async () => {
+  const { stdout } = await execFileAsync('node', [
+    '--inspect=0',
+    inspectCommand,
+    'sub',
+  ]);
   expect(stdout).toBe("[ '--inspect=0' ]\n");
 });
 
 // ip address
-test('when execArgv --inspect=127.0.0.1:9250 then spawn execArgs --inspect=127.0.0.1:9251', async() => {
-  const { stdout } = await execFileAsync('node', ['--inspect=127.0.0.1:9250', inspectCommand, 'sub']);
+test('when execArgv --inspect=127.0.0.1:9250 then spawn execArgs --inspect=127.0.0.1:9251', async () => {
+  const { stdout } = await execFileAsync('node', [
+    '--inspect=127.0.0.1:9250',
+    inspectCommand,
+    'sub',
+  ]);
   expect(stdout).toBe("[ '--inspect=127.0.0.1:9251' ]\n");
 });
 
 // localhost
-test('when execArgv --inspect=localhost:9260 then spawn execArgs --inspect=localhost:9261', async() => {
-  const { stdout } = await execFileAsync('node', ['--inspect=localhost:9260', inspectCommand, 'sub']);
+test('when execArgv --inspect=localhost:9260 then spawn execArgs --inspect=localhost:9261', async () => {
+  const { stdout } = await execFileAsync('node', [
+    '--inspect=localhost:9260',
+    inspectCommand,
+    'sub',
+  ]);
   expect(stdout).toBe("[ '--inspect=localhost:9261' ]\n");
 });
 
 // --inspect-port, just test most likely format
-test('when execArgv --inspect-port=9270 then spawn execArgs --inspect-port=127.0.0.1:9271', async() => {
-  const { stdout } = await execFileAsync('node', ['--inspect-port=9270', inspectCommand, 'sub']);
+test('when execArgv --inspect-port=9270 then spawn execArgs --inspect-port=127.0.0.1:9271', async () => {
+  const { stdout } = await execFileAsync('node', [
+    '--inspect-port=9270',
+    inspectCommand,
+    'sub',
+  ]);
   expect(stdout).toBe("[ '--inspect-port=127.0.0.1:9271' ]\n");
 });

--- a/tests/command.executableSubcommand.lookup.test.js
+++ b/tests/command.executableSubcommand.lookup.test.js
@@ -10,7 +10,7 @@ const execFileAsync = util.promisify(childProcess.execFile);
 // Suppress false positive warnings due to use of testOrSkipOnWindows
 /* eslint-disable jest/no-standalone-expect */
 
-const testOrSkipOnWindows = (process.platform === 'win32') ? test.skip : test;
+const testOrSkipOnWindows = process.platform === 'win32' ? test.skip : test;
 const pm = path.join(__dirname, './fixtures/pm');
 
 test('when subcommand file missing then error', () => {
@@ -41,49 +41,55 @@ test('when alias subcommand file missing then error', () => {
   });
 });
 
-test('when subcommand file has no suffix then lookup succeeds', async() => {
+test('when subcommand file has no suffix then lookup succeeds', async () => {
   const { stdout } = await execFileAsync('node', [pm, 'install']);
   expect(stdout).toBe('install\n');
 });
 
-test('when alias subcommand file has no suffix then lookup succeeds', async() => {
+test('when alias subcommand file has no suffix then lookup succeeds', async () => {
   const { stdout } = await execFileAsync('node', [pm, 'i']);
   expect(stdout).toBe('install\n');
 });
 
-test('when subcommand target executablefile has no suffix then lookup succeeds', async() => {
+test('when subcommand target executablefile has no suffix then lookup succeeds', async () => {
   const { stdout } = await execFileAsync('node', [pm, 'specifyInstall']);
   expect(stdout).toBe('install\n');
 });
 
-test('when subcommand file suffix .js then lookup succeeds', async() => {
+test('when subcommand file suffix .js then lookup succeeds', async () => {
   const { stdout } = await execFileAsync('node', [pm, 'publish']);
   expect(stdout).toBe('publish\n');
 });
 
-test('when alias subcommand file suffix .js then lookup succeeds', async() => {
+test('when alias subcommand file suffix .js then lookup succeeds', async () => {
   const { stdout } = await execFileAsync('node', [pm, 'p']);
   expect(stdout).toBe('publish\n');
 });
 
-test('when subcommand target executablefile has suffix .js then lookup succeeds', async() => {
+test('when subcommand target executablefile has suffix .js then lookup succeeds', async () => {
   const { stdout } = await execFileAsync('node', [pm, 'specifyPublish']);
   expect(stdout).toBe('publish\n');
 });
 
-testOrSkipOnWindows('when subcommand file is symlink then lookup succeeds', async() => {
-  const pmlink = path.join(__dirname, 'fixtures', 'pmlink');
-  const { stdout } = await execFileAsync('node', [pmlink, 'install']);
-  expect(stdout).toBe('install\n');
-});
+testOrSkipOnWindows(
+  'when subcommand file is symlink then lookup succeeds',
+  async () => {
+    const pmlink = path.join(__dirname, 'fixtures', 'pmlink');
+    const { stdout } = await execFileAsync('node', [pmlink, 'install']);
+    expect(stdout).toBe('install\n');
+  },
+);
 
-testOrSkipOnWindows('when subcommand file is double symlink then lookup succeeds', async() => {
-  const pmlink = path.join(__dirname, 'fixtures', 'another-dir', 'pm');
-  const { stdout } = await execFileAsync('node', [pmlink, 'install']);
-  expect(stdout).toBe('install\n');
-});
+testOrSkipOnWindows(
+  'when subcommand file is double symlink then lookup succeeds',
+  async () => {
+    const pmlink = path.join(__dirname, 'fixtures', 'another-dir', 'pm');
+    const { stdout } = await execFileAsync('node', [pmlink, 'install']);
+    expect(stdout).toBe('install\n');
+  },
+);
 
-test('when subcommand suffix is .ts then lookup succeeds', async() => {
+test('when subcommand suffix is .ts then lookup succeeds', async () => {
   // We support looking for ts files for ts-node in particular, but don't need to test ts-node itself.
   // The subcommand is both plain JavaScript code for this test.
   const binLinkTs = path.join(__dirname, 'fixtures-extensions', 'pm.js');
@@ -92,19 +98,19 @@ test('when subcommand suffix is .ts then lookup succeeds', async() => {
   expect(stdout).toBe('found .ts\n');
 });
 
-test('when subcommand suffix is .cjs then lookup succeeds', async() => {
+test('when subcommand suffix is .cjs then lookup succeeds', async () => {
   const binLinkTs = path.join(__dirname, 'fixtures-extensions', 'pm.js');
   const { stdout } = await execFileAsync('node', [binLinkTs, 'try-cjs']);
   expect(stdout).toBe('found .cjs\n');
 });
 
-test('when subcommand suffix is .mjs then lookup succeeds', async() => {
+test('when subcommand suffix is .mjs then lookup succeeds', async () => {
   const binLinkTs = path.join(__dirname, 'fixtures-extensions', 'pm.js');
   const { stdout } = await execFileAsync('node', [binLinkTs, 'try-mjs']);
   expect(stdout).toBe('found .mjs\n');
 });
 
-test('when subsubcommand then lookup sub-sub-command', async() => {
+test('when subsubcommand then lookup sub-sub-command', async () => {
   const { stdout } = await execFileAsync('node', [pm, 'cache', 'clear']);
   expect(stdout).toBe('cache-clear\n');
 });

--- a/tests/command.executableSubcommand.mock.test.js
+++ b/tests/command.executableSubcommand.mock.test.js
@@ -16,7 +16,9 @@ test('when subcommand executable missing (ENOENT) then throw custom message', ()
   // If the command is not found, we show a custom error with an explanation and offer
   // some advice for possible fixes.
   const mockProcess = new EventEmitter();
-  const spawnSpy = jest.spyOn(childProcess, 'spawn').mockImplementation(() => { return mockProcess; });
+  const spawnSpy = jest.spyOn(childProcess, 'spawn').mockImplementation(() => {
+    return mockProcess;
+  });
   const program = new commander.Command();
   program.exitOverride();
   program.command('executable', 'executable description');
@@ -30,7 +32,9 @@ test('when subcommand executable missing (ENOENT) then throw custom message', ()
 test('when subcommand executable not executable (EACCES) then throw custom message', () => {
   // Side note: this error does not actually happen on Windows! But we can still simulate the behaviour on other platforms.
   const mockProcess = new EventEmitter();
-  const spawnSpy = jest.spyOn(childProcess, 'spawn').mockImplementation(() => { return mockProcess; });
+  const spawnSpy = jest.spyOn(childProcess, 'spawn').mockImplementation(() => {
+    return mockProcess;
+  });
   const program = new commander.Command();
   program.exitOverride();
   program.command('executable', 'executable description');
@@ -45,7 +49,9 @@ test('when subcommand executable fails with other error  and exitOverride then r
   // The existing behaviour is to just silently fail for unexpected errors, as it is happening
   // asynchronously in spawned process and client can not catch errors.
   const mockProcess = new EventEmitter();
-  const spawnSpy = jest.spyOn(childProcess, 'spawn').mockImplementation(() => { return mockProcess; });
+  const spawnSpy = jest.spyOn(childProcess, 'spawn').mockImplementation(() => {
+    return mockProcess;
+  });
   const program = new commander.Command();
   program.exitOverride((err) => {
     throw err;
@@ -67,8 +73,10 @@ test('when subcommand executable fails with other error then exit', () => {
   // The existing behaviour is to just silently fail for unexpected errors, as it is happening
   // asynchronously in spawned process and client can not catch errors.
   const mockProcess = new EventEmitter();
-  const spawnSpy = jest.spyOn(childProcess, 'spawn').mockImplementation(() => { return mockProcess; });
-  const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => { });
+  const spawnSpy = jest.spyOn(childProcess, 'spawn').mockImplementation(() => {
+    return mockProcess;
+  });
+  const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});
   const program = new commander.Command();
   program.command('executable', 'executable description');
   program.parse(['executable'], { from: 'user' });

--- a/tests/command.executableSubcommand.search.test.js
+++ b/tests/command.executableSubcommand.search.test.js
@@ -21,7 +21,8 @@ function extractMockSpawnCommand(mock) {
   return mock.mock.calls[0][0];
 }
 
-const describeOrSkipOnWindows = (process.platform === 'win32') ? describe.skip : describe;
+const describeOrSkipOnWindows =
+  process.platform === 'win32' ? describe.skip : describe;
 
 describe('search for subcommand', () => {
   let spawnSpy;
@@ -31,7 +32,7 @@ describe('search for subcommand', () => {
     spawnSpy = jest.spyOn(childProcess, 'spawn').mockImplementation(() => {
       return {
         on: () => {},
-        killed: true
+        killed: true,
       };
     });
   });
@@ -84,45 +85,50 @@ describe('search for subcommand', () => {
   });
 
   // We always use node on Windows, and don't spawn executable as the command (which may be a feature or a shortcoming!?).
-  describeOrSkipOnWindows('subcommand command name with no matching local file (non-Windows)', () => {
-    beforeEach(() => {
-      existsSpy.mockImplementation(() => false);
-    });
+  describeOrSkipOnWindows(
+    'subcommand command name with no matching local file (non-Windows)',
+    () => {
+      beforeEach(() => {
+        existsSpy.mockImplementation(() => false);
+      });
 
-    test('when named pm and no script arg or executableDir then spawn pm-sub as command', () => {
-      const program = new commander.Command();
-      program.name('pm');
-      program.command('sub', 'executable description');
-      program.parse(['sub'], { from: 'user' });
+      test('when named pm and no script arg or executableDir then spawn pm-sub as command', () => {
+        const program = new commander.Command();
+        program.name('pm');
+        program.command('sub', 'executable description');
+        program.parse(['sub'], { from: 'user' });
 
-      expect(extractMockSpawnCommand(spawnSpy)).toEqual('pm-sub');
-    });
+        expect(extractMockSpawnCommand(spawnSpy)).toEqual('pm-sub');
+      });
 
-    test('when named pm and script arg then still spawn pm-sub as command', () => {
-      const program = new commander.Command();
-      program.name('pm');
-      program.command('sub', 'executable description');
-      program.parse(['node', 'script-name', 'sub']);
+      test('when named pm and script arg then still spawn pm-sub as command', () => {
+        const program = new commander.Command();
+        program.name('pm');
+        program.command('sub', 'executable description');
+        program.parse(['node', 'script-name', 'sub']);
 
-      expect(extractMockSpawnCommand(spawnSpy)).toEqual('pm-sub');
-    });
+        expect(extractMockSpawnCommand(spawnSpy)).toEqual('pm-sub');
+      });
 
-    test('when no name and script arg then spawn script-sub as command', () => {
-      const program = new commander.Command();
-      program.command('sub', 'executable description');
-      program.parse(['node', 'script.js', 'sub']);
+      test('when no name and script arg then spawn script-sub as command', () => {
+        const program = new commander.Command();
+        program.command('sub', 'executable description');
+        program.parse(['node', 'script.js', 'sub']);
 
-      expect(extractMockSpawnCommand(spawnSpy)).toEqual('script-sub');
-    });
+        expect(extractMockSpawnCommand(spawnSpy)).toEqual('script-sub');
+      });
 
-    test('when named pm and script arg and executableFile then spawn executableFile as command', () => {
-      const program = new commander.Command();
-      program.command('sub', 'executable description', { executableFile: 'myExecutable' });
-      program.parse(['node', 'script.js', 'sub']);
+      test('when named pm and script arg and executableFile then spawn executableFile as command', () => {
+        const program = new commander.Command();
+        program.command('sub', 'executable description', {
+          executableFile: 'myExecutable',
+        });
+        program.parse(['node', 'script.js', 'sub']);
 
-      expect(extractMockSpawnCommand(spawnSpy)).toEqual('myExecutable');
-    });
-  });
+        expect(extractMockSpawnCommand(spawnSpy)).toEqual('myExecutable');
+      });
+    },
+  );
 
   describe('subcommand command name with matching local file', () => {
     test('when construct with name pm and script arg then spawn local pm-sub.js', () => {
@@ -131,7 +137,11 @@ describe('search for subcommand', () => {
 
       const localPath = path.resolve(gLocalDirectory, 'pm-sub.js');
       existsSpy.mockImplementation((path) => path === localPath);
-      program.parse(['node', path.resolve(gLocalDirectory, 'script.js'), 'sub']);
+      program.parse([
+        'node',
+        path.resolve(gLocalDirectory, 'script.js'),
+        'sub',
+      ]);
 
       expect(extractMockSpawnArgs(spawnSpy)).toEqual([localPath]);
     });
@@ -143,7 +153,11 @@ describe('search for subcommand', () => {
 
       const localPath = path.resolve(gLocalDirectory, 'pm-sub.js');
       existsSpy.mockImplementation((path) => path === localPath);
-      program.parse(['node', path.resolve(gLocalDirectory, 'script.js'), 'sub']);
+      program.parse([
+        'node',
+        path.resolve(gLocalDirectory, 'script.js'),
+        'sub',
+      ]);
 
       expect(extractMockSpawnArgs(spawnSpy)).toEqual([localPath]);
     });
@@ -154,7 +168,11 @@ describe('search for subcommand', () => {
 
       const localPath = path.resolve(gLocalDirectory, 'script-sub.js');
       existsSpy.mockImplementation((path) => path === localPath);
-      program.parse(['node', path.resolve(gLocalDirectory, 'script.js'), 'sub']);
+      program.parse([
+        'node',
+        path.resolve(gLocalDirectory, 'script.js'),
+        'sub',
+      ]);
 
       expect(extractMockSpawnArgs(spawnSpy)).toEqual([localPath]);
     });
@@ -167,7 +185,11 @@ describe('search for subcommand', () => {
       // Fallback for compatibility with Commander <= v8
       const localPath = path.resolve(gLocalDirectory, 'script-sub.js');
       existsSpy.mockImplementation((path) => path === localPath);
-      program.parse(['node', path.resolve(gLocalDirectory, 'script.js'), 'sub']);
+      program.parse([
+        'node',
+        path.resolve(gLocalDirectory, 'script.js'),
+        'sub',
+      ]);
 
       expect(extractMockSpawnArgs(spawnSpy)).toEqual([localPath]);
     });
@@ -207,7 +229,11 @@ describe('search for subcommand', () => {
       program.executableDir(execDir);
       const localPath = path.resolve(execDir, 'script-sub.js');
       existsSpy.mockImplementation((path) => path === localPath);
-      program.parse(['node', path.resolve(gLocalDirectory, 'script-Dir', 'script'), 'sub']);
+      program.parse([
+        'node',
+        path.resolve(gLocalDirectory, 'script-Dir', 'script'),
+        'sub',
+      ]);
 
       expect(extractMockSpawnArgs(spawnSpy)).toEqual([localPath]);
     });
@@ -218,10 +244,16 @@ describe('search for subcommand', () => {
 
       const linkPath = path.resolve(gLocalDirectory, 'link', 'link');
       const scriptPath = path.resolve(gLocalDirectory, 'script', 'script.js');
-      const scriptSubPath = path.resolve(gLocalDirectory, 'script', 'link-sub.js');
-      const realPathSyncSpy = jest.spyOn(fs, 'realpathSync').mockImplementation((path) => {
-        return path === linkPath ? scriptPath : linkPath;
-      });
+      const scriptSubPath = path.resolve(
+        gLocalDirectory,
+        'script',
+        'link-sub.js',
+      );
+      const realPathSyncSpy = jest
+        .spyOn(fs, 'realpathSync')
+        .mockImplementation((path) => {
+          return path === linkPath ? scriptPath : linkPath;
+        });
       existsSpy.mockImplementation((path) => path === scriptSubPath);
       program.parse(['node', linkPath, 'sub']);
       realPathSyncSpy.mockRestore();
@@ -233,10 +265,16 @@ describe('search for subcommand', () => {
       const program = new commander.Command('pm');
       const localPath = path.join('relative', 'exec.js');
       const absolutePath = path.resolve(gLocalDirectory, localPath);
-      program.command('sub', 'executable description', { executableFile: localPath });
+      program.command('sub', 'executable description', {
+        executableFile: localPath,
+      });
 
       existsSpy.mockImplementation((path) => path === absolutePath);
-      program.parse(['node', path.resolve(gLocalDirectory, 'script.js'), 'sub']);
+      program.parse([
+        'node',
+        path.resolve(gLocalDirectory, 'script.js'),
+        'sub',
+      ]);
 
       expect(extractMockSpawnArgs(spawnSpy)).toEqual([absolutePath]);
     });
@@ -244,10 +282,16 @@ describe('search for subcommand', () => {
     test('when name pm and script arg and absolute executableFile then spawn local exec.js', () => {
       const program = new commander.Command('pm');
       const localPath = path.resolve(gLocalDirectory, 'absolute', 'exec.js');
-      program.command('sub', 'executable description', { executableFile: localPath });
+      program.command('sub', 'executable description', {
+        executableFile: localPath,
+      });
 
       existsSpy.mockImplementation((path) => path === localPath);
-      program.parse(['node', path.resolve(gLocalDirectory, 'script.js'), 'sub']);
+      program.parse([
+        'node',
+        path.resolve(gLocalDirectory, 'script.js'),
+        'sub',
+      ]);
 
       expect(extractMockSpawnArgs(spawnSpy)).toEqual([localPath]);
     });
@@ -262,7 +306,9 @@ describe('search for subcommand', () => {
       program.parse(['node', scriptPath, 'sub']);
       const sourceExt = ['.js', '.ts', '.tsx', '.mjs', '.cjs'];
       sourceExt.forEach((ext) => {
-        expect(existsSpy).toHaveBeenCalledWith(path.resolve(gLocalDirectory, `script-sub${ext}`));
+        expect(existsSpy).toHaveBeenCalledWith(
+          path.resolve(gLocalDirectory, `script-sub${ext}`),
+        );
       });
     });
   });

--- a/tests/command.executableSubcommand.signals.test.js
+++ b/tests/command.executableSubcommand.signals.test.js
@@ -6,27 +6,31 @@ const pmPath = path.join(__dirname, 'fixtures', 'pm');
 // Disabling some tests on Windows as:
 // "Windows does not support sending signals"
 //  https://nodejs.org/api/process.html#process_signal_events
-const describeOrSkipOnWindows = (process.platform === 'win32') ? describe.skip : describe;
+const describeOrSkipOnWindows =
+  process.platform === 'win32' ? describe.skip : describe;
 
 describeOrSkipOnWindows('signals', () => {
-  test.each(['SIGINT', 'SIGHUP', 'SIGTERM', 'SIGUSR1', 'SIGUSR2'])('when program sent %s then executableSubcommand sent signal too', (signal, done) => {
-    // Spawn program. The listen subcommand waits for a signal and writes the name of the signal to stdout.
-    const proc = childProcess.spawn(pmPath, ['listen'], {});
+  test.each(['SIGINT', 'SIGHUP', 'SIGTERM', 'SIGUSR1', 'SIGUSR2'])(
+    'when program sent %s then executableSubcommand sent signal too',
+    (signal, done) => {
+      // Spawn program. The listen subcommand waits for a signal and writes the name of the signal to stdout.
+      const proc = childProcess.spawn(pmPath, ['listen'], {});
 
-    let processOutput = '';
-    proc.stdout.on('data', (data) => {
-      if (processOutput.length === 0) {
-        // Send signal to program.
-        proc.kill(`${signal}`);
-      }
-      processOutput += data.toString();
-    });
-    proc.on('close', (code) => {
-      // Check the child subcommand received the signal too.
-      expect(processOutput).toBe(`Listening for signal...${signal}`);
-      done();
-    });
-  });
+      let processOutput = '';
+      proc.stdout.on('data', (data) => {
+        if (processOutput.length === 0) {
+          // Send signal to program.
+          proc.kill(`${signal}`);
+        }
+        processOutput += data.toString();
+      });
+      proc.on('close', (code) => {
+        // Check the child subcommand received the signal too.
+        expect(processOutput).toBe(`Listening for signal...${signal}`);
+        done();
+      });
+    },
+  );
 
   test('when executable subcommand sent signal then program exit code is non-zero', () => {
     const { status } = childProcess.spawnSync(pmPath, ['terminate'], {});
@@ -34,13 +38,21 @@ describeOrSkipOnWindows('signals', () => {
   });
 
   test('when command has exitOverride and executable subcommand sent signal then exit code is non-zero', () => {
-    const { status } = childProcess.spawnSync(pmPath, ['exit-override', 'terminate'], {});
+    const { status } = childProcess.spawnSync(
+      pmPath,
+      ['exit-override', 'terminate'],
+      {},
+    );
     expect(status).toBeGreaterThan(0);
   });
 
   // Not a signal test, but closely related code so adding here.
   test('when command has exitOverride and executable subcommand fails then program exit code is subcommand exit code', () => {
-    const { status } = childProcess.spawnSync(pmPath, ['exit-override', 'fail'], {});
+    const { status } = childProcess.spawnSync(
+      pmPath,
+      ['exit-override', 'fail'],
+      {},
+    );
     expect(status).toEqual(42);
   });
 });

--- a/tests/command.executableSubcommand.test.js
+++ b/tests/command.executableSubcommand.test.js
@@ -5,10 +5,14 @@ const commander = require('../');
 // This is the default behaviour when no default command and no action handlers
 test('when no command specified and executable then display help', () => {
   // Optional. Suppress normal output to keep test output clean.
-  const writeSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => { });
+  const writeSpy = jest
+    .spyOn(process.stderr, 'write')
+    .mockImplementation(() => {});
   const program = new commander.Command();
   program
-    .exitOverride((err) => { throw err; })
+    .exitOverride((err) => {
+      throw err;
+    })
     .command('install', 'install description');
   expect(() => {
     program.parse(['node', 'test']);

--- a/tests/command.exitOverride.test.js
+++ b/tests/command.exitOverride.test.js
@@ -20,7 +20,9 @@ describe('.exitOverride and error details', () => {
   let stderrSpy;
 
   beforeAll(() => {
-    stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => { });
+    stderrSpy = jest
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -33,8 +35,7 @@ describe('.exitOverride and error details', () => {
 
   test('when specify unknown program option then throw CommanderError', () => {
     const program = new commander.Command();
-    program
-      .exitOverride();
+    program.exitOverride();
 
     let caughtErr;
     try {
@@ -44,15 +45,17 @@ describe('.exitOverride and error details', () => {
     }
 
     expect(stderrSpy).toHaveBeenCalled();
-    expectCommanderError(caughtErr, 1, 'commander.unknownOption', "error: unknown option '-m'");
+    expectCommanderError(
+      caughtErr,
+      1,
+      'commander.unknownOption',
+      "error: unknown option '-m'",
+    );
   });
 
   test('when specify unknown command then throw CommanderError', () => {
     const program = new commander.Command();
-    program
-      .name('prog')
-      .exitOverride()
-      .command('sub');
+    program.name('prog').exitOverride().command('sub');
 
     let caughtErr;
     try {
@@ -62,17 +65,25 @@ describe('.exitOverride and error details', () => {
     }
 
     expect(stderrSpy).toHaveBeenCalled();
-    expectCommanderError(caughtErr, 1, 'commander.unknownCommand', "error: unknown command 'oops'");
+    expectCommanderError(
+      caughtErr,
+      1,
+      'commander.unknownCommand',
+      "error: unknown command 'oops'",
+    );
   });
 
   // Same error as above, but with custom handler.
   test('when supply custom handler then throw custom error', () => {
-    const customError = new commander.CommanderError(123, 'custom-code', 'custom-message');
+    const customError = new commander.CommanderError(
+      123,
+      'custom-code',
+      'custom-message',
+    );
     const program = new commander.Command();
-    program
-      .exitOverride((_err) => {
-        throw customError;
-      });
+    program.exitOverride((_err) => {
+      throw customError;
+    });
 
     let caughtErr;
     try {
@@ -81,15 +92,18 @@ describe('.exitOverride and error details', () => {
       caughtErr = err;
     }
 
-    expectCommanderError(caughtErr, customError.exitCode, customError.code, customError.message);
+    expectCommanderError(
+      caughtErr,
+      customError.exitCode,
+      customError.code,
+      customError.message,
+    );
   });
 
   test('when specify option without required value then throw CommanderError', () => {
     const optionFlags = '-p, --pepper <type>';
     const program = new commander.Command();
-    program
-      .exitOverride()
-      .option(optionFlags, 'add pepper');
+    program.exitOverride().option(optionFlags, 'add pepper');
 
     let caughtErr;
     try {
@@ -99,7 +113,12 @@ describe('.exitOverride and error details', () => {
     }
 
     expect(stderrSpy).toHaveBeenCalled();
-    expectCommanderError(caughtErr, 1, 'commander.optionMissingArgument', `error: option '${optionFlags}' argument missing`);
+    expectCommanderError(
+      caughtErr,
+      1,
+      'commander.optionMissingArgument',
+      `error: option '${optionFlags}' argument missing`,
+    );
   });
 
   test('when specify command without required argument then throw CommanderError', () => {
@@ -107,7 +126,7 @@ describe('.exitOverride and error details', () => {
     program
       .exitOverride()
       .command('compress <arg-name>')
-      .action(() => { });
+      .action(() => {});
 
     let caughtErr;
     try {
@@ -117,14 +136,17 @@ describe('.exitOverride and error details', () => {
     }
 
     expect(stderrSpy).toHaveBeenCalled();
-    expectCommanderError(caughtErr, 1, 'commander.missingArgument', "error: missing required argument 'arg-name'");
+    expectCommanderError(
+      caughtErr,
+      1,
+      'commander.missingArgument',
+      "error: missing required argument 'arg-name'",
+    );
   });
 
   test('when specify program without required argument and no action handler then throw CommanderError', () => {
     const program = new commander.Command();
-    program
-      .exitOverride()
-      .argument('<arg-name>');
+    program.exitOverride().argument('<arg-name>');
 
     let caughtErr;
     try {
@@ -134,7 +156,12 @@ describe('.exitOverride and error details', () => {
     }
 
     expect(stderrSpy).toHaveBeenCalled();
-    expectCommanderError(caughtErr, 1, 'commander.missingArgument', "error: missing required argument 'arg-name'");
+    expectCommanderError(
+      caughtErr,
+      1,
+      'commander.missingArgument',
+      "error: missing required argument 'arg-name'",
+    );
   });
 
   test('when specify excess argument then throw CommanderError', () => {
@@ -142,7 +169,7 @@ describe('.exitOverride and error details', () => {
     program
       .exitOverride()
       .allowExcessArguments(false)
-      .action(() => { });
+      .action(() => {});
 
     let caughtErr;
     try {
@@ -152,7 +179,12 @@ describe('.exitOverride and error details', () => {
     }
 
     expect(stderrSpy).toHaveBeenCalled();
-    expectCommanderError(caughtErr, 1, 'commander.excessArguments', 'error: too many arguments. Expected 0 arguments but got 1.');
+    expectCommanderError(
+      caughtErr,
+      1,
+      'commander.excessArguments',
+      'error: too many arguments. Expected 0 arguments but got 1.',
+    );
   });
 
   test('when specify command with excess argument then throw CommanderError', () => {
@@ -161,7 +193,7 @@ describe('.exitOverride and error details', () => {
       .exitOverride()
       .command('speak')
       .allowExcessArguments(false)
-      .action(() => { });
+      .action(() => {});
 
     let caughtErr;
     try {
@@ -171,14 +203,20 @@ describe('.exitOverride and error details', () => {
     }
 
     expect(stderrSpy).toHaveBeenCalled();
-    expectCommanderError(caughtErr, 1, 'commander.excessArguments', "error: too many arguments for 'speak'. Expected 0 arguments but got 1.");
+    expectCommanderError(
+      caughtErr,
+      1,
+      'commander.excessArguments',
+      "error: too many arguments for 'speak'. Expected 0 arguments but got 1.",
+    );
   });
 
   test('when specify --help then throw CommanderError', () => {
-    const writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => { });
+    const writeSpy = jest
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => {});
     const program = new commander.Command();
-    program
-      .exitOverride();
+    program.exitOverride();
 
     let caughtErr;
     try {
@@ -187,15 +225,18 @@ describe('.exitOverride and error details', () => {
       caughtErr = err;
     }
 
-    expectCommanderError(caughtErr, 0, 'commander.helpDisplayed', '(outputHelp)');
+    expectCommanderError(
+      caughtErr,
+      0,
+      'commander.helpDisplayed',
+      '(outputHelp)',
+    );
     writeSpy.mockRestore();
   });
 
   test('when executable subcommand and no command specified then throw CommanderError', () => {
     const program = new commander.Command();
-    program
-      .exitOverride()
-      .command('compress', 'compress description');
+    program.exitOverride().command('compress', 'compress description');
 
     let caughtErr;
     try {
@@ -208,12 +249,12 @@ describe('.exitOverride and error details', () => {
   });
 
   test('when specify --version then throw CommanderError', () => {
-    const stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => { });
+    const stdoutSpy = jest
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => {});
     const myVersion = '1.2.3';
     const program = new commander.Command();
-    program
-      .exitOverride()
-      .version(myVersion);
+    program.exitOverride().version(myVersion);
 
     let caughtErr;
     try {
@@ -226,14 +267,19 @@ describe('.exitOverride and error details', () => {
     stdoutSpy.mockRestore();
   });
 
-  test('when executableSubcommand succeeds then call exitOverride', async() => {
+  test('when executableSubcommand succeeds then call exitOverride', async () => {
     expect.hasAssertions();
     const pm = path.join(__dirname, 'fixtures/pm');
     const program = new commander.Command();
     await new Promise((resolve) => {
       program
         .exitOverride((err) => {
-          expectCommanderError(err, 0, 'commander.executeSubCommandAsync', '(close)');
+          expectCommanderError(
+            err,
+            0,
+            'commander.executeSubCommandAsync',
+            '(close)',
+          );
           resolve();
         })
         .command('silent', 'description');
@@ -244,9 +290,7 @@ describe('.exitOverride and error details', () => {
   test('when mandatory program option missing then throw CommanderError', () => {
     const optionFlags = '-p, --pepper <type>';
     const program = new commander.Command();
-    program
-      .exitOverride()
-      .requiredOption(optionFlags, 'add pepper');
+    program.exitOverride().requiredOption(optionFlags, 'add pepper');
 
     let caughtErr;
     try {
@@ -255,7 +299,12 @@ describe('.exitOverride and error details', () => {
       caughtErr = err;
     }
 
-    expectCommanderError(caughtErr, 1, 'commander.missingMandatoryOptionValue', `error: required option '${optionFlags}' not specified`);
+    expectCommanderError(
+      caughtErr,
+      1,
+      'commander.missingMandatoryOptionValue',
+      `error: required option '${optionFlags}' not specified`,
+    );
   });
 
   test('when option argument not in choices then throw CommanderError', () => {
@@ -272,7 +321,12 @@ describe('.exitOverride and error details', () => {
       caughtErr = err;
     }
 
-    expectCommanderError(caughtErr, 1, 'commander.invalidArgument', "error: option '--colour <shade>' argument 'green' is invalid. Allowed choices are red, blue.");
+    expectCommanderError(
+      caughtErr,
+      1,
+      'commander.invalidArgument',
+      "error: option '--colour <shade>' argument 'green' is invalid. Allowed choices are red, blue.",
+    );
   });
 
   test('when command argument not in choices then throw CommanderError', () => {
@@ -289,7 +343,12 @@ describe('.exitOverride and error details', () => {
       caughtErr = err;
     }
 
-    expectCommanderError(caughtErr, 1, 'commander.invalidArgument', "error: command-argument value 'green' is invalid for argument 'shade'. Allowed choices are red, blue.");
+    expectCommanderError(
+      caughtErr,
+      1,
+      'commander.invalidArgument',
+      "error: command-argument value 'green' is invalid for argument 'shade'. Allowed choices are red, blue.",
+    );
   });
 
   test('when custom processing for option throws InvalidArgumentError then catch CommanderError', () => {
@@ -298,9 +357,7 @@ describe('.exitOverride and error details', () => {
     }
     const optionFlags = '--colour <shade>';
     const program = new commander.Command();
-    program
-      .exitOverride()
-      .option(optionFlags, 'specify shade', justSayNo);
+    program.exitOverride().option(optionFlags, 'specify shade', justSayNo);
 
     let caughtErr;
     try {
@@ -309,7 +366,12 @@ describe('.exitOverride and error details', () => {
       caughtErr = err;
     }
 
-    expectCommanderError(caughtErr, 1, 'commander.invalidArgument', "error: option '--colour <shade>' argument 'green' is invalid. NO");
+    expectCommanderError(
+      caughtErr,
+      1,
+      'commander.invalidArgument',
+      "error: option '--colour <shade>' argument 'green' is invalid. NO",
+    );
   });
 
   test('when custom processing for argument throws InvalidArgumentError then catch CommanderError', () => {
@@ -329,7 +391,12 @@ describe('.exitOverride and error details', () => {
       caughtErr = err;
     }
 
-    expectCommanderError(caughtErr, 1, 'commander.invalidArgument', "error: command-argument value 'green' is invalid for argument 'n'. NO");
+    expectCommanderError(
+      caughtErr,
+      1,
+      'commander.invalidArgument',
+      "error: command-argument value 'green' is invalid for argument 'n'. NO",
+    );
   });
 
   test('when has conflicting option then throw CommanderError', () => {
@@ -346,13 +413,17 @@ describe('.exitOverride and error details', () => {
       caughtErr = err;
     }
 
-    expectCommanderError(caughtErr, 1, 'commander.conflictingOption', "error: option '--debug' cannot be used with option '--silent'");
+    expectCommanderError(
+      caughtErr,
+      1,
+      'commander.conflictingOption',
+      "error: option '--debug' cannot be used with option '--silent'",
+    );
   });
 
   test('when call error() then throw CommanderError', () => {
     const program = new commander.Command();
-    program
-      .exitOverride();
+    program.exitOverride();
 
     let caughtErr;
     try {
@@ -366,7 +437,7 @@ describe('.exitOverride and error details', () => {
 });
 
 test('when no override and error then exit(1)', () => {
-  const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => { });
+  const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});
   const program = new commander.Command();
   program.configureOutput({ outputError: () => {} });
   program.parse(['--unknownOption'], { from: 'user' });

--- a/tests/command.help.test.js
+++ b/tests/command.help.test.js
@@ -8,10 +8,8 @@ const commander = require('../');
 // Avoid doing many full format tests as will be broken by any layout changes!
 test('when call helpInformation for program then help format is as expected (usage, options, commands)', () => {
   const program = new commander.Command();
-  program
-    .command('my-command <file>');
-  const expectedHelpInformation =
-`Usage: test [options] [command]
+  program.command('my-command <file>');
+  const expectedHelpInformation = `Usage: test [options] [command]
 
 Options:
   -h, --help         display help for command
@@ -28,9 +26,7 @@ Commands:
 
 test('when use .description for command then help includes description', () => {
   const program = new commander.Command();
-  program
-    .command('simple-command')
-    .description('custom-description');
+  program.command('simple-command').description('custom-description');
   program._help = 'test';
   const helpInformation = program.helpInformation();
   expect(helpInformation).toMatch(/simple-command +custom-description/);
@@ -38,10 +34,11 @@ test('when use .description for command then help includes description', () => {
 
 test('when call .help then exit', () => {
   // Optional. Suppress normal output to keep test output clean.
-  const writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => { });
+  const writeSpy = jest
+    .spyOn(process.stdout, 'write')
+    .mockImplementation(() => {});
   const program = new commander.Command();
-  program
-    .exitOverride();
+  program.exitOverride();
   expect(() => {
     program.help();
   }).toThrow('(outputHelp)');
@@ -50,10 +47,11 @@ test('when call .help then exit', () => {
 
 test('when specify --help then exit', () => {
   // Optional. Suppress normal output to keep test output clean.
-  const writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => { });
+  const writeSpy = jest
+    .spyOn(process.stdout, 'write')
+    .mockImplementation(() => {});
   const program = new commander.Command();
-  program
-    .exitOverride();
+  program.exitOverride();
   expect(() => {
     program.parse(['node', 'test', '--help']);
   }).toThrow('(outputHelp)');
@@ -62,11 +60,12 @@ test('when specify --help then exit', () => {
 
 test('when call help(cb) then display cb output and exit', () => {
   // Using spy to detect custom output
-  const writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => { });
+  const writeSpy = jest
+    .spyOn(process.stdout, 'write')
+    .mockImplementation(() => {});
   const helpReplacement = 'reformatted help';
   const program = new commander.Command();
-  program
-    .exitOverride();
+  program.exitOverride();
   expect(() => {
     program.help((helpInformation) => {
       return helpReplacement;
@@ -78,7 +77,9 @@ test('when call help(cb) then display cb output and exit', () => {
 
 test('when call outputHelp(cb) then display cb output', () => {
   // Using spy to detect custom output
-  const writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => { });
+  const writeSpy = jest
+    .spyOn(process.stdout, 'write')
+    .mockImplementation(() => {});
   const helpReplacement = 'reformatted help';
   const program = new commander.Command();
   program.outputHelp((helpInformation) => {
@@ -97,16 +98,14 @@ test('when call deprecated outputHelp(cb) with wrong callback return type then t
 
 test('when command sets deprecated noHelp then not displayed in helpInformation', () => {
   const program = new commander.Command();
-  program
-    .command('secret', 'secret description', { noHelp: true });
+  program.command('secret', 'secret description', { noHelp: true });
   const helpInformation = program.helpInformation();
   expect(helpInformation).not.toMatch('secret');
 });
 
 test('when command sets hidden then not displayed in helpInformation', () => {
   const program = new commander.Command();
-  program
-    .command('secret', 'secret description', { hidden: true });
+  program.command('secret', 'secret description', { hidden: true });
   const helpInformation = program.helpInformation();
   expect(helpInformation).not.toMatch('secret');
 });
@@ -115,33 +114,31 @@ test('when addCommand with hidden:true then not displayed in helpInformation', (
   const secretCmd = new commander.Command('secret');
 
   const program = new commander.Command();
-  program
-    .addCommand(secretCmd, { hidden: true });
+  program.addCommand(secretCmd, { hidden: true });
   const helpInformation = program.helpInformation();
   expect(helpInformation).not.toMatch('secret');
 });
 
 test('when help short flag masked then not displayed in helpInformation', () => {
   const program = new commander.Command();
-  program
-    .option('-h, --host', 'select host');
+  program.option('-h, --host', 'select host');
   const helpInformation = program.helpInformation();
   expect(helpInformation).not.toMatch(/\W-h\W.*display help/);
 });
 
 test('when both help flags masked then not displayed in helpInformation', () => {
   const program = new commander.Command();
-  program
-    .option('-h, --help', 'custom');
+  program.option('-h, --help', 'custom');
   const helpInformation = program.helpInformation();
   expect(helpInformation).not.toMatch('display help');
 });
 
 test('when call .help then output on stdout', () => {
-  const writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => { });
+  const writeSpy = jest
+    .spyOn(process.stdout, 'write')
+    .mockImplementation(() => {});
   const program = new commander.Command();
-  program
-    .exitOverride();
+  program.exitOverride();
   expect(() => {
     program.help();
   }).toThrow('(outputHelp)');
@@ -150,10 +147,11 @@ test('when call .help then output on stdout', () => {
 });
 
 test('when call .help with { error: true } then output on stderr', () => {
-  const writeSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => { });
+  const writeSpy = jest
+    .spyOn(process.stderr, 'write')
+    .mockImplementation(() => {});
   const program = new commander.Command();
-  program
-    .exitOverride();
+  program.exitOverride();
   expect(() => {
     program.help({ error: true });
   }).toThrow('(outputHelp)');
@@ -164,16 +162,14 @@ test('when call .help with { error: true } then output on stderr', () => {
 test('when no options then Options not included in helpInformation', () => {
   const program = new commander.Command();
   // No custom options, no version option, no help option
-  program
-    .helpOption(false);
+  program.helpOption(false);
   const helpInformation = program.helpInformation();
   expect(helpInformation).not.toMatch('Options');
 });
 
 test('when negated option then option included in helpInformation', () => {
   const program = new commander.Command();
-  program
-    .option('-C, --no-colour', 'colourless');
+  program.option('-C, --no-colour', 'colourless');
   const helpInformation = program.helpInformation();
   expect(helpInformation).toMatch('--no-colour');
   expect(helpInformation).toMatch('colourless');
@@ -181,85 +177,91 @@ test('when negated option then option included in helpInformation', () => {
 
 test('when option.hideHelp() then option not included in helpInformation', () => {
   const program = new commander.Command();
-  program
-    .addOption(new commander.Option('-s,--secret', 'secret option').hideHelp());
+  program.addOption(
+    new commander.Option('-s,--secret', 'secret option').hideHelp(),
+  );
   const helpInformation = program.helpInformation();
   expect(helpInformation).not.toMatch('secret');
 });
 
 test('when option.hideHelp(true) then option not included in helpInformation', () => {
   const program = new commander.Command();
-  program
-    .addOption(new commander.Option('-s,--secret', 'secret option').hideHelp(true));
+  program.addOption(
+    new commander.Option('-s,--secret', 'secret option').hideHelp(true),
+  );
   const helpInformation = program.helpInformation();
   expect(helpInformation).not.toMatch('secret');
 });
 
 test('when option.hideHelp(false) then option included in helpInformation', () => {
   const program = new commander.Command();
-  program
-    .addOption(new commander.Option('-s,--secret', 'secret option').hideHelp(false));
+  program.addOption(
+    new commander.Option('-s,--secret', 'secret option').hideHelp(false),
+  );
   const helpInformation = program.helpInformation();
   expect(helpInformation).toMatch('secret');
 });
 
 test('when option has default value then default included in helpInformation', () => {
   const program = new commander.Command();
-  program
-    .option('-p, --port <portNumber>', 'port number', 80);
+  program.option('-p, --port <portNumber>', 'port number', 80);
   const helpInformation = program.helpInformation();
   expect(helpInformation).toMatch('(default: 80)');
 });
 
 test('when option has default value description then default description included in helpInformation', () => {
   const program = new commander.Command();
-  program
-    .addOption(new commander.Option('-a, --address <dotted>', 'ip address').default('127.0.0.1', 'home'));
+  program.addOption(
+    new commander.Option('-a, --address <dotted>', 'ip address').default(
+      '127.0.0.1',
+      'home',
+    ),
+  );
   const helpInformation = program.helpInformation();
   expect(helpInformation).toMatch('(default: home)');
 });
 
 test('when option has choices then choices included in helpInformation', () => {
   const program = new commander.Command();
-  program
-    .addOption(new commander.Option('-c, --colour <colour>').choices(['red', 'blue']));
+  program.addOption(
+    new commander.Option('-c, --colour <colour>').choices(['red', 'blue']),
+  );
   const helpInformation = program.helpInformation();
   expect(helpInformation).toMatch('(choices: "red", "blue")');
 });
 
 test('when option has choices and default then both included in helpInformation', () => {
   const program = new commander.Command();
-  program
-    .addOption(new commander.Option('-c, --colour <colour>').choices(['red', 'blue']).default('red'));
+  program.addOption(
+    new commander.Option('-c, --colour <colour>')
+      .choices(['red', 'blue'])
+      .default('red'),
+  );
   const helpInformation = program.helpInformation();
   expect(helpInformation).toMatch('(choices: "red", "blue", default: "red")');
 });
 
 test('when argument then included in helpInformation', () => {
   const program = new commander.Command();
-  program
-    .name('foo')
-    .argument('<file>');
+  program.name('foo').argument('<file>');
   const helpInformation = program.helpInformation();
   expect(helpInformation).toMatch('Usage: foo [options] <file>');
 });
 
 test('when argument described then included in helpInformation', () => {
   const program = new commander.Command();
-  program
-    .argument('<file>', 'input source')
-    .helpOption(false);
+  program.argument('<file>', 'input source').helpOption(false);
   const helpInformation = program.helpInformation();
   expect(helpInformation).toMatch(/Arguments:\n +file +input source/);
 });
 
 test('when argument described with default then included in helpInformation', () => {
   const program = new commander.Command();
-  program
-    .argument('[file]', 'input source', 'test.txt')
-    .helpOption(false);
+  program.argument('[file]', 'input source', 'test.txt').helpOption(false);
   const helpInformation = program.helpInformation();
-  expect(helpInformation).toMatch(/Arguments:\n +file +input source \(default: "test.txt"\)/);
+  expect(helpInformation).toMatch(
+    /Arguments:\n +file +input source \(default: "test.txt"\)/,
+  );
 });
 
 test('when arguments described in deprecated way then included in helpInformation', () => {
@@ -284,16 +286,23 @@ test('when arguments described in deprecated way and empty description then argu
 
 test('when argument has choices then choices included in helpInformation', () => {
   const program = new commander.Command();
-  program
-    .addArgument(new commander.Argument('<colour>', 'preferred colour').choices(['red', 'blue']));
+  program.addArgument(
+    new commander.Argument('<colour>', 'preferred colour').choices([
+      'red',
+      'blue',
+    ]),
+  );
   const helpInformation = program.helpInformation();
   expect(helpInformation).toMatch('(choices: "red", "blue")');
 });
 
 test('when argument has choices and default then both included in helpInformation', () => {
   const program = new commander.Command();
-  program
-    .addArgument(new commander.Argument('<colour>', 'preferred colour').choices(['red', 'blue']).default('red'));
+  program.addArgument(
+    new commander.Argument('<colour>', 'preferred colour')
+      .choices(['red', 'blue'])
+      .default('red'),
+  );
   const helpInformation = program.helpInformation();
   expect(helpInformation).toMatch('(choices: "red", "blue", default: "red")');
 });

--- a/tests/command.helpCommand.test.js
+++ b/tests/command.helpCommand.test.js
@@ -59,8 +59,10 @@ describe('help command processed on correct command', () => {
   let writeSpy;
 
   beforeAll(() => {
-    writeErrorSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => { });
-    writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => { });
+    writeErrorSpy = jest
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => {});
+    writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -77,7 +79,9 @@ describe('help command processed on correct command', () => {
     const program = new commander.Command();
     program.exitOverride();
     program.command('sub1');
-    program.exitOverride(() => { throw new Error('program'); });
+    program.exitOverride(() => {
+      throw new Error('program');
+    });
     expect(() => {
       program.parse('node test.js help'.split(' '));
     }).toThrow('program');
@@ -87,7 +91,9 @@ describe('help command processed on correct command', () => {
     const program = new commander.Command();
     program.exitOverride();
     program.command('sub1');
-    program.exitOverride(() => { throw new Error('program'); });
+    program.exitOverride(() => {
+      throw new Error('program');
+    });
     expect(() => {
       program.parse('node test.js help unknown'.split(' '));
     }).toThrow('program');
@@ -97,7 +103,9 @@ describe('help command processed on correct command', () => {
     const program = new commander.Command();
     program.exitOverride();
     const sub1 = program.command('sub1');
-    sub1.exitOverride(() => { throw new Error('sub1'); });
+    sub1.exitOverride(() => {
+      throw new Error('sub1');
+    });
     expect(() => {
       program.parse('node test.js help sub1'.split(' '));
     }).toThrow('sub1');
@@ -108,7 +116,9 @@ describe('help command processed on correct command', () => {
     program.exitOverride();
     const sub1 = program.command('sub1');
     const sub2 = sub1.command('sub2');
-    sub2.exitOverride(() => { throw new Error('sub2'); });
+    sub2.exitOverride(() => {
+      throw new Error('sub2');
+    });
     expect(() => {
       program.parse('node test.js sub1 help sub2'.split(' '));
     }).toThrow('sub2');
@@ -118,7 +128,9 @@ describe('help command processed on correct command', () => {
     const program = new commander.Command();
     program.exitOverride();
     program.command('sub1', { isDefault: true });
-    program.exitOverride(() => { throw new Error('program'); });
+    program.exitOverride(() => {
+      throw new Error('program');
+    });
     expect(() => {
       program.parse('node test.js help'.split(' '));
     }).toThrow('program');
@@ -130,7 +142,9 @@ describe('help command processed on correct command', () => {
     program.helpOption('-H');
     const sub = program.command('sub');
     // Patch help for easy way to check called.
-    sub.help = () => { throw new Error('sub help'); };
+    sub.help = () => {
+      throw new Error('sub help');
+    };
     expect(() => {
       program.parse(['help', 'sub'], { from: 'user' });
     }).toThrow('sub help');
@@ -139,10 +153,11 @@ describe('help command processed on correct command', () => {
   test('when no help options in sub then "help sub" works', () => {
     const program = new commander.Command();
     program.exitOverride();
-    const sub = program.command('sub')
-      .helpOption(false);
+    const sub = program.command('sub').helpOption(false);
     // Patch help for easy way to check called.
-    sub.help = () => { throw new Error('sub help'); };
+    sub.help = () => {
+      throw new Error('sub help');
+    };
     expect(() => {
       program.parse(['help', 'sub'], { from: 'user' });
     }).toThrow('sub help');
@@ -155,7 +170,9 @@ describe('help command processed on correct command', () => {
     program.helpOption('-h, --help');
     sub.helpOption('-a, --assist');
     // Patch help for easy way to check called.
-    sub.help = () => { throw new Error('sub help'); };
+    sub.help = () => {
+      throw new Error('sub help');
+    };
     expect(() => {
       program.parse(['help', 'sub'], { from: 'user' });
     }).toThrow('sub help');

--- a/tests/command.helpOption.test.js
+++ b/tests/command.helpOption.test.js
@@ -6,8 +6,10 @@ describe('helpOption', () => {
 
   beforeAll(() => {
     // Optional. Suppress expected output to keep test output clean.
-    writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => { });
-    writeErrorSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => { });
+    writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => {});
+    writeErrorSpy = jest
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -22,9 +24,7 @@ describe('helpOption', () => {
 
   test('when helpOption has custom flags then custom short flag invokes help', () => {
     const program = new commander.Command();
-    program
-      .exitOverride()
-      .helpOption('-c,--custom-help', 'custom help output');
+    program.exitOverride().helpOption('-c,--custom-help', 'custom help output');
     expect(() => {
       program.parse(['-c'], { from: 'user' });
     }).toThrow('(outputHelp)');
@@ -32,9 +32,7 @@ describe('helpOption', () => {
 
   test('when helpOption has custom flags then custom long flag invokes help', () => {
     const program = new commander.Command();
-    program
-      .exitOverride()
-      .helpOption('-c,--custom-help', 'custom help output');
+    program.exitOverride().helpOption('-c,--custom-help', 'custom help output');
     expect(() => {
       program.parse(['--custom-help'], { from: 'user' });
     }).toThrow('(outputHelp)');
@@ -42,9 +40,7 @@ describe('helpOption', () => {
 
   test('when helpOption has just custom short flag then custom short flag invokes help', () => {
     const program = new commander.Command();
-    program
-      .exitOverride()
-      .helpOption('-c', 'custom help output');
+    program.exitOverride().helpOption('-c', 'custom help output');
     expect(() => {
       program.parse(['-c'], { from: 'user' });
     }).toThrow('(outputHelp)');
@@ -52,9 +48,7 @@ describe('helpOption', () => {
 
   test('when helpOption has just custom long flag then custom long flag invokes help', () => {
     const program = new commander.Command();
-    program
-      .exitOverride()
-      .helpOption('--custom-help', 'custom help output');
+    program.exitOverride().helpOption('--custom-help', 'custom help output');
     expect(() => {
       program.parse(['--custom-help'], { from: 'user' });
     }).toThrow('(outputHelp)');
@@ -62,41 +56,37 @@ describe('helpOption', () => {
 
   test('when helpOption has custom description then helpInformation include custom description', () => {
     const program = new commander.Command();
-    program
-      .helpOption('-C,--custom-help', 'custom help output');
+    program.helpOption('-C,--custom-help', 'custom help output');
     const helpInformation = program.helpInformation();
     expect(helpInformation).toMatch(/-C,--custom-help +custom help output/);
   });
 
   test('when helpOption has just flags then helpInformation includes default description', () => {
     const program = new commander.Command();
-    program
-      .helpOption('-C,--custom-help');
+    program.helpOption('-C,--custom-help');
     const helpInformation = program.helpInformation();
-    expect(helpInformation).toMatch(/-C,--custom-help +display help for command/);
+    expect(helpInformation).toMatch(
+      /-C,--custom-help +display help for command/,
+    );
   });
 
   test('when helpOption has just description then helpInformation includes default flags', () => {
     const program = new commander.Command();
-    program
-      .helpOption(undefined, 'custom help output');
+    program.helpOption(undefined, 'custom help output');
     const helpInformation = program.helpInformation();
     expect(helpInformation).toMatch(/-h, --help +custom help output/);
   });
 
   test('when helpOption(false) then helpInformation does not include --help', () => {
     const program = new commander.Command();
-    program
-      .helpOption(false);
+    program.helpOption(false);
     const helpInformation = program.helpInformation();
     expect(helpInformation).not.toMatch('--help');
   });
 
   test('when helpOption(false) then --help is an unknown option', () => {
     const program = new commander.Command();
-    program
-      .exitOverride()
-      .helpOption(false);
+    program.exitOverride().helpOption(false);
     let caughtErr;
     try {
       program.parse(['--help'], { from: 'user' });
@@ -108,9 +98,7 @@ describe('helpOption', () => {
 
   test('when helpOption(false) then -h is an unknown option', () => {
     const program = new commander.Command();
-    program
-      .exitOverride()
-      .helpOption(false);
+    program.exitOverride().helpOption(false);
     let caughtErr;
     try {
       program.parse(['-h'], { from: 'user' });
@@ -122,10 +110,7 @@ describe('helpOption', () => {
 
   test('when helpOption(false) then unknown command error does not suggest --help', () => {
     const program = new commander.Command();
-    program
-      .exitOverride()
-      .helpOption(false)
-      .command('foo');
+    program.exitOverride().helpOption(false).command('foo');
     expect(() => {
       program.parse(['UNKNOWN'], { from: 'user' });
     }).toThrow("error: unknown command 'UNKNOWN'");

--- a/tests/command.hook.test.js
+++ b/tests/command.hook.test.js
@@ -10,9 +10,7 @@ test('when hook event wrong then throw', () => {
 test('when no action then action hooks not called', () => {
   const hook = jest.fn();
   const program = new commander.Command();
-  program
-    .hook('preAction', hook)
-    .hook('postAction', hook);
+  program.hook('preAction', hook).hook('postAction', hook);
   program.parse([], { from: 'user' });
   expect(hook).not.toHaveBeenCalled();
 });
@@ -63,9 +61,9 @@ describe('action hooks with synchronous hooks, order', () => {
   test('when hook preAction at program and sub then hooks called program then sub', () => {
     const calls = [];
     const program = new commander.Command();
+    program.hook('preAction', () => calls.push('program'));
     program
-      .hook('preAction', () => calls.push('program'));
-    program.command('sub')
+      .command('sub')
       .hook('preAction', () => calls.push('sub'))
       .action(() => calls.push('action'));
     program.parse(['sub'], { from: 'user' });
@@ -75,9 +73,9 @@ describe('action hooks with synchronous hooks, order', () => {
   test('when hook postAction at program and sub then hooks called sub then program', () => {
     const calls = [];
     const program = new commander.Command();
+    program.hook('postAction', () => calls.push('program'));
     program
-      .hook('postAction', () => calls.push('program'));
-    program.command('sub')
+      .command('sub')
       .hook('postAction', () => calls.push('sub'))
       .action(() => calls.push('action'));
     program.parse(['sub'], { from: 'user' });
@@ -93,7 +91,8 @@ describe('action hooks with synchronous hooks, order', () => {
     program
       .hook('preAction', () => calls.push('pb2'))
       .hook('postAction', () => calls.push('pa2'));
-    program.command('sub')
+    program
+      .command('sub')
       .hook('preAction', () => calls.push('sb'))
       .hook('postAction', () => calls.push('sa'))
       .action(() => calls.push('action'));
@@ -106,9 +105,7 @@ describe('action hooks context', () => {
   test('when hook on program then passed program/program', () => {
     const hook = jest.fn();
     const program = new commander.Command();
-    program
-      .hook('preAction', hook)
-      .action(() => {});
+    program.hook('preAction', hook).action(() => {});
     program.parse([], { from: 'user' });
     expect(hook).toHaveBeenCalledWith(program, program);
   });
@@ -116,10 +113,8 @@ describe('action hooks context', () => {
   test('when hook on program and call sub then passed program/sub', () => {
     const hook = jest.fn();
     const program = new commander.Command();
-    program
-      .hook('preAction', hook);
-    const sub = program.command('sub')
-      .action(() => {});
+    program.hook('preAction', hook);
+    const sub = program.command('sub').action(() => {});
     program.parse(['sub'], { from: 'user' });
     expect(hook).toHaveBeenCalledWith(program, sub);
   });
@@ -127,7 +122,8 @@ describe('action hooks context', () => {
   test('when hook on sub and call sub then passed sub/sub', () => {
     const hook = jest.fn();
     const program = new commander.Command();
-    const sub = program.command('sub')
+    const sub = program
+      .command('sub')
       .hook('preAction', hook)
       .action(() => {});
     program.parse(['sub'], { from: 'user' });
@@ -149,24 +145,21 @@ describe('action hooks context', () => {
   test('when hook program on preAction and call sub then thisCommand has program options set', () => {
     expect.assertions(1);
     const program = new commander.Command();
-    program
-      .option('--debug')
-      .hook('preAction', (thisCommand) => {
-        expect(thisCommand.opts().debug).toEqual(true);
-      });
-    program.command('sub')
-      .action(() => {});
+    program.option('--debug').hook('preAction', (thisCommand) => {
+      expect(thisCommand.opts().debug).toEqual(true);
+    });
+    program.command('sub').action(() => {});
     program.parse(['sub', '--debug'], { from: 'user' });
   });
 
   test('when hook program on preAction and call sub then actionCommand has sub options set', () => {
     expect.assertions(1);
     const program = new commander.Command();
+    program.hook('preAction', (thisCommand, actionCommand) => {
+      expect(actionCommand.opts().debug).toEqual(true);
+    });
     program
-      .hook('preAction', (thisCommand, actionCommand) => {
-        expect(actionCommand.opts().debug).toEqual(true);
-      });
-    program.command('sub')
+      .command('sub')
       .option('--debug')
       .action(() => {});
     program.parse(['sub', '--debug'], { from: 'user' });
@@ -200,35 +193,30 @@ describe('action hooks context', () => {
   test('when hook program on preAction and call sub then thisCommand has program args set', () => {
     expect.assertions(1);
     const program = new commander.Command();
-    program
-      .argument('[arg]')
-      .hook('preAction', (thisCommand) => {
-        expect(thisCommand.args).toEqual(['sub', 'value']);
-      });
-    program.command('sub')
-      .action(() => {});
+    program.argument('[arg]').hook('preAction', (thisCommand) => {
+      expect(thisCommand.args).toEqual(['sub', 'value']);
+    });
+    program.command('sub').action(() => {});
     program.parse(['sub', 'value'], { from: 'user' });
   });
 
   test('when hook program on preAction and call sub then actionCommand has sub args set', () => {
     expect.assertions(1);
     const program = new commander.Command();
-    program
-      .hook('preAction', (thisCommand, actionCommand) => {
-        expect(actionCommand.args).toEqual(['value']);
-      });
-    program.command('sub')
-      .action(() => {});
+    program.hook('preAction', (thisCommand, actionCommand) => {
+      expect(actionCommand.args).toEqual(['value']);
+    });
+    program.command('sub').action(() => {});
     program.parse(['sub', 'value'], { from: 'user' });
   });
 });
 
 describe('action hooks async', () => {
-  test('when async preAction then async from preAction', async() => {
+  test('when async preAction then async from preAction', async () => {
     const calls = [];
     const program = new commander.Command();
     program
-      .hook('preAction', async() => {
+      .hook('preAction', async () => {
         await 0;
         calls.push('before');
       })
@@ -239,11 +227,11 @@ describe('action hooks async', () => {
     expect(calls).toEqual(['before', 'action']);
   });
 
-  test('when async postAction then async from postAction', async() => {
+  test('when async postAction then async from postAction', async () => {
     const calls = [];
     const program = new commander.Command();
     program
-      .hook('postAction', async() => {
+      .hook('postAction', async () => {
         await 0;
         calls.push('after');
       })
@@ -254,13 +242,13 @@ describe('action hooks async', () => {
     expect(calls).toEqual(['action', 'after']);
   });
 
-  test('when async action then async from action', async() => {
+  test('when async action then async from action', async () => {
     const calls = [];
     const program = new commander.Command();
     program
       .hook('preAction', () => calls.push('before'))
       .hook('postAction', () => calls.push('after'))
-      .action(async() => {
+      .action(async () => {
         await 0;
         calls.push('action');
       });
@@ -270,11 +258,11 @@ describe('action hooks async', () => {
     expect(calls).toEqual(['before', 'action', 'after']);
   });
 
-  test('when async first preAction then async from first preAction', async() => {
+  test('when async first preAction then async from first preAction', async () => {
     const calls = [];
     const program = new commander.Command();
     program
-      .hook('preAction', async() => {
+      .hook('preAction', async () => {
         await 0;
         calls.push('1');
       })
@@ -286,12 +274,12 @@ describe('action hooks async', () => {
     expect(calls).toEqual(['1', '2', 'action']);
   });
 
-  test('when async second preAction then async from second preAction', async() => {
+  test('when async second preAction then async from second preAction', async () => {
     const calls = [];
     const program = new commander.Command();
     program
       .hook('preAction', () => calls.push('1'))
-      .hook('preAction', async() => {
+      .hook('preAction', async () => {
         await 0;
         calls.push('2');
       })
@@ -302,56 +290,98 @@ describe('action hooks async', () => {
     expect(calls).toEqual(['1', '2', 'action']);
   });
 
-  test('when async hook everything then hooks called nested', async() => {
+  test('when async hook everything then hooks called nested', async () => {
     const calls = [];
     const program = new commander.Command();
     program
-      .hook('preAction', async() => { await 0; calls.push('pb1'); })
-      .hook('postAction', async() => { await 0; calls.push('pa1'); });
+      .hook('preAction', async () => {
+        await 0;
+        calls.push('pb1');
+      })
+      .hook('postAction', async () => {
+        await 0;
+        calls.push('pa1');
+      });
     program
-      .hook('preAction', async() => { await 0; calls.push('pb2'); })
-      .hook('postAction', async() => { await 0; calls.push('pa2'); });
-    program.command('sub')
-      .hook('preAction', async() => { await 0; calls.push('sb'); })
-      .hook('postAction', async() => { await 0; calls.push('sa'); })
-      .action(async() => { await 0; calls.push('action'); });
+      .hook('preAction', async () => {
+        await 0;
+        calls.push('pb2');
+      })
+      .hook('postAction', async () => {
+        await 0;
+        calls.push('pa2');
+      });
+    program
+      .command('sub')
+      .hook('preAction', async () => {
+        await 0;
+        calls.push('sb');
+      })
+      .hook('postAction', async () => {
+        await 0;
+        calls.push('sa');
+      })
+      .action(async () => {
+        await 0;
+        calls.push('action');
+      });
     const result = program.parseAsync(['sub'], { from: 'user' });
     expect(calls).toEqual([]);
     await result;
     expect(calls).toEqual(['pb1', 'pb2', 'sb', 'action', 'sa', 'pa2', 'pa1']);
   });
 
-  test('preSubcommand hook should work', async() => {
+  test('preSubcommand hook should work', async () => {
     const calls = [];
     const program = new commander.Command();
-    program
-      .hook('preSubcommand', async() => { await 0; calls.push(0); });
-    program.command('sub')
-      .action(async() => { await 1; calls.push(1); });
-    program.action(async() => { await 2; calls.push(2); });
+    program.hook('preSubcommand', async () => {
+      await 0;
+      calls.push(0);
+    });
+    program.command('sub').action(async () => {
+      await 1;
+      calls.push(1);
+    });
+    program.action(async () => {
+      await 2;
+      calls.push(2);
+    });
     const result = program.parseAsync(['sub'], { from: 'user' });
     expect(calls).toEqual([]);
     await result;
     expect(calls).toEqual([0, 1]);
   });
-  test('preSubcommand hook should effective for direct subcommands', async() => {
+  test('preSubcommand hook should effective for direct subcommands', async () => {
     const calls = [];
     const program = new commander.Command();
-    program
-      .hook('preSubcommand', async(thisCommand, subCommand) => {
-        await 'preSubcommand';
-        calls.push('preSubcommand');
-        calls.push(subCommand.name());
-      });
+    program.hook('preSubcommand', async (thisCommand, subCommand) => {
+      await 'preSubcommand';
+      calls.push('preSubcommand');
+      calls.push(subCommand.name());
+    });
     program
       .command('first')
-      .action(async() => { await 'first'; calls.push('first'); })
+      .action(async () => {
+        await 'first';
+        calls.push('first');
+      })
       .command('second')
-      .action(async() => { await 'second'; calls.push('second'); })
+      .action(async () => {
+        await 'second';
+        calls.push('second');
+      })
       .command('third')
-      .action(async() => { await 'third'; calls.push('third'); });
-    program.action(async() => { await 2; calls.push(2); });
-    const result = program.parseAsync(['first', 'second', 'third'], { from: 'user' });
+      .action(async () => {
+        await 'third';
+        calls.push('third');
+      });
+    program.action(async () => {
+      await 2;
+      calls.push(2);
+    });
+    const result = program.parseAsync(['first', 'second', 'third'], {
+      from: 'user',
+    });
     expect(calls).toEqual([]);
     await result;
     expect(calls).toEqual(['preSubcommand', 'first', 'third']);

--- a/tests/command.name.test.js
+++ b/tests/command.name.test.js
@@ -15,7 +15,9 @@ test('when set program name and parse then name is as assigned', () => {
 
 test('when program name not set and parse with script argument then plain name is found from script name', () => {
   const program = new commander.Command();
-  program.parse(['node', path.resolve(process.cwd(), 'script.js')], { from: 'node' });
+  program.parse(['node', path.resolve(process.cwd(), 'script.js')], {
+    from: 'node',
+  });
   expect(program.name()).toBe('script');
 });
 
@@ -27,8 +29,7 @@ test('when command name not set and no script argument in parse then name is pro
 
 test('when add command then command is named', () => {
   const program = new commander.Command();
-  const subcommand = program
-    .command('mycommand <file>');
+  const subcommand = program.command('mycommand <file>');
   expect(subcommand.name()).toBe('mycommand');
 });
 

--- a/tests/command.nested.test.js
+++ b/tests/command.nested.test.js
@@ -3,10 +3,7 @@ const commander = require('../');
 test('when call nested subcommand then runs', () => {
   const program = new commander.Command();
   const leafAction = jest.fn();
-  program
-    .command('sub1')
-    .command('sub2')
-    .action(leafAction);
+  program.command('sub1').command('sub2').action(leafAction);
   program.parse('node test.js sub1 sub2'.split(' '));
   expect(leafAction).toHaveBeenCalled();
 });

--- a/tests/command.onCommand.test.js
+++ b/tests/command.onCommand.test.js
@@ -7,9 +7,7 @@ describe(".command('*')", () => {
   test('when action handler for subcommand then emit command:subcommand', () => {
     const mockListener = jest.fn();
     const program = new commander.Command();
-    program
-      .command('sub')
-      .action(() => {});
+    program.command('sub').action(() => {});
     program.on('command:sub', mockListener);
     program.parse(['sub'], { from: 'user' });
     expect(mockListener).toHaveBeenCalled();
@@ -18,8 +16,7 @@ describe(".command('*')", () => {
   test('when no action handler for subcommand then still emit command:subcommand', () => {
     const mockListener = jest.fn();
     const program = new commander.Command();
-    program
-      .command('sub');
+    program.command('sub');
     program.on('command:sub', mockListener);
     program.parse(['sub'], { from: 'user' });
     expect(mockListener).toHaveBeenCalled();
@@ -28,9 +25,7 @@ describe(".command('*')", () => {
   test('when subcommand has argument then emit command:subcommand with argument', () => {
     const mockListener = jest.fn();
     const program = new commander.Command();
-    program
-      .command('sub <file>')
-      .action(() => {});
+    program.command('sub <file>').action(() => {});
     program.on('command:sub', mockListener);
     program.parse(['sub', 'file'], { from: 'user' });
     expect(mockListener).toHaveBeenCalledWith(['file'], []);

--- a/tests/command.option-misuse.test.js
+++ b/tests/command.option-misuse.test.js
@@ -3,7 +3,8 @@ const { Command, Option } = require('../');
 // It is a reasonable and easy mistake to pass Option to .option(). Detect this
 // and offer advice.
 
-const expectedMessage = 'To add an Option object use addOption() instead of option() or requiredOption()';
+const expectedMessage =
+  'To add an Option object use addOption() instead of option() or requiredOption()';
 
 test('when pass Option to .option() then throw', () => {
   const program = new Command();

--- a/tests/command.parse.test.js
+++ b/tests/command.parse.test.js
@@ -72,17 +72,15 @@ describe('.parse() args from', () => {
 describe('return type', () => {
   test('when call .parse then returns program', () => {
     const program = new commander.Command();
-    program
-      .action(() => { });
+    program.action(() => {});
 
     const result = program.parse(['node', 'test']);
     expect(result).toBe(program);
   });
 
-  test('when await .parseAsync then returns program', async() => {
+  test('when await .parseAsync then returns program', async () => {
     const program = new commander.Command();
-    program
-      .action(() => { });
+    program.action(() => {});
 
     const result = await program.parseAsync(['node', 'test']);
     expect(result).toBe(program);
@@ -132,7 +130,7 @@ describe('parse parameter is treated as readonly, per TypeScript declaration', (
 });
 
 describe('parseAsync parameter is treated as readonly, per TypeScript declaration', () => {
-  test('when parse called then parameter does not change', async() => {
+  test('when parse called then parameter does not change', async () => {
     const program = new commander.Command();
     program.option('--debug');
     const original = ['node', '--debug', 'arg'];
@@ -141,7 +139,7 @@ describe('parseAsync parameter is treated as readonly, per TypeScript declaratio
     expect(param).toEqual(original);
   });
 
-  test('when parseAsync called and parsed args later changed then parameter does not change', async() => {
+  test('when parseAsync called and parsed args later changed then parameter does not change', async () => {
     const program = new commander.Command();
     program.option('--debug');
     const original = ['node', '--debug', 'arg'];
@@ -152,7 +150,7 @@ describe('parseAsync parameter is treated as readonly, per TypeScript declaratio
     expect(param).toEqual(original);
   });
 
-  test('when parseAsync called and param later changed then parsed args do not change', async() => {
+  test('when parseAsync called and param later changed then parsed args do not change', async () => {
     const program = new commander.Command();
     program.option('--debug');
     const param = ['node', '--debug', 'arg'];

--- a/tests/command.parseOptions.test.js
+++ b/tests/command.parseOptions.test.js
@@ -16,8 +16,7 @@ describe('regression tests', () => {
     program
       .command('doit [id]')
       .option('--better', 'do it better')
-      .action((id, cmd) => {
-      });
+      .action((id, cmd) => {});
     return program;
   }
 
@@ -36,9 +35,19 @@ describe('regression tests', () => {
   });
 
   // https://github.com/tj/commander.js/issues/508
-  test('when arguments to executable include option flags then argument order preserved', async() => {
+  test('when arguments to executable include option flags then argument order preserved', async () => {
     const pm = path.join(__dirname, 'fixtures/pm');
-    const { stdout } = await execFileAsync('node', [pm, 'echo', '1', '2', '--dry-run', '3', '4', '5', '6']);
+    const { stdout } = await execFileAsync('node', [
+      pm,
+      'echo',
+      '1',
+      '2',
+      '--dry-run',
+      '3',
+      '4',
+      '5',
+      '6',
+    ]);
     expect(stdout).toBe("[ '1', '2', '--dry-run', '3', '4', '5', '6' ]\n");
   });
 });
@@ -51,8 +60,7 @@ describe('parseOptions', () => {
       .option('--global-value <value>')
       .command('sub [args...]')
       .option('--sub-flag');
-    program
-      .action(() => { });
+    program.action(() => {});
     return program;
   }
 
@@ -151,7 +159,10 @@ describe('parseOptions', () => {
   test('when program has literal after unknown option then literal preserved too', () => {
     const program = createProgram();
     const result = program.parseOptions('--unknown1 -- --unknown2'.split(' '));
-    expect(result).toEqual({ operands: [], unknown: ['--unknown1', '--', '--unknown2'] });
+    expect(result).toEqual({
+      operands: [],
+      unknown: ['--unknown1', '--', '--unknown2'],
+    });
   });
 });
 
@@ -159,8 +170,7 @@ describe('parseOptions', () => {
 describe('parse and program.args', () => {
   test('when program has known flag and operand then option removed and operand returned', () => {
     const program = new commander.Command();
-    program
-      .option('--global-flag');
+    program.option('--global-flag');
     program.parse('node test.js --global-flag arg'.split(' '));
     expect(program.args).toEqual(['arg']);
   });
@@ -171,7 +181,11 @@ describe('parse and program.args', () => {
       .allowUnknownOption()
       .option('--global-flag')
       .option('--global-value <value>');
-    program.parse('node test.js aaa --global-flag bbb --unknown ccc --global-value value'.split(' '));
+    program.parse(
+      'node test.js aaa --global-flag bbb --unknown ccc --global-value value'.split(
+        ' ',
+      ),
+    );
     expect(program.args).toEqual(['aaa', 'bbb', '--unknown', 'ccc']);
   });
 
@@ -182,7 +196,11 @@ describe('parse and program.args', () => {
       .option('--global-value <value>')
       .command('sub [args...]')
       .option('--sub-flag');
-    program.parse('node test.js --global-flag sub --sub-flag arg --global-value value'.split(' '));
+    program.parse(
+      'node test.js --global-flag sub --sub-flag arg --global-value value'.split(
+        ' ',
+      ),
+    );
     expect(program.args).toEqual(['sub', '--sub-flag', 'arg']);
   });
 });
@@ -228,8 +246,7 @@ describe('Utility Conventions', () => {
       .option('-b,--bbb')
       .option('-c,--ccc <value>')
       .option('-d,--ddd [value]');
-    program
-      .action(() => { });
+    program.action(() => {});
     return program;
   }
 
@@ -244,7 +261,7 @@ describe('Utility Conventions', () => {
     const program = createProgram();
     const result = program.parseOptions(['-pq']);
     expect(result).toEqual({ operands: [], unknown: ['-pq'] });
-    expect(program.opts()).toEqual({ });
+    expect(program.opts()).toEqual({});
   });
 
   test('when program has combo known short option and required value then arg removed', () => {
@@ -286,7 +303,7 @@ describe('Utility Conventions', () => {
     const program = createProgram();
     const result = program.parseOptions(['--rrr=value']);
     expect(result).toEqual({ operands: [], unknown: ['--rrr=value'] });
-    expect(program.opts()).toEqual({ });
+    expect(program.opts()).toEqual({});
   });
 
   test('when program has combo optional and combineFlagAndOptionalValue() then treat as value', () => {

--- a/tests/command.positionalOptions.test.js
+++ b/tests/command.positionalOptions.test.js
@@ -7,9 +7,7 @@ describe('program with passThrough', () => {
   function makeProgram() {
     const program = new commander.Command();
     program.passThroughOptions();
-    program
-      .option('-d, --debug')
-      .argument('<args...>');
+    program.option('-d, --debug').argument('<args...>');
     return program;
   }
 
@@ -38,19 +36,23 @@ describe('program with passThrough', () => {
     const mockAction = jest.fn();
     program.action(mockAction);
     program.parse(['arg', '--pass'], { from: 'user' });
-    expect(mockAction).toHaveBeenCalledWith(['arg', '--pass'], program.opts(), program);
+    expect(mockAction).toHaveBeenCalledWith(
+      ['arg', '--pass'],
+      program.opts(),
+      program,
+    );
   });
 
   test('when help option (without command-argument) then help called', () => {
     const program = makeProgram();
     const mockHelp = jest.fn(() => '');
 
-    program
-      .exitOverride()
-      .configureHelp({ formatHelp: mockHelp });
+    program.exitOverride().configureHelp({ formatHelp: mockHelp });
     try {
       program.parse(['--help'], { from: 'user' });
-    } catch (err) { /* empty */ }
+    } catch (err) {
+      /* empty */
+    }
     expect(mockHelp).toHaveBeenCalled();
   });
 
@@ -108,7 +110,9 @@ describe('program with positionalOptions and subcommand', () => {
 
   test('when shared option before and after subcommand then both parsed', () => {
     const { program, sub } = makeProgram();
-    program.parse(['--shared', 'program', 'sub', '--shared', 'local'], { from: 'user' });
+    program.parse(['--shared', 'program', 'sub', '--shared', 'local'], {
+      from: 'user',
+    });
     expect(program.opts().shared).toEqual('program');
     expect(sub.opts().shared).toEqual('local');
   });
@@ -120,24 +124,25 @@ describe('program with positionalOptions and subcommand', () => {
     [['sub', '--help'], 0, 1],
     [['sub', 'foo', '--help'], 0, 1],
     [['help'], 1, 0],
-    [['help', 'sub'], 0, 1]
-  ])('help: when user args %p then program/sub help called %p/%p', (userArgs, expectProgramHelpCount, expectSubHelpCount) => {
-    const { program, sub } = makeProgram();
-    const mockProgramHelp = jest.fn();
-    program
-      .exitOverride()
-      .configureHelp({ formatHelp: mockProgramHelp });
-    const mockSubHelp = jest.fn();
-    sub
-      .exitOverride()
-      .configureHelp({ formatHelp: mockSubHelp });
+    [['help', 'sub'], 0, 1],
+  ])(
+    'help: when user args %p then program/sub help called %p/%p',
+    (userArgs, expectProgramHelpCount, expectSubHelpCount) => {
+      const { program, sub } = makeProgram();
+      const mockProgramHelp = jest.fn();
+      program.exitOverride().configureHelp({ formatHelp: mockProgramHelp });
+      const mockSubHelp = jest.fn();
+      sub.exitOverride().configureHelp({ formatHelp: mockSubHelp });
 
-    try {
-      program.parse(userArgs, { from: 'user' });
-    } catch (err) { /* empty */ }
-    expect(mockProgramHelp).toHaveBeenCalledTimes(expectProgramHelpCount);
-    expect(mockSubHelp).toHaveBeenCalledTimes(expectSubHelpCount);
-  });
+      try {
+        program.parse(userArgs, { from: 'user' });
+      } catch (err) {
+        /* empty */
+      }
+      expect(mockProgramHelp).toHaveBeenCalledTimes(expectProgramHelpCount);
+      expect(mockSubHelp).toHaveBeenCalledTimes(expectSubHelpCount);
+    },
+  );
 });
 
 // ---------------------------------------------------------------
@@ -187,24 +192,25 @@ describe('program with positionalOptions and default subcommand (called sub)', (
   test.each([
     [[], 0, 0],
     [['--help'], 1, 0],
-    [['help'], 1, 0]
-  ])('help: when user args %p then program/sub help called %p/%p', (userArgs, expectProgramHelpCount, expectSubHelpCount) => {
-    const { program, sub } = makeProgram();
-    const mockProgramHelp = jest.fn();
-    program
-      .exitOverride()
-      .configureHelp({ formatHelp: mockProgramHelp });
-    const mockSubHelp = jest.fn();
-    sub
-      .exitOverride()
-      .configureHelp({ formatHelp: mockSubHelp });
+    [['help'], 1, 0],
+  ])(
+    'help: when user args %p then program/sub help called %p/%p',
+    (userArgs, expectProgramHelpCount, expectSubHelpCount) => {
+      const { program, sub } = makeProgram();
+      const mockProgramHelp = jest.fn();
+      program.exitOverride().configureHelp({ formatHelp: mockProgramHelp });
+      const mockSubHelp = jest.fn();
+      sub.exitOverride().configureHelp({ formatHelp: mockSubHelp });
 
-    try {
-      program.parse(userArgs, { from: 'user' });
-    } catch (err) {  /* empty */ }
-    expect(mockProgramHelp).toHaveBeenCalledTimes(expectProgramHelpCount);
-    expect(mockSubHelp).toHaveBeenCalledTimes(expectSubHelpCount);
-  });
+      try {
+        program.parse(userArgs, { from: 'user' });
+      } catch (err) {
+        /* empty */
+      }
+      expect(mockProgramHelp).toHaveBeenCalledTimes(expectProgramHelpCount);
+      expect(mockSubHelp).toHaveBeenCalledTimes(expectSubHelpCount);
+    },
+  );
 });
 
 // ------------------------------------------------------------------------------
@@ -269,7 +275,10 @@ describe('subcommand with passThrough', () => {
 
   test('when shared option before sub and after sub and after sub parameter then all three parsed', () => {
     const { program, sub } = makeProgram();
-    program.parse(['--shared=global', 'sub', '--shared=local', 'arg', '--shared'], { from: 'user' });
+    program.parse(
+      ['--shared=global', 'sub', '--shared=local', 'arg', '--shared'],
+      { from: 'user' },
+    );
     expect(program.opts().shared).toEqual('global');
     expect(sub.opts().shared).toEqual('local');
     expect(sub.args).toEqual(['arg', '--shared']);
@@ -281,8 +290,7 @@ describe('subcommand with passThrough', () => {
 describe('default command with passThrough', () => {
   function makeProgram() {
     const program = new commander.Command();
-    program
-      .enablePositionalOptions();
+    program.enablePositionalOptions();
     const sub = program
       .command('sub', { isDefault: true })
       .passThroughOptions()
@@ -371,8 +379,7 @@ describe('broken passThrough', () => {
 
   test('when program not positional and add subcommand with passThroughOptions then error', () => {
     const program = new commander.Command();
-    const sub = new commander.Command('sub')
-      .passThroughOptions();
+    const sub = new commander.Command('sub').passThroughOptions();
 
     expect(() => {
       program.addCommand(sub);
@@ -431,10 +438,7 @@ describe('program with action handler and passThrough and subcommand', () => {
 describe('program with allowUnknownOption', () => {
   test('when passThroughOptions and unknown option then arguments from unknown passed through', () => {
     const program = new commander.Command();
-    program
-      .passThroughOptions()
-      .allowUnknownOption()
-      .option('--debug');
+    program.passThroughOptions().allowUnknownOption().option('--debug');
 
     program.parse(['--unknown', '--debug'], { from: 'user' });
     expect(program.args).toEqual(['--unknown', '--debug']);
@@ -442,10 +446,7 @@ describe('program with allowUnknownOption', () => {
 
   test('when positionalOptions and unknown option then known options then known option parsed', () => {
     const program = new commander.Command();
-    program
-      .enablePositionalOptions()
-      .allowUnknownOption()
-      .option('--debug');
+    program.enablePositionalOptions().allowUnknownOption().option('--debug');
 
     program.parse(['--unknown', '--debug'], { from: 'user' });
     expect(program.opts().debug).toBe(true);
@@ -458,9 +459,7 @@ describe('program with allowUnknownOption', () => {
 describe('passThroughOptions(xxx) and option after command-argument', () => {
   function makeProgram() {
     const program = new commander.Command();
-    program
-      .option('-d, --debug')
-      .argument('<args...>');
+    program.option('-d, --debug').argument('<args...>');
     return program;
   }
 
@@ -492,11 +491,8 @@ describe('passThroughOptions(xxx) and option after command-argument', () => {
 describe('enablePositionalOptions(xxx) and shared option after subcommand', () => {
   function makeProgram() {
     const program = new commander.Command();
-    program
-      .option('-d, --debug');
-    const sub = program
-      .command('sub')
-      .option('-d, --debug');
+    program.option('-d, --debug');
+    const sub = program.command('sub').option('-d, --debug');
     return { program, sub };
   }
 

--- a/tests/command.showHelpAfterError.test.js
+++ b/tests/command.showHelpAfterError.test.js
@@ -67,8 +67,7 @@ describe('showHelpAfterError with message', () => {
 
   test('when too many command-arguments then shows help', () => {
     const { program, writeMock } = makeProgram();
-    program
-      .allowExcessArguments(false);
+    program.allowExcessArguments(false);
     let caughtErr;
     try {
       program.parse(['surprise'], { from: 'user' });
@@ -116,6 +115,8 @@ test('when showHelpAfterError() and error and then shows full help', () => {
 
   try {
     program.parse(['--unknown-option'], { from: 'user' });
-  } catch (err) {  /* empty */ }
+  } catch (err) {
+    /* empty */
+  }
   expect(writeMock).toHaveBeenLastCalledWith(program.helpInformation());
 });

--- a/tests/command.showSuggestionAfterError.test.js
+++ b/tests/command.showSuggestionAfterError.test.js
@@ -2,15 +2,17 @@ const { Command } = require('../');
 
 function getSuggestion(program, arg) {
   let message = '';
-  program
-    .exitOverride()
-    .configureOutput({
-      writeErr: (str) => { message = str; }
-    });
+  program.exitOverride().configureOutput({
+    writeErr: (str) => {
+      message = str;
+    },
+  });
 
   try {
     program.parse([arg], { from: 'user' });
-  } catch (err) {  /* empty */ }
+  } catch (err) {
+    /* empty */
+  }
 
   const match = message.match(/Did you mean (one of )?(.*)\?/);
   return match ? match[2] : null;

--- a/tests/command.unknownCommand.test.js
+++ b/tests/command.unknownCommand.test.js
@@ -5,7 +5,9 @@ describe('unknownCommand', () => {
   let writeErrorSpy;
 
   beforeAll(() => {
-    writeErrorSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => { });
+    writeErrorSpy = jest
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -26,12 +28,8 @@ describe('unknownCommand', () => {
 
   test('when unknown command but action handler taking arg then no error', () => {
     const program = new commander.Command();
-    program
-      .exitOverride()
-      .command('sub');
-    program
-      .argument('[args...]')
-      .action(() => { });
+    program.exitOverride().command('sub');
+    program.argument('[args...]').action(() => {});
     expect(() => {
       program.parse('node test.js unknown'.split(' '));
     }).not.toThrow();
@@ -39,11 +37,8 @@ describe('unknownCommand', () => {
 
   test('when unknown command but listener then no error', () => {
     const program = new commander.Command();
-    program
-      .exitOverride()
-      .command('sub');
-    program
-      .on('command:*', () => { });
+    program.exitOverride().command('sub');
+    program.on('command:*', () => {});
     expect(() => {
       program.parse('node test.js unknown'.split(' '));
     }).not.toThrow();
@@ -51,9 +46,7 @@ describe('unknownCommand', () => {
 
   test('when unknown command then error', () => {
     const program = new commander.Command();
-    program
-      .exitOverride()
-      .command('sub');
+    program.exitOverride().command('sub');
     let caughtErr;
     try {
       program.parse('node test.js unknown'.split(' '));
@@ -67,9 +60,7 @@ describe('unknownCommand', () => {
     //  The unknown command is more useful since the option is for an unknown command (and might be
     // ok if the command had been correctly spelled, say).
     const program = new commander.Command();
-    program
-      .exitOverride()
-      .command('sub');
+    program.exitOverride().command('sub');
     let caughtErr;
     try {
       program.parse('node test.js sbu --silly'.split(' '));

--- a/tests/command.unknownOption.test.js
+++ b/tests/command.unknownOption.test.js
@@ -7,7 +7,9 @@ describe('unknownOption', () => {
   let writeErrorSpy;
 
   beforeAll(() => {
-    writeErrorSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => { });
+    writeErrorSpy = jest
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -85,8 +87,7 @@ describe('unknownOption', () => {
 
   test('when specify unknown option with simple program then error', () => {
     const program = new commander.Command();
-    program
-      .exitOverride();
+    program.exitOverride();
     let caughtErr;
     try {
       program.parse(['node', 'test', '--NONSENSE']);
@@ -98,8 +99,7 @@ describe('unknownOption', () => {
 
   test('when specify unknown global option before subcommand then error', () => {
     const program = new commander.Command();
-    program
-      .exitOverride();
+    program.exitOverride();
     program.command('sub');
 
     let caughtErr;

--- a/tests/command.usage.test.js
+++ b/tests/command.usage.test.js
@@ -12,8 +12,7 @@ test('when default usage and check program help then starts with default usage',
 test('when custom usage and check program help then starts with custom usage', () => {
   const myUsage = 'custom';
   const program = new commander.Command();
-  program
-    .usage(myUsage);
+  program.usage(myUsage);
 
   program.name('test');
   const helpInformation = program.helpInformation();
@@ -23,8 +22,7 @@ test('when custom usage and check program help then starts with custom usage', (
 
 test('when default usage and check subcommand help then starts with default usage including program name', () => {
   const program = new commander.Command();
-  const subCommand = program
-    .command('info');
+  const subCommand = program.command('info');
 
   program.name('test');
   const helpInformation = subCommand.helpInformation();
@@ -35,9 +33,7 @@ test('when default usage and check subcommand help then starts with default usag
 test('when custom usage and check subcommand help then starts with custom usage including program name', () => {
   const myUsage = 'custom';
   const program = new commander.Command();
-  const subCommand = program
-    .command('info')
-    .usage(myUsage);
+  const subCommand = program.command('info').usage(myUsage);
 
   program.name('test');
   const helpInformation = subCommand.helpInformation();
@@ -48,8 +44,7 @@ test('when custom usage and check subcommand help then starts with custom usage 
 test('when has option then [options] included in usage', () => {
   const program = new commander.Command();
 
-  program
-    .option('--foo');
+  program.option('--foo');
 
   expect(program.usage()).toMatch('[options]');
 });
@@ -57,8 +52,7 @@ test('when has option then [options] included in usage', () => {
 test('when no options then [options] not included in usage', () => {
   const program = new commander.Command();
 
-  program
-    .helpOption(false);
+  program.helpOption(false);
 
   expect(program.usage()).not.toMatch('[options]');
 });
@@ -66,8 +60,7 @@ test('when no options then [options] not included in usage', () => {
 test('when has command then [command] included in usage', () => {
   const program = new commander.Command();
 
-  program
-    .command('foo');
+  program.command('foo');
 
   expect(program.usage()).toMatch('[command]');
 });
@@ -81,8 +74,7 @@ test('when no commands then [command] not included in usage', () => {
 test('when argument then argument included in usage', () => {
   const program = new commander.Command();
 
-  program
-    .argument('<file>');
+  program.argument('<file>');
 
   expect(program.usage()).toMatch('<file>');
 });
@@ -90,10 +82,7 @@ test('when argument then argument included in usage', () => {
 test('when options and command and argument then all three included in usage', () => {
   const program = new commander.Command();
 
-  program
-    .argument('<file>')
-    .option('--alpha')
-    .command('beta');
+  program.argument('<file>').option('--alpha').command('beta');
 
   expect(program.usage()).toEqual('[options] [command] <file>');
 });

--- a/tests/commander.configureCommand.test.js
+++ b/tests/commander.configureCommand.test.js
@@ -6,8 +6,7 @@ const commander = require('../');
 
 test('when default then options not stored on command', () => {
   const program = new commander.Command();
-  program
-    .option('--foo <value>', 'description');
+  program.option('--foo <value>', 'description');
   program.parse(['node', 'test', '--foo', 'bar']);
   expect(program.foo).toBeUndefined();
   expect(program.opts().foo).toBe('bar');
@@ -16,9 +15,7 @@ test('when default then options not stored on command', () => {
 test('when default then options+command passed to action', () => {
   const program = new commander.Command();
   const callback = jest.fn();
-  program
-    .argument('<value>')
-    .action(callback);
+  program.argument('<value>').action(callback);
   program.parse(['node', 'test', 'value']);
   expect(callback).toHaveBeenCalledWith('value', program.opts(), program);
 });
@@ -27,9 +24,7 @@ test('when default then options+command passed to action', () => {
 
 test('when storeOptionsAsProperties() then options stored on command', () => {
   const program = new commander.Command();
-  program
-    .storeOptionsAsProperties()
-    .option('--foo <value>', 'description');
+  program.storeOptionsAsProperties().option('--foo <value>', 'description');
   program.parse(['node', 'test', '--foo', 'bar']);
   expect(program.foo).toBe('bar');
   expect(program.opts().foo).toBe('bar');
@@ -37,9 +32,7 @@ test('when storeOptionsAsProperties() then options stored on command', () => {
 
 test('when storeOptionsAsProperties(true) then options stored on command', () => {
   const program = new commander.Command();
-  program
-    .storeOptionsAsProperties(true)
-    .option('--foo <value>', 'description');
+  program.storeOptionsAsProperties(true).option('--foo <value>', 'description');
   program.parse(['node', 'test', '--foo', 'bar']);
   expect(program.foo).toBe('bar');
   expect(program.opts().foo).toBe('bar');
@@ -58,10 +51,7 @@ test('when storeOptionsAsProperties(false) then options not stored on command', 
 test('when storeOptionsAsProperties() then command+command passed to action', () => {
   const program = new commander.Command();
   const callback = jest.fn();
-  program
-    .storeOptionsAsProperties()
-    .argument('<value>')
-    .action(callback);
+  program.storeOptionsAsProperties().argument('<value>').action(callback);
   program.parse(['node', 'test', 'value']);
   expect(callback).toHaveBeenCalledWith('value', program, program);
 });
@@ -69,10 +59,7 @@ test('when storeOptionsAsProperties() then command+command passed to action', ()
 test('when storeOptionsAsProperties(false) then opts+command passed to action', () => {
   const program = new commander.Command();
   const callback = jest.fn();
-  program
-    .storeOptionsAsProperties(false)
-    .argument('<value>')
-    .action(callback);
+  program.storeOptionsAsProperties(false).argument('<value>').action(callback);
   program.parse(['node', 'test', 'value']);
   expect(callback).toHaveBeenCalledWith('value', program.opts(), program);
 });

--- a/tests/deprecated.test.js
+++ b/tests/deprecated.test.js
@@ -7,24 +7,21 @@ const commander = require('../');
 describe('option with regular expression instead of custom processing function', () => {
   test('when option not given then value is default', () => {
     const program = new commander.Command();
-    program
-      .option('--cheese <type>', 'cheese type', /mild|tasty/, 'mild');
+    program.option('--cheese <type>', 'cheese type', /mild|tasty/, 'mild');
     program.parse([], { from: 'user' });
     expect(program.opts().cheese).toEqual('mild');
   });
 
   test('when argument matches regexp then value is as specified', () => {
     const program = new commander.Command();
-    program
-      .option('--cheese <type>', 'cheese type', /mild|tasty/, 'mild');
+    program.option('--cheese <type>', 'cheese type', /mild|tasty/, 'mild');
     program.parse(['--cheese', 'tasty'], { from: 'user' });
     expect(program.opts().cheese).toEqual('tasty');
   });
 
   test('when argument does not match regexp then value is default', () => {
     const program = new commander.Command();
-    program
-      .option('--cheese <type>', 'cheese type', /mild|tasty/, 'mild');
+    program.option('--cheese <type>', 'cheese type', /mild|tasty/, 'mild');
     program.parse(['--cheese', 'other'], { from: 'user' });
     expect(program.opts().cheese).toEqual('mild');
   });

--- a/tests/esm-imports-test.mjs
+++ b/tests/esm-imports-test.mjs
@@ -1,4 +1,16 @@
-import { program, Command, Option, Argument, CommanderError, InvalidArgumentError, InvalidOptionArgumentError, Help, createCommand, createArgument, createOption } from '../esm.mjs';
+import {
+  program,
+  Command,
+  Option,
+  Argument,
+  CommanderError,
+  InvalidArgumentError,
+  InvalidOptionArgumentError,
+  Help,
+  createCommand,
+  createArgument,
+  createOption,
+} from '../esm.mjs';
 
 // Do some simple checks that expected imports are available at runtime.
 // Run using `npm run test-esm`.

--- a/tests/fixtures/inspect.js
+++ b/tests/fixtures/inspect.js
@@ -4,6 +4,4 @@ const { program } = require('../../');
 
 process.env.FORCE_COLOR = 0; // work-around bug in Jest: https://github.com/jestjs/jest/issues/14391
 
-program
-  .command('sub', 'install one or more packages')
-  .parse(process.argv);
+program.command('sub', 'install one or more packages').parse(process.argv);

--- a/tests/fixtures/pm
+++ b/tests/fixtures/pm
@@ -7,25 +7,40 @@ process.env.FORCE_COLOR = 0; // work-around bug in Jest: https://github.com/jest
 
 program
   .version('0.0.1')
-  .command('install [name]', 'install one or more packages').alias('i')
-  .command('search [query]', 'search with optional query').alias('s')
-  .command('cache', 'actions dealing with the cache').alias('c')
+  .command('install [name]', 'install one or more packages')
+  .alias('i')
+  .command('search [query]', 'search with optional query')
+  .alias('s')
+  .command('cache', 'actions dealing with the cache')
+  .alias('c')
   .command('echo', 'echo arguments')
-  .command('list', 'list packages installed').alias('lst')
-  .command('listen', 'listen for supported signal events').alias('l')
-  .command('publish', 'publish or update package').alias('p')
+  .command('list', 'list packages installed')
+  .alias('lst')
+  .command('listen', 'listen for supported signal events')
+  .alias('l')
+  .command('publish', 'publish or update package')
+  .alias('p')
   .command('default', 'default command', { hidden: true, isDefault: true })
-  .command('specifyInstall', 'specify install subcommand', { executableFile: 'pm-install' })
-  .command('specifyPublish', 'specify publish subcommand', { executableFile: 'pm-publish' })
+  .command('specifyInstall', 'specify install subcommand', {
+    executableFile: 'pm-install',
+  })
+  .command('specifyPublish', 'specify publish subcommand', {
+    executableFile: 'pm-publish',
+  })
   .command('silent', 'silently succeed')
   .command('fail', 'exit with non-zero status code')
   .command('terminate', 'terminate due to signal');
 
 program
   .command('exit-override')
-  .exitOverride((err) => { process.exit(err.exitCode); })
-  .command('fail', 'exit with non-zero status code', { executableFile: path.join(__dirname, 'pm-fail.js') })
-  .command('terminate', 'terminate due to signal', { executableFile: path.join(__dirname, 'pm-terminate.js') });
+  .exitOverride((err) => {
+    process.exit(err.exitCode);
+  })
+  .command('fail', 'exit with non-zero status code', {
+    executableFile: path.join(__dirname, 'pm-fail.js'),
+  })
+  .command('terminate', 'terminate due to signal', {
+    executableFile: path.join(__dirname, 'pm-terminate.js'),
+  });
 
-program
-  .parse(process.argv);
+program.parse(process.argv);

--- a/tests/fixtures/pm-listen
+++ b/tests/fixtures/pm-listen
@@ -1,29 +1,29 @@
 #!/usr/bin/env node
 
-process.on('SIGUSR1', function() {
+process.on('SIGUSR1', function () {
   process.stdout.write('SIGUSR1');
   process.exit();
 });
 
-process.on('SIGUSR2', function() {
+process.on('SIGUSR2', function () {
   process.stdout.write('SIGUSR2');
   process.exit();
 });
 
-process.on('SIGTERM', function() {
+process.on('SIGTERM', function () {
   process.stdout.write('SIGTERM');
   process.exit();
 });
 
-process.on('SIGINT', function() {
+process.on('SIGINT', function () {
   process.stdout.write('SIGINT');
   process.exit();
 });
 
-process.on('SIGHUP', function() {
+process.on('SIGHUP', function () {
   process.stdout.write('SIGHUP');
   process.exit();
 });
 
 process.stdout.write('Listening for signal...');
-setInterval(function() {}, 1000); // Stay running
+setInterval(function () {}, 1000); // Stay running

--- a/tests/help.argumentDescription.test.js
+++ b/tests/help.argumentDescription.test.js
@@ -17,20 +17,31 @@ describe('argumentDescription', () => {
   });
 
   test('when argument has default value then return description and default value', () => {
-    const argument = new commander.Argument('[n]', 'description').default('default');
+    const argument = new commander.Argument('[n]', 'description').default(
+      'default',
+    );
     const helper = new commander.Help();
-    expect(helper.argumentDescription(argument)).toEqual('description (default: "default")');
+    expect(helper.argumentDescription(argument)).toEqual(
+      'description (default: "default")',
+    );
   });
 
   test('when argument has default value description then return description and custom default description', () => {
-    const argument = new commander.Argument('[n]', 'description').default('default value', 'custom');
+    const argument = new commander.Argument('[n]', 'description').default(
+      'default value',
+      'custom',
+    );
     const helper = new commander.Help();
-    expect(helper.argumentDescription(argument)).toEqual('description (default: custom)');
+    expect(helper.argumentDescription(argument)).toEqual(
+      'description (default: custom)',
+    );
   });
 
   test('when an argument has default value and no description then still return default value', () => {
     const argument = new commander.Argument('[n]').default('default');
     const helper = new commander.Help();
-    expect(helper.argumentDescription(argument)).toEqual('(default: "default")');
+    expect(helper.argumentDescription(argument)).toEqual(
+      '(default: "default")',
+    );
   });
 });

--- a/tests/help.commandTerm.test.js
+++ b/tests/help.commandTerm.test.js
@@ -12,22 +12,19 @@ describe('subcommandTerm', () => {
   });
 
   test('when command has alias then returns name|alias', () => {
-    const command = new commander.Command('program')
-      .alias('alias');
+    const command = new commander.Command('program').alias('alias');
     const helper = new commander.Help();
     expect(helper.subcommandTerm(command)).toEqual('program|alias');
   });
 
   test('when command has options then returns name [options]', () => {
-    const command = new commander.Command('program')
-      .option('-a,--all');
+    const command = new commander.Command('program').option('-a,--all');
     const helper = new commander.Help();
     expect(helper.subcommandTerm(command)).toEqual('program [options]');
   });
 
   test('when command has <argument> then returns name <argument>', () => {
-    const command = new commander.Command('program')
-      .argument('<argument>');
+    const command = new commander.Command('program').argument('<argument>');
     const helper = new commander.Help();
     expect(helper.subcommandTerm(command)).toEqual('program <argument>');
   });
@@ -38,6 +35,8 @@ describe('subcommandTerm', () => {
       .option('-a,--all')
       .argument('<argument>');
     const helper = new commander.Help();
-    expect(helper.subcommandTerm(command)).toEqual('program|alias [options] <argument>');
+    expect(helper.subcommandTerm(command)).toEqual(
+      'program|alias [options] <argument>',
+    );
   });
 });

--- a/tests/help.commandUsage.test.js
+++ b/tests/help.commandUsage.test.js
@@ -21,28 +21,22 @@ describe('commandUsage', () => {
 
   test('when program has alias then usage includes alias', () => {
     const program = new commander.Command();
-    program
-      .name('program')
-      .alias('alias');
+    program.name('program').alias('alias');
     const helper = new commander.Help();
     expect(helper.commandUsage(program)).toEqual('program|alias [options]');
   });
 
   test('when help for subcommand then usage includes hierarchy', () => {
     const program = new commander.Command();
-    program
-      .name('program');
-    const sub = program.command('sub')
-      .name('sub');
+    program.name('program');
+    const sub = program.command('sub').name('sub');
     const helper = new commander.Help();
     expect(helper.commandUsage(sub)).toEqual('program sub [options]');
   });
 
   test('when program has argument then usage includes argument', () => {
     const program = new commander.Command();
-    program
-      .name('program')
-      .argument('<file>');
+    program.name('program').argument('<file>');
     const helper = new commander.Help();
     expect(helper.commandUsage(program)).toEqual('program [options] <file>');
   });

--- a/tests/help.longestArgumentTermLength.test.js
+++ b/tests/help.longestArgumentTermLength.test.js
@@ -14,7 +14,9 @@ describe('longestArgumentTermLength', () => {
     const program = new commander.Command();
     program.argument('<wonder>', 'wonder description');
     const helper = new commander.Help();
-    expect(helper.longestArgumentTermLength(program, helper)).toEqual('wonder'.length);
+    expect(helper.longestArgumentTermLength(program, helper)).toEqual(
+      'wonder'.length,
+    );
   });
 
   test('when has multiple argument descriptions then returns longest', () => {
@@ -23,6 +25,8 @@ describe('longestArgumentTermLength', () => {
     program.argument('<longest>', 'x');
     program.argument('<beta>', 'x');
     const helper = new commander.Help();
-    expect(helper.longestArgumentTermLength(program, helper)).toEqual('longest'.length);
+    expect(helper.longestArgumentTermLength(program, helper)).toEqual(
+      'longest'.length,
+    );
   });
 });

--- a/tests/help.longestCommandTermLength.test.js
+++ b/tests/help.longestCommandTermLength.test.js
@@ -13,21 +13,21 @@ describe('longestSubcommandTermLength', () => {
   test('when command and no help then returns length of term', () => {
     const sub = new commander.Command('sub');
     const program = new commander.Command();
-    program
-      .addHelpCommand(false)
-      .addCommand(sub);
+    program.addHelpCommand(false).addCommand(sub);
     const helper = new commander.Help();
-    expect(helper.longestSubcommandTermLength(program, helper)).toEqual(helper.subcommandTerm(sub).length);
+    expect(helper.longestSubcommandTermLength(program, helper)).toEqual(
+      helper.subcommandTerm(sub).length,
+    );
   });
 
   test('when command with arg and no help then returns length of term', () => {
     const sub = new commander.Command('sub <file)');
     const program = new commander.Command();
-    program
-      .addHelpCommand(false)
-      .addCommand(sub);
+    program.addHelpCommand(false).addCommand(sub);
     const helper = new commander.Help();
-    expect(helper.longestSubcommandTermLength(program, helper)).toEqual(helper.subcommandTerm(sub).length);
+    expect(helper.longestSubcommandTermLength(program, helper)).toEqual(
+      helper.subcommandTerm(sub).length,
+    );
   });
 
   test('when multiple commands then returns longest length', () => {
@@ -39,14 +39,17 @@ describe('longestSubcommandTermLength', () => {
       .command(longestCommandName, 'desc')
       .command('after', 'desc');
     const helper = new commander.Help();
-    expect(helper.longestSubcommandTermLength(program, helper)).toEqual(longestCommandName.length);
+    expect(helper.longestSubcommandTermLength(program, helper)).toEqual(
+      longestCommandName.length,
+    );
   });
 
   test('when just help command then returns length of help term', () => {
     const program = new commander.Command();
-    program
-      .addHelpCommand(true);
+    program.addHelpCommand(true);
     const helper = new commander.Help();
-    expect(helper.longestSubcommandTermLength(program, helper)).toEqual('help [command]'.length);
+    expect(helper.longestSubcommandTermLength(program, helper)).toEqual(
+      'help [command]'.length,
+    );
   });
 });

--- a/tests/help.longestOptionTermLength.test.js
+++ b/tests/help.longestOptionTermLength.test.js
@@ -14,7 +14,9 @@ describe('longestOptionTermLength', () => {
   test('when just implicit help option returns length of help flags', () => {
     const program = new commander.Command();
     const helper = new commander.Help();
-    expect(helper.longestOptionTermLength(program, helper)).toEqual('-h, --help'.length);
+    expect(helper.longestOptionTermLength(program, helper)).toEqual(
+      '-h, --help'.length,
+    );
   });
 
   test('when multiple option then returns longest length', () => {
@@ -25,6 +27,8 @@ describe('longestOptionTermLength', () => {
       .option(longestOptionFlags)
       .option('--after');
     const helper = new commander.Help();
-    expect(helper.longestOptionTermLength(program, helper)).toEqual(longestOptionFlags.length);
+    expect(helper.longestOptionTermLength(program, helper)).toEqual(
+      longestOptionFlags.length,
+    );
   });
 });

--- a/tests/help.optionDescription.test.js
+++ b/tests/help.optionDescription.test.js
@@ -21,7 +21,9 @@ describe('optionDescription', () => {
     const description = 'description';
     const option = new commander.Option('-a', description).default(true);
     const helper = new commander.Help();
-    expect(helper.optionDescription(option)).toEqual('description (default: true)');
+    expect(helper.optionDescription(option)).toEqual(
+      'description (default: true)',
+    );
   });
 
   test('when boolean option has default value string then return description without default', () => {
@@ -33,9 +35,13 @@ describe('optionDescription', () => {
 
   test('when optional option has preset value then return description and default value', () => {
     const description = 'description';
-    const option = new commander.Option('--aa [value]', description).preset('abc');
+    const option = new commander.Option('--aa [value]', description).preset(
+      'abc',
+    );
     const helper = new commander.Help();
-    expect(helper.optionDescription(option)).toEqual('description (preset: "abc")');
+    expect(helper.optionDescription(option)).toEqual(
+      'description (preset: "abc")',
+    );
   });
 
   test('when boolean option has preset value then return description without default', () => {
@@ -54,16 +60,25 @@ describe('optionDescription', () => {
   test('when option has default value description then return description and custom default description', () => {
     const description = 'description';
     const defaultValueDescription = 'custom';
-    const option = new commander.Option('-a <value>', description).default('default value', defaultValueDescription);
+    const option = new commander.Option('-a <value>', description).default(
+      'default value',
+      defaultValueDescription,
+    );
     const helper = new commander.Help();
-    expect(helper.optionDescription(option)).toEqual(`description (default: ${defaultValueDescription})`);
+    expect(helper.optionDescription(option)).toEqual(
+      `description (default: ${defaultValueDescription})`,
+    );
   });
 
   test('when option has choices then return description and choices', () => {
     const description = 'description';
     const choices = ['one', 'two'];
-    const option = new commander.Option('-a <value>', description).choices(choices);
+    const option = new commander.Option('-a <value>', description).choices(
+      choices,
+    );
     const helper = new commander.Help();
-    expect(helper.optionDescription(option)).toEqual('description (choices: "one", "two")');
+    expect(helper.optionDescription(option)).toEqual(
+      'description (choices: "one", "two")',
+    );
   });
 });

--- a/tests/help.padWidth.test.js
+++ b/tests/help.padWidth.test.js
@@ -7,11 +7,8 @@ describe('padWidth', () => {
   test('when argument term longest return argument length', () => {
     const longestThing = 'veryLongThingBiggerThanOthers';
     const program = new commander.Command();
-    program
-      .argument(`<${longestThing}>`, 'description')
-      .option('-o');
-    program
-      .command('sub');
+    program.argument(`<${longestThing}>`, 'description').option('-o');
+    program.command('sub');
     const helper = new commander.Help();
     expect(helper.padWidth(program, helper)).toEqual(longestThing.length);
   });
@@ -19,11 +16,8 @@ describe('padWidth', () => {
   test('when option term longest return option length', () => {
     const longestThing = '--very-long-thing-bigger-than-others';
     const program = new commander.Command();
-    program
-      .argument('<file>', 'desc')
-      .option(longestThing);
-    program
-      .command('sub');
+    program.argument('<file>', 'desc').option(longestThing);
+    program.command('sub');
     const helper = new commander.Help();
     expect(helper.padWidth(program, helper)).toEqual(longestThing.length);
   });
@@ -35,8 +29,7 @@ describe('padWidth', () => {
       .argument('<file>', 'desc')
       .option(longestThing)
       .configureHelp({ showGlobalOptions: true });
-    const sub = program
-      .command('sub');
+    const sub = program.command('sub');
     const helper = sub.createHelp();
     expect(helper.padWidth(sub, helper)).toEqual(longestThing.length);
   });
@@ -44,11 +37,8 @@ describe('padWidth', () => {
   test('when command term longest return command length', () => {
     const longestThing = 'very-long-thing-bigger-than-others';
     const program = new commander.Command();
-    program
-      .argument('<file>', 'desc')
-      .option('-o');
-    program
-      .command(longestThing);
+    program.argument('<file>', 'desc').option('-o');
+    program.command(longestThing);
     const helper = new commander.Help();
     expect(helper.padWidth(program, helper)).toEqual(longestThing.length);
   });

--- a/tests/help.showGlobalOptions.test.js
+++ b/tests/help.showGlobalOptions.test.js
@@ -2,36 +2,29 @@ const commander = require('../');
 
 test('when default configuration then global options hidden', () => {
   const program = new commander.Command();
-  program
-    .option('--global');
+  program.option('--global');
   const sub = program.command('sub');
   expect(sub.helpInformation()).not.toContain('global');
 });
 
 test('when showGlobalOptions:true then program options shown', () => {
   const program = new commander.Command();
-  program
-    .option('--global')
-    .configureHelp({ showGlobalOptions: true });
+  program.option('--global').configureHelp({ showGlobalOptions: true });
   const sub = program.command('sub');
   expect(sub.helpInformation()).toContain('global');
 });
 
 test('when showGlobalOptions:true and no global options then global options header not shown', () => {
   const program = new commander.Command();
-  program
-    .configureHelp({ showGlobalOptions: true });
+  program.configureHelp({ showGlobalOptions: true });
   const sub = program.command('sub');
   expect(sub.helpInformation()).not.toContain('Global');
 });
 
 test('when showGlobalOptions:true and nested commands then combined nested options shown program last', () => {
   const program = new commander.Command();
-  program
-    .option('--global')
-    .configureHelp({ showGlobalOptions: true });
-  const sub1 = program.command('sub1')
-    .option('--sub1');
+  program.option('--global').configureHelp({ showGlobalOptions: true });
+  const sub1 = program.command('sub1').option('--sub1');
   const sub2 = sub1.command('sub2');
   expect(sub2.helpInformation()).toContain(`Global Options:
   --sub1
@@ -46,10 +39,7 @@ test('when showGlobalOptions:true and sortOptions: true then global options sort
     .option('-4')
     .option('-2')
     .configureHelp({ showGlobalOptions: true, sortOptions: true });
-  const sub1 = program.command('sub1')
-    .option('-6')
-    .option('-1')
-    .option('-5');
+  const sub1 = program.command('sub1').option('-6').option('-1').option('-5');
   const sub2 = sub1.command('sub2');
   expect(sub2.helpInformation()).toContain(`Global Options:
   -1

--- a/tests/help.sortCommands.test.js
+++ b/tests/help.sortCommands.test.js
@@ -11,7 +11,9 @@ describe('sortSubcommands', () => {
       .command('aaa', 'desc')
       .command('bbb', 'desc');
     const helper = program.createHelp();
-    const visibleCommandNames = helper.visibleCommands(program).map(cmd => cmd.name());
+    const visibleCommandNames = helper
+      .visibleCommands(program)
+      .map((cmd) => cmd.name());
     expect(visibleCommandNames).toEqual(['ccc', 'aaa', 'bbb', 'help']);
   });
 
@@ -23,7 +25,9 @@ describe('sortSubcommands', () => {
       .command('aaa', 'desc')
       .command('bbb', 'desc');
     const helper = program.createHelp();
-    const visibleCommandNames = helper.visibleCommands(program).map(cmd => cmd.name());
+    const visibleCommandNames = helper
+      .visibleCommands(program)
+      .map((cmd) => cmd.name());
     expect(visibleCommandNames).toEqual(['aaa', 'bbb', 'ccc', 'help']);
   });
 });

--- a/tests/help.sortOptions.test.js
+++ b/tests/help.sortOptions.test.js
@@ -11,7 +11,9 @@ describe('sortOptions', () => {
       .option('--aaa', 'desc')
       .option('--bbb', 'desc');
     const helper = program.createHelp();
-    const visibleOptionNames = helper.visibleOptions(program).map(option => option.name());
+    const visibleOptionNames = helper
+      .visibleOptions(program)
+      .map((option) => option.name());
     expect(visibleOptionNames).toEqual(['zzz', 'aaa', 'bbb', 'help']);
   });
 
@@ -23,7 +25,9 @@ describe('sortOptions', () => {
       .option('--aaa', 'desc')
       .option('--bbb', 'desc');
     const helper = program.createHelp();
-    const visibleOptionNames = helper.visibleOptions(program).map(cmd => cmd.name());
+    const visibleOptionNames = helper
+      .visibleOptions(program)
+      .map((cmd) => cmd.name());
     expect(visibleOptionNames).toEqual(['aaa', 'bbb', 'help', 'zzz']);
   });
 
@@ -35,7 +39,9 @@ describe('sortOptions', () => {
       .option('-n,--aaa', 'desc')
       .option('-o,--bbb', 'desc');
     const helper = program.createHelp();
-    const visibleOptionNames = helper.visibleOptions(program).map(cmd => cmd.name());
+    const visibleOptionNames = helper
+      .visibleOptions(program)
+      .map((cmd) => cmd.name());
     expect(visibleOptionNames).toEqual(['help', 'zzz', 'aaa', 'bbb']);
   });
 
@@ -47,7 +53,9 @@ describe('sortOptions', () => {
       .option('--aaa', 'desc')
       .option('-b', 'desc');
     const helper = program.createHelp();
-    const visibleOptionNames = helper.visibleOptions(program).map(cmd => cmd.name());
+    const visibleOptionNames = helper
+      .visibleOptions(program)
+      .map((cmd) => cmd.name());
     expect(visibleOptionNames).toEqual(['aaa', 'b', 'help', 'zzz']);
   });
 
@@ -59,7 +67,9 @@ describe('sortOptions', () => {
       .option('-a', 'desc')
       .option('-c', 'desc');
     const helper = program.createHelp();
-    const visibleOptionNames = helper.visibleOptions(program).map(cmd => cmd.name());
+    const visibleOptionNames = helper
+      .visibleOptions(program)
+      .map((cmd) => cmd.name());
     expect(visibleOptionNames).toEqual(['a', 'B', 'c', 'help']);
   });
 
@@ -72,7 +82,9 @@ describe('sortOptions', () => {
       .option('--no-bbb', 'desc')
       .option('--aaa', 'desc');
     const helper = program.createHelp();
-    const visibleOptionNames = helper.visibleOptions(program).map(cmd => cmd.name());
+    const visibleOptionNames = helper
+      .visibleOptions(program)
+      .map((cmd) => cmd.name());
     expect(visibleOptionNames).toEqual(['aaa', 'bbb', 'ccc', 'help', 'no-bbb']);
   });
 });

--- a/tests/help.suggestion.test.js
+++ b/tests/help.suggestion.test.js
@@ -9,7 +9,9 @@ function getSuggestion(program, arg) {
     .showSuggestionAfterError() // make sure on
     .exitOverride()
     .configureOutput({
-      writeErr: (str) => { message = str; }
+      writeErr: (str) => {
+        message = str;
+      },
     });
   // Do the same setup for subcommand.
   const sub = program._findCommand('sub');
@@ -19,7 +21,9 @@ function getSuggestion(program, arg) {
     // Passing in an array for a few of the tests.
     const args = Array.isArray(arg) ? arg : [arg];
     program.parse(args, { from: 'user' });
-  } catch (err) {  /* empty */ }
+  } catch (err) {
+    /* empty */
+  }
 
   const match = message.match(/Did you mean (one of )?(.*)\?/);
   return match ? match[2] : null;
@@ -36,38 +40,49 @@ test.each([
   ['act', ['cat'], 'cat', '1 transposition'],
   ['cxx', ['cat'], null, '2 edits away and short string'],
   ['caxx', ['cart'], 'cart', '2 edits away and longer string'],
-  ['1234567', ['1234567890'], '1234567890', '3 edits away is similar for long string'],
+  [
+    '1234567',
+    ['1234567890'],
+    '1234567890',
+    '3 edits away is similar for long string',
+  ],
   ['123456', ['1234567890'], null, '4 edits is too far'],
   ['xat', ['rat', 'cat', 'bat'], 'bat, cat, rat', 'sorted possibles'],
-  ['cart', ['camb', 'cant', 'bard'], 'cant', 'only closest of different edit distances']
-])('when cli of %s and commands %j then suggest %s because %s', (arg, commandNames, expected) => {
-  const program = new Command();
-  commandNames.forEach(name => { program.command(name); });
-  const suggestion = getSuggestion(program, arg);
-  expect(suggestion).toBe(expected);
-});
+  [
+    'cart',
+    ['camb', 'cant', 'bard'],
+    'cant',
+    'only closest of different edit distances',
+  ],
+])(
+  'when cli of %s and commands %j then suggest %s because %s',
+  (arg, commandNames, expected) => {
+    const program = new Command();
+    commandNames.forEach((name) => {
+      program.command(name);
+    });
+    const suggestion = getSuggestion(program, arg);
+    expect(suggestion).toBe(expected);
+  },
+);
 
 test('when similar alias then suggest alias', () => {
   const program = new Command();
-  program.command('xyz')
-    .alias('car');
+  program.command('xyz').alias('car');
   const suggestion = getSuggestion(program, 'bar');
   expect(suggestion).toBe('car');
 });
 
 test('when similar hidden alias then not suggested', () => {
   const program = new Command();
-  program.command('xyz')
-    .alias('visible')
-    .alias('silent');
+  program.command('xyz').alias('visible').alias('silent');
   const suggestion = getSuggestion(program, 'slent');
   expect(suggestion).toBe(null);
 });
 
 test('when similar command and alias then suggest both', () => {
   const program = new Command();
-  program.command('aaaaa')
-    .alias('cat');
+  program.command('aaaaa').alias('cat');
   program.command('bat');
   program.command('ccccc');
   const suggestion = getSuggestion(program, 'mat');
@@ -132,30 +147,48 @@ test.each([
   ['--act', ['--cat'], '--cat', '1 transposition'],
   ['--cxx', ['--cat'], null, '2 edits away and short string'],
   ['--caxx', ['--cart'], '--cart', '2 edits away and longer string'],
-  ['--1234567', ['--1234567890'], '--1234567890', '3 edits away is similar for long string'],
+  [
+    '--1234567',
+    ['--1234567890'],
+    '--1234567890',
+    '3 edits away is similar for long string',
+  ],
   ['--123456', ['--1234567890'], null, '4 edits is too far'],
-  ['--xat', ['--rat', '--cat', '--bat'], '--bat, --cat, --rat', 'sorted possibles'],
-  ['--cart', ['--camb', '--cant', '--bard'], '--cant', 'only closest of different edit distances']
-])('when cli of %s and options %j then suggest %s because %s', (arg, commandNames, expected) => {
-  const program = new Command();
-  commandNames.forEach(name => { program.option(name); });
-  const suggestion = getSuggestion(program, arg);
-  expect(suggestion).toBe(expected);
-});
+  [
+    '--xat',
+    ['--rat', '--cat', '--bat'],
+    '--bat, --cat, --rat',
+    'sorted possibles',
+  ],
+  [
+    '--cart',
+    ['--camb', '--cant', '--bard'],
+    '--cant',
+    'only closest of different edit distances',
+  ],
+])(
+  'when cli of %s and options %j then suggest %s because %s',
+  (arg, commandNames, expected) => {
+    const program = new Command();
+    commandNames.forEach((name) => {
+      program.option(name);
+    });
+    const suggestion = getSuggestion(program, arg);
+    expect(suggestion).toBe(expected);
+  },
+);
 
 test('when no options then no suggestion', () => {
   // Checking nothing blows up as much as no suggestion!
   const program = new Command();
-  program
-    .helpOption(false);
+  program.helpOption(false);
   const suggestion = getSuggestion(program, '--option');
   expect(suggestion).toBe(null);
 });
 
 test('when subcommand option then candidate for subcommand option suggestion', () => {
   const program = new Command();
-  program.command('sub')
-    .option('-l,--local');
+  program.command('sub').option('-l,--local');
   const suggestion = getSuggestion(program, ['sub', '--loca']);
   expect(suggestion).toBe('--local');
 });
@@ -170,8 +203,7 @@ test('when global option then candidate for subcommand option suggestion', () =>
 
 test('when global option but positionalOptions then not candidate for subcommand suggestion', () => {
   const program = new Command();
-  program
-    .enablePositionalOptions();
+  program.enablePositionalOptions();
   program.option('-g, --global');
   program.command('sub');
   const suggestion = getSuggestion(program, ['sub', '--globla']);
@@ -181,8 +213,7 @@ test('when global option but positionalOptions then not candidate for subcommand
 test('when global and local options then both candidates', () => {
   const program = new Command();
   program.option('--cat');
-  program.command('sub')
-    .option('--rat');
+  program.command('sub').option('--rat');
   const suggestion = getSuggestion(program, ['sub', '--bat']);
   expect(suggestion).toBe('--cat, --rat');
 });

--- a/tests/help.visibleArguments.test.js
+++ b/tests/help.visibleArguments.test.js
@@ -23,19 +23,23 @@ describe('visibleArguments', () => {
     const helper = new commander.Help();
     const visibleArguments = helper.visibleArguments(program);
     expect(visibleArguments.length).toEqual(1);
-    expect(visibleArguments[0]).toEqual(new commander.Argument('<file>', 'file description'));
+    expect(visibleArguments[0]).toEqual(
+      new commander.Argument('<file>', 'file description'),
+    );
   });
 
   test('when argument and legacy argument description then returned', () => {
     const program = new commander.Command();
     program.argument('<file>');
     program.description('', {
-      file: 'file description'
+      file: 'file description',
     });
     const helper = new commander.Help();
     const visibleArguments = helper.visibleArguments(program);
     expect(visibleArguments.length).toEqual(1);
-    expect(visibleArguments[0]).toEqual(new commander.Argument('<file>', 'file description'));
+    expect(visibleArguments[0]).toEqual(
+      new commander.Argument('<file>', 'file description'),
+    );
   });
 
   test('when arguments and some described then all returned', () => {
@@ -45,7 +49,9 @@ describe('visibleArguments', () => {
     const helper = new commander.Help();
     const visibleArguments = helper.visibleArguments(program);
     expect(visibleArguments.length).toEqual(2);
-    expect(visibleArguments[0]).toEqual(new commander.Argument('<file1>', 'file1 description'));
+    expect(visibleArguments[0]).toEqual(
+      new commander.Argument('<file1>', 'file1 description'),
+    );
     expect(visibleArguments[1]).toEqual(new commander.Argument('<file2>'));
   });
 
@@ -54,12 +60,14 @@ describe('visibleArguments', () => {
     program.argument('<file1>');
     program.argument('<file2>');
     program.description('', {
-      file1: 'file1 description'
+      file1: 'file1 description',
     });
     const helper = new commander.Help();
     const visibleArguments = helper.visibleArguments(program);
     expect(visibleArguments.length).toEqual(2);
-    expect(visibleArguments[0]).toEqual(new commander.Argument('<file1>', 'file1 description'));
+    expect(visibleArguments[0]).toEqual(
+      new commander.Argument('<file1>', 'file1 description'),
+    );
     expect(visibleArguments[1]).toEqual(new commander.Argument('<file2>'));
   });
 });

--- a/tests/help.visibleCommands.test.js
+++ b/tests/help.visibleCommands.test.js
@@ -12,10 +12,11 @@ describe('visibleCommands', () => {
 
   test('when add command then visible (with help)', () => {
     const program = new commander.Command();
-    program
-      .command('sub');
+    program.command('sub');
     const helper = new commander.Help();
-    const visibleCommandNames = helper.visibleCommands(program).map(cmd => cmd.name());
+    const visibleCommandNames = helper
+      .visibleCommands(program)
+      .map((cmd) => cmd.name());
     expect(visibleCommandNames).toEqual(['sub', 'help']);
   });
 
@@ -24,10 +25,11 @@ describe('visibleCommands', () => {
     program
       .command('visible', 'desc')
       .command('invisible-executable', 'desc', { hidden: true });
-    program
-      .command('invisible-action', { hidden: true });
+    program.command('invisible-action', { hidden: true });
     const helper = new commander.Help();
-    const visibleCommandNames = helper.visibleCommands(program).map(cmd => cmd.name());
+    const visibleCommandNames = helper
+      .visibleCommands(program)
+      .map((cmd) => cmd.name());
     expect(visibleCommandNames).toEqual(['visible', 'help']);
   });
 });

--- a/tests/help.visibleGlobalOptions.test.js
+++ b/tests/help.visibleGlobalOptions.test.js
@@ -2,8 +2,7 @@ const commander = require('../');
 
 test('when default configuration then return empty array', () => {
   const program = new commander.Command();
-  program
-    .option('--global');
+  program.option('--global');
   const sub = program.command('sub');
   const helper = sub.createHelp();
   expect(helper.visibleGlobalOptions(program)).toEqual([]);
@@ -11,35 +10,34 @@ test('when default configuration then return empty array', () => {
 
 test('when showGlobalOptions:true then return program options', () => {
   const program = new commander.Command();
-  program
-    .option('--global')
-    .configureHelp({ showGlobalOptions: true });
+  program.option('--global').configureHelp({ showGlobalOptions: true });
   const sub = program.command('sub');
   const helper = sub.createHelp();
-  const visibleOptionNames = helper.visibleGlobalOptions(sub).map(option => option.name());
+  const visibleOptionNames = helper
+    .visibleGlobalOptions(sub)
+    .map((option) => option.name());
   expect(visibleOptionNames).toEqual(['global']);
 });
 
 test('when showGlobalOptions:true and program has version then return version', () => {
   const program = new commander.Command();
-  program
-    .configureHelp({ showGlobalOptions: true })
-    .version('1.2.3');
+  program.configureHelp({ showGlobalOptions: true }).version('1.2.3');
   const sub = program.command('sub');
   const helper = sub.createHelp();
-  const visibleOptionNames = helper.visibleGlobalOptions(sub).map(option => option.name());
+  const visibleOptionNames = helper
+    .visibleGlobalOptions(sub)
+    .map((option) => option.name());
   expect(visibleOptionNames).toEqual(['version']);
 });
 
 test('when showGlobalOptions:true and nested commands then return combined global options', () => {
   const program = new commander.Command();
-  program
-    .configureHelp({ showGlobalOptions: true })
-    .option('--global');
-  const sub1 = program.command('sub1')
-    .option('--sub1');
+  program.configureHelp({ showGlobalOptions: true }).option('--global');
+  const sub1 = program.command('sub1').option('--sub1');
   const sub2 = sub1.command('sub2');
   const helper = sub2.createHelp();
-  const visibleOptionNames = helper.visibleGlobalOptions(sub2).map(option => option.name());
+  const visibleOptionNames = helper
+    .visibleGlobalOptions(sub2)
+    .map((option) => option.name());
   expect(visibleOptionNames).toEqual(['sub1', 'global']);
 });

--- a/tests/help.visibleOptions.test.js
+++ b/tests/help.visibleOptions.test.js
@@ -7,7 +7,9 @@ describe('visibleOptions', () => {
   test('when no options then just help visible', () => {
     const program = new commander.Command();
     const helper = new commander.Help();
-    const visibleOptionNames = helper.visibleOptions(program).map(option => option.name());
+    const visibleOptionNames = helper
+      .visibleOptions(program)
+      .map((option) => option.name());
     expect(visibleOptionNames).toEqual(['help']);
   });
 
@@ -22,7 +24,9 @@ describe('visibleOptions', () => {
     const program = new commander.Command();
     program.option('-v,--visible');
     const helper = new commander.Help();
-    const visibleOptionNames = helper.visibleOptions(program).map(option => option.name());
+    const visibleOptionNames = helper
+      .visibleOptions(program)
+      .map((option) => option.name());
     expect(visibleOptionNames).toEqual(['visible', 'help']);
   });
 
@@ -32,7 +36,9 @@ describe('visibleOptions', () => {
       .option('-v,--visible')
       .addOption(new commander.Option('--invisible').hideHelp());
     const helper = new commander.Help();
-    const visibleOptionNames = helper.visibleOptions(program).map(option => option.name());
+    const visibleOptionNames = helper
+      .visibleOptions(program)
+      .map((option) => option.name());
     expect(visibleOptionNames).toEqual(['visible', 'help']);
   });
 });

--- a/tests/help.wrap.test.js
+++ b/tests/help.wrap.test.js
@@ -85,10 +85,12 @@ describe('wrapping by formatHelp', () => {
     const program = new commander.Command();
     program
       .configureHelp({ helpWidth: 80 })
-      .option('-x --extra-long-option-switch', 'kjsahdkajshkahd kajhsd akhds kashd kajhs dkha dkh aksd ka dkha kdh kasd ka kahs dkh sdkh askdh aksd kashdk ahsd kahs dkha skdh');
+      .option(
+        '-x --extra-long-option-switch',
+        'kjsahdkajshkahd kajhsd akhds kashd kajhs dkha dkh aksd ka dkha kdh kasd ka kahs dkh sdkh askdh aksd kashdk ahsd kahs dkha skdh',
+      );
 
-    const expectedOutput =
-`Usage:  [options]
+    const expectedOutput = `Usage:  [options]
 
 Options:
   -x --extra-long-option-switch  kjsahdkajshkahd kajhsd akhds kashd kajhs dkha
@@ -104,10 +106,13 @@ Options:
     const program = new commander.Command();
     program
       .configureHelp({ helpWidth: 80 })
-      .option('-x --extra-long-option <value>', 'kjsahdkajshkahd kajhsd akhds', 'aaa bbb ccc ddd eee fff ggg');
+      .option(
+        '-x --extra-long-option <value>',
+        'kjsahdkajshkahd kajhsd akhds',
+        'aaa bbb ccc ddd eee fff ggg',
+      );
 
-    const expectedOutput =
-`Usage:  [options]
+    const expectedOutput = `Usage:  [options]
 
 Options:
   -x --extra-long-option <value>  kjsahdkajshkahd kajhsd akhds (default: "aaa
@@ -123,10 +128,12 @@ Options:
     program
       .configureHelp({ helpWidth: 80 })
       .option('-x --extra-long-option-switch', 'x')
-      .command('alpha', 'Lorem mollit quis dolor ex do eu quis ad insa a commodo esse.');
+      .command(
+        'alpha',
+        'Lorem mollit quis dolor ex do eu quis ad insa a commodo esse.',
+      );
 
-    const expectedOutput =
-`Usage:  [options] [command]
+    const expectedOutput = `Usage:  [options] [command]
 
 Options:
   -x --extra-long-option-switch  x
@@ -144,13 +151,13 @@ Commands:
   test('when not enough room then help not wrapped', () => {
     // Not wrapping if less than 40 columns available for wrapping.
     const program = new commander.Command();
-    const commandDescription = 'description text of very long command which should not be automatically be wrapped. Do fugiat eiusmod ipsum laboris excepteur pariatur sint ullamco tempor labore eu.';
+    const commandDescription =
+      'description text of very long command which should not be automatically be wrapped. Do fugiat eiusmod ipsum laboris excepteur pariatur sint ullamco tempor labore eu.';
     program
       .configureHelp({ helpWidth: 60 })
       .command('1234567801234567890x', commandDescription);
 
-    const expectedOutput =
-`Usage:  [options] [command]
+    const expectedOutput = `Usage:  [options] [command]
 
 Options:
   -h, --help            display help for command
@@ -167,16 +174,16 @@ Commands:
     // #396: leave custom format alone, apart from space-space indent
     const optionSpec = '-t, --time <HH:MM>';
     const program = new commander.Command();
-    program
-      .configureHelp({ helpWidth: 80 })
-      .option(optionSpec, `select time
+    program.configureHelp({ helpWidth: 80 }).option(
+      optionSpec,
+      `select time
 
 Time can also be specified using special values:
   "dawn" - From night to sunrise.
-`);
+`,
+    );
 
-    const expectedOutput =
-`Usage:  [options]
+    const expectedOutput = `Usage:  [options]
 
 Options:
   ${optionSpec}  select time
@@ -192,8 +199,7 @@ Options:
 
   test('when command description long then wrapped', () => {
     const program = new commander.Command();
-    program
-      .configureHelp({ helpWidth: 80 })
+    program.configureHelp({ helpWidth: 80 })
       .description(`Do fugiat eiusmod ipsum laboris excepteur pariatur sint ullamco tempor labore eu Do fugiat eiusmod ipsum laboris excepteur pariatur sint ullamco tempor labore eu
 After line break Do fugiat eiusmod ipsum laboris excepteur pariatur sint ullamco tempor labore eu Do fugiat eiusmod ipsum laboris excepteur pariatur sint ullamco tempor labore eu`);
     const expectedOutput = `Usage:  [options]

--- a/tests/incrementNodeInspectorPort.test.js
+++ b/tests/incrementNodeInspectorPort.test.js
@@ -10,7 +10,7 @@ describe('incrementNodeInspectorPort', () => {
   beforeAll(() => {
     spawnSpy = jest.spyOn(childProcess, 'spawn').mockImplementation(() => {
       return {
-        on: () => {}
+        on: () => {},
       };
     });
     signalSpy = jest.spyOn(process, 'on').mockImplementation(() => {});
@@ -29,7 +29,9 @@ describe('incrementNodeInspectorPort', () => {
   function makeProgram() {
     const program = new commander.Command();
     const fileWhichExists = path.join(__dirname, './fixtures/pm-cache.js');
-    program.command('cache', 'stand-alone command', { executableFile: fileWhichExists });
+    program.command('cache', 'stand-alone command', {
+      executableFile: fileWhichExists,
+    });
     return program;
   }
 

--- a/tests/option.chain.test.js
+++ b/tests/option.chain.test.js
@@ -9,7 +9,7 @@ describe('Option methods that should return this for chaining', () => {
 
   test('when call .argParser() then returns this', () => {
     const option = new Option('-e,--example <value>');
-    const result = option.argParser(() => { });
+    const result = option.argParser(() => {});
     expect(result).toBe(option);
   });
 

--- a/tests/options.bool.combo.test.js
+++ b/tests/options.bool.combo.test.js
@@ -122,7 +122,11 @@ describe('boolean option combo with non-boolean default and preset', () => {
   function createPepperProgramWithDefaultAndPreset() {
     const program = new commander.Command();
     program
-      .addOption(new commander.Option('-p, --pepper').default('default').preset('preset'))
+      .addOption(
+        new commander.Option('-p, --pepper')
+          .default('default')
+          .preset('preset'),
+      )
       .option('-P, --no-pepper', 'remove pepper');
     return program;
   }

--- a/tests/options.bool.test.js
+++ b/tests/options.bool.test.js
@@ -6,32 +6,28 @@ const commander = require('../');
 describe('boolean flag on program', () => {
   test('when boolean flag not specified then value is undefined', () => {
     const program = new commander.Command();
-    program
-      .option('--pepper', 'add pepper');
+    program.option('--pepper', 'add pepper');
     program.parse(['node', 'test']);
     expect(program.opts().pepper).toBeUndefined();
   });
 
   test('when boolean flag specified then value is true', () => {
     const program = new commander.Command();
-    program
-      .option('--pepper', 'add pepper');
+    program.option('--pepper', 'add pepper');
     program.parse(['node', 'test', '--pepper']);
     expect(program.opts().pepper).toBe(true);
   });
 
   test('when negatable boolean flag not specified then value is true', () => {
     const program = new commander.Command();
-    program
-      .option('--no-cheese', 'remove cheese');
+    program.option('--no-cheese', 'remove cheese');
     program.parse(['node', 'test']);
     expect(program.opts().cheese).toBe(true);
   });
 
   test('when negatable boolean flag specified then value is false', () => {
     const program = new commander.Command();
-    program
-      .option('--no-cheese', 'remove cheese');
+    program.option('--no-cheese', 'remove cheese');
     program.parse(['node', 'test', '--no-cheese']);
     expect(program.opts().cheese).toBe(false);
   });
@@ -45,7 +41,9 @@ describe('boolean flag on command', () => {
     program
       .command('sub')
       .option('--pepper', 'add pepper')
-      .action((options) => { subCommandOptions = options; });
+      .action((options) => {
+        subCommandOptions = options;
+      });
     program.parse(['node', 'test', 'sub']);
     expect(subCommandOptions.pepper).toBeUndefined();
   });
@@ -56,7 +54,9 @@ describe('boolean flag on command', () => {
     program
       .command('sub')
       .option('--pepper', 'add pepper')
-      .action((options) => { subCommandOptions = options; });
+      .action((options) => {
+        subCommandOptions = options;
+      });
     program.parse(['node', 'test', 'sub', '--pepper']);
     expect(subCommandOptions.pepper).toBe(true);
   });
@@ -67,7 +67,9 @@ describe('boolean flag on command', () => {
     program
       .command('sub')
       .option('--no-cheese', 'remove cheese')
-      .action((options) => { subCommandOptions = options; });
+      .action((options) => {
+        subCommandOptions = options;
+      });
     program.parse(['node', 'test', 'sub']);
     expect(subCommandOptions.cheese).toBe(true);
   });
@@ -78,7 +80,9 @@ describe('boolean flag on command', () => {
     program
       .command('sub')
       .option('--no-cheese', 'remove cheese')
-      .action((options) => { subCommandOptions = options; });
+      .action((options) => {
+        subCommandOptions = options;
+      });
     program.parse(['node', 'test', 'sub', '--no-cheese']);
     expect(subCommandOptions.cheese).toBe(false);
   });
@@ -91,8 +95,7 @@ describe('boolean flag with non-boolean default', () => {
   test('when flag not specified then value is "default"', () => {
     const flagValue = 'black';
     const program = new commander.Command();
-    program
-      .option('--olives', 'Add green olives?', flagValue);
+    program.option('--olives', 'Add green olives?', flagValue);
     program.parse(['node', 'test']);
     expect(program.opts().olives).toBe(flagValue);
   });
@@ -100,8 +103,7 @@ describe('boolean flag with non-boolean default', () => {
   test('when flag specified then value is true', () => {
     const flagValue = 'black';
     const program = new commander.Command();
-    program
-      .option('-v, --olives', 'Add green olives?', flagValue);
+    program.option('-v, --olives', 'Add green olives?', flagValue);
     program.parse(['node', 'test', '--olives']);
     expect(program.opts().olives).toBe(true);
   });
@@ -121,16 +123,14 @@ describe('boolean flag with non-boolean default', () => {
 describe('regression test for -no- in middle of option flag', () => {
   test('when flag not specified then value is undefined', () => {
     const program = new commander.Command();
-    program
-      .option('--module-no-parse');
+    program.option('--module-no-parse');
     program.parse(['node', 'test']);
     expect(program.opts().moduleNoParse).toBeUndefined();
   });
 
   test('when flag specified then value is true', () => {
     const program = new commander.Command();
-    program
-      .option('--module-no-parse');
+    program.option('--module-no-parse');
     program.parse(['node', 'test', '--module-no-parse']);
     expect(program.opts().moduleNoParse).toEqual(true);
   });

--- a/tests/options.camelcase.test.js
+++ b/tests/options.camelcase.test.js
@@ -4,48 +4,42 @@ const commander = require('../');
 
 test('when option defined with --word-word then option property is wordWord', () => {
   const program = new commander.Command();
-  program
-    .option('--my-option', 'description');
+  program.option('--my-option', 'description');
   program.parse(['node', 'test', '--my-option']);
   expect(program.opts().myOption).toBe(true);
 });
 
 test('when option defined with --word-wORD then option property is wordWORD', () => {
   const program = new commander.Command();
-  program
-    .option('--my-oPTION', 'description');
+  program.option('--my-oPTION', 'description');
   program.parse(['node', 'test', '--my-oPTION']);
   expect(program.opts().myOPTION).toBe(true);
 });
 
 test('when option defined with --word-WORD then option property is wordWORD', () => {
   const program = new commander.Command();
-  program
-    .option('--my-OPTION', 'description');
+  program.option('--my-OPTION', 'description');
   program.parse(['node', 'test', '--my-OPTION']);
   expect(program.opts().myOPTION).toBe(true);
 });
 
 test('when option defined with --word-word-word then option property is wordWordWord', () => {
   const program = new commander.Command();
-  program
-    .option('--my-special-option', 'description');
+  program.option('--my-special-option', 'description');
   program.parse(['node', 'test', '--my-special-option']);
   expect(program.opts().mySpecialOption).toBe(true);
 });
 
 test('when option defined with --word-WORD-word then option property is wordWORDWord', () => {
   const program = new commander.Command();
-  program
-    .option('--my-SPECIAL-option', 'description');
+  program.option('--my-SPECIAL-option', 'description');
   program.parse(['node', 'test', '--my-SPECIAL-option']);
   expect(program.opts().mySPECIALOption).toBe(true);
 });
 
 test('when option defined with --Word then option property is Word', () => {
   const program = new commander.Command();
-  program
-    .option('--Myoption', 'description');
+  program.option('--Myoption', 'description');
   program.parse(['node', 'test', '--Myoption']);
   expect(program.opts().Myoption).toBe(true);
 });

--- a/tests/options.choices.test.js
+++ b/tests/options.choices.test.js
@@ -4,7 +4,9 @@ test('when option argument in choices then option set', () => {
   const program = new commander.Command();
   program
     .exitOverride()
-    .addOption(new commander.Option('--colour <shade>').choices(['red', 'blue']));
+    .addOption(
+      new commander.Option('--colour <shade>').choices(['red', 'blue']),
+    );
   program.parse(['--colour', 'red'], { from: 'user' });
   expect(program.opts().colour).toBe('red');
 });
@@ -15,9 +17,11 @@ test('when option argument is not in choices then error', () => {
   program
     .exitOverride()
     .configureOutput({
-      writeErr: () => {}
+      writeErr: () => {},
     })
-    .addOption(new commander.Option('--colour <shade>').choices(['red', 'blue']));
+    .addOption(
+      new commander.Option('--colour <shade>').choices(['red', 'blue']),
+    );
   expect(() => {
     program.parse(['--colour', 'orange'], { from: 'user' });
   }).toThrow();
@@ -46,7 +50,7 @@ describe('choices parameter is treated as readonly, per TypeScript declaration',
     program
       .exitOverride()
       .configureOutput({
-        writeErr: () => {}
+        writeErr: () => {},
       })
       .addOption(new commander.Option('--colour <shade>').choices(param));
     param.push('orange');

--- a/tests/options.conflicts.test.js
+++ b/tests/options.conflicts.test.js
@@ -9,14 +9,18 @@ describe('command with conflicting options', () => {
       .exitOverride()
       .configureOutput({
         writeErr: () => {},
-        writeOut: () => {}
+        writeOut: () => {},
       })
       .command('foo')
-      .addOption(new commander.Option('-s, --silent', "Don't print anything").env('SILENT'))
       .addOption(
-        new commander.Option('-j, --json', 'Format output as json').env('JSON').conflicts([
-          'silent'
-        ])
+        new commander.Option('-s, --silent', "Don't print anything").env(
+          'SILENT',
+        ),
+      )
+      .addOption(
+        new commander.Option('-j, --json', 'Format output as json')
+          .env('JSON')
+          .conflicts(['silent']),
       )
       .action(actionMock);
 
@@ -43,7 +47,7 @@ describe('command with conflicting options', () => {
     expect(actionMock).toHaveBeenCalledTimes(1);
     expect(actionMock).toHaveBeenCalledWith(
       { silent: true },
-      expect.any(Object)
+      expect.any(Object),
     );
   });
 
@@ -52,7 +56,9 @@ describe('command with conflicting options', () => {
 
     expect(() => {
       program.parse('node test.js foo --silent --json'.split(' '));
-    }).toThrow("error: option '-j, --json' cannot be used with option '-s, --silent'");
+    }).toThrow(
+      "error: option '-j, --json' cannot be used with option '-s, --silent'",
+    );
   });
 
   test('should report the env variable as the conflicting option source, when conflicting option is set', () => {
@@ -62,7 +68,9 @@ describe('command with conflicting options', () => {
 
     expect(() => {
       program.parse('node test.js foo --json'.split(' '));
-    }).toThrow("error: option '-j, --json' cannot be used with environment variable 'SILENT'");
+    }).toThrow(
+      "error: option '-j, --json' cannot be used with environment variable 'SILENT'",
+    );
   });
 
   test('should report the env variable as the configured option source, when configured option is set', () => {
@@ -72,7 +80,9 @@ describe('command with conflicting options', () => {
 
     expect(() => {
       program.parse('node test.js foo --silent'.split(' '));
-    }).toThrow("error: environment variable 'JSON' cannot be used with option '-s, --silent'");
+    }).toThrow(
+      "error: environment variable 'JSON' cannot be used with option '-s, --silent'",
+    );
   });
 
   test('should report both env variables as sources, when configured option and conflicting option are set', () => {
@@ -83,18 +93,27 @@ describe('command with conflicting options', () => {
 
     expect(() => {
       program.parse('node test.js foo'.split(' '));
-    }).toThrow("error: environment variable 'JSON' cannot be used with environment variable 'SILENT'");
+    }).toThrow(
+      "error: environment variable 'JSON' cannot be used with environment variable 'SILENT'",
+    );
   });
 
   test('should allow default value with a conflicting option', () => {
     const { program, actionMock } = makeProgram();
 
-    program.commands[0].addOption(new commander.Option('-d, --debug', 'print debug logs').default(true).conflicts(['silent']));
+    program.commands[0].addOption(
+      new commander.Option('-d, --debug', 'print debug logs')
+        .default(true)
+        .conflicts(['silent']),
+    );
 
     program.parse('node test.js foo --silent'.split(' '));
 
     expect(actionMock).toHaveBeenCalledTimes(1);
-    expect(actionMock).toHaveBeenCalledWith({ debug: true, silent: true }, expect.any(Object));
+    expect(actionMock).toHaveBeenCalledWith(
+      { debug: true, silent: true },
+      expect.any(Object),
+    );
   });
 
   test('should report conflict on negated option flag', () => {
@@ -108,7 +127,9 @@ describe('command with conflicting options', () => {
 
     expect(() => {
       program.parse('node test.js bar --red -N'.split(' '));
-    }).toThrow("error: option '--red' cannot be used with option '-N, --no-color'");
+    }).toThrow(
+      "error: option '--red' cannot be used with option '-N, --no-color'",
+    );
   });
 
   test('should report conflict on negated option env variable', () => {
@@ -124,7 +145,9 @@ describe('command with conflicting options', () => {
 
     expect(() => {
       program.parse('node test.js bar --red'.split(' '));
-    }).toThrow("error: option '--red' cannot be used with environment variable 'NO_COLOR'");
+    }).toThrow(
+      "error: option '--red' cannot be used with environment variable 'NO_COLOR'",
+    );
   });
 
   test('should report correct error for shorthand negated option', () => {
@@ -137,7 +160,9 @@ describe('command with conflicting options', () => {
 
     expect(() => {
       program.parse('node test.js bar --red -N'.split(' '));
-    }).toThrow("error: option '-N, --no-color' cannot be used with option '--red'");
+    }).toThrow(
+      "error: option '-N, --no-color' cannot be used with option '--red'",
+    );
   });
 
   test('should report correct error for positive option when negated is configured', () => {
@@ -180,7 +205,9 @@ describe('command with conflicting options', () => {
     process.env.DUAL = 'true';
     expect(() => {
       program.parse('node test.js bar --red'.split(' '));
-    }).toThrow("error: environment variable 'DUAL' cannot be used with option '--red'");
+    }).toThrow(
+      "error: environment variable 'DUAL' cannot be used with option '--red'",
+    );
   });
 
   test('should report correct error for negated env variable when positive is configured', () => {
@@ -195,7 +222,9 @@ describe('command with conflicting options', () => {
     process.env.NO_DUAL = 'true';
     expect(() => {
       program.parse('node test.js bar --red'.split(' '));
-    }).toThrow("error: environment variable 'NO_DUAL' cannot be used with option '--red'");
+    }).toThrow(
+      "error: environment variable 'NO_DUAL' cannot be used with option '--red'",
+    );
   });
 
   test('should report correct error for positive option with string value when negated is configured', () => {
@@ -209,7 +238,9 @@ describe('command with conflicting options', () => {
 
     expect(() => {
       program.parse('node test.js bar --red --dual2 foo'.split(' '));
-    }).toThrow("error: option '--dual2 <str>' cannot be used with option '--red'");
+    }).toThrow(
+      "error: option '--dual2 <str>' cannot be used with option '--red'",
+    );
   });
 
   test('should report correct error for negated option with preset when negated is configured', () => {
@@ -240,7 +271,10 @@ describe('command with conflicting options', () => {
     program.parse('node test.js bar --a --b'.split(' '));
 
     expect(actionMock).toHaveBeenCalledTimes(1);
-    expect(actionMock).toHaveBeenCalledWith({ a: true, b: true }, expect.any(Object));
+    expect(actionMock).toHaveBeenCalledWith(
+      { a: true, b: true },
+      expect.any(Object),
+    );
   });
 
   test('should throw error when conflicts is invoked with a single string that equals another option', () => {

--- a/tests/options.custom-processing.test.js
+++ b/tests/options.custom-processing.test.js
@@ -20,16 +20,14 @@ function commaSeparatedList(value, dummyPrevious) {
 test('when option not specified then callback not called', () => {
   const mockCoercion = jest.fn();
   const program = new commander.Command();
-  program
-    .option('-i, --integer <n>', 'number', mockCoercion);
+  program.option('-i, --integer <n>', 'number', mockCoercion);
   program.parse(['node', 'test']);
   expect(mockCoercion).not.toHaveBeenCalled();
 });
 
 test('when option not specified then value is undefined', () => {
   const program = new commander.Command();
-  program
-    .option('-i, --integer <n>', 'number', myParseInt);
+  program.option('-i, --integer <n>', 'number', myParseInt);
   program.parse(['node', 'test']);
   expect(program.opts().integer).toBeUndefined();
 });
@@ -37,8 +35,7 @@ test('when option not specified then value is undefined', () => {
 test('when starting value is defined and option not specified then callback not called', () => {
   const mockCoercion = jest.fn();
   const program = new commander.Command();
-  program
-    .option('-i, --integer <n>', 'number', mockCoercion, 1);
+  program.option('-i, --integer <n>', 'number', mockCoercion, 1);
   program.parse(['node', 'test']);
   expect(mockCoercion).not.toHaveBeenCalled();
 });
@@ -47,8 +44,7 @@ test('when starting value is defined and option not specified then value is star
   // NB: Can not specify a starting value for a boolean flag! Discovered when writing this test...
   const startingValue = 1;
   const program = new commander.Command();
-  program
-    .option('-i, --integer <n>', 'number', myParseInt, startingValue);
+  program.option('-i, --integer <n>', 'number', myParseInt, startingValue);
   program.parse(['node', 'test']);
   expect(program.opts().integer).toBe(startingValue);
 });
@@ -57,8 +53,7 @@ test('when option specified then callback called with value', () => {
   const mockCoercion = jest.fn();
   const value = '1';
   const program = new commander.Command();
-  program
-    .option('-i, --integer <n>', 'number', mockCoercion);
+  program.option('-i, --integer <n>', 'number', mockCoercion);
   program.parse(['node', 'test', '-i', value]);
   expect(mockCoercion).toHaveBeenCalledWith(value, undefined);
 });
@@ -66,10 +61,9 @@ test('when option specified then callback called with value', () => {
 test('when option specified then value is as returned from callback', () => {
   const callbackResult = 2;
   const program = new commander.Command();
-  program
-    .option('-i, --integer <n>', 'number', () => {
-      return callbackResult;
-    });
+  program.option('-i, --integer <n>', 'number', () => {
+    return callbackResult;
+  });
   program.parse(['node', 'test', '-i', '0']);
   expect(program.opts().integer).toBe(callbackResult);
 });
@@ -79,8 +73,7 @@ test('when starting value is defined and option specified then callback called w
   const startingValue = 1;
   const value = '2';
   const program = new commander.Command();
-  program
-    .option('-i, --integer <n>', 'number', mockCoercion, startingValue);
+  program.option('-i, --integer <n>', 'number', mockCoercion, startingValue);
   program.parse(['node', 'test', '-i', value]);
   expect(mockCoercion).toHaveBeenCalledWith(value, startingValue);
 });
@@ -90,8 +83,7 @@ test('when option specified multiple times then callback called with value and p
     return 'callback';
   });
   const program = new commander.Command();
-  program
-    .option('-i, --integer <n>', 'number', mockCoercion);
+  program.option('-i, --integer <n>', 'number', mockCoercion);
   program.parse(['node', 'test', '-i', '1', '-i', '2']);
   expect(mockCoercion).toHaveBeenCalledTimes(2);
   expect(mockCoercion).toHaveBeenNthCalledWith(1, '1', undefined);
@@ -102,40 +94,44 @@ test('when option specified multiple times then callback called with value and p
 
 test('when parseFloat "1e2" then value is 100', () => {
   const program = new commander.Command();
-  program
-    .option('-f, --float <number>', 'float argument', parseFloat);
+  program.option('-f, --float <number>', 'float argument', parseFloat);
   program.parse(['node', 'test', '-f', '1e2']);
   expect(program.opts().float).toBe(100);
 });
 
 test('when myParseInt "1" then value is 1', () => {
   const program = new commander.Command();
-  program
-    .option('-i, --integer <number>', 'integer argument', myParseInt);
+  program.option('-i, --integer <number>', 'integer argument', myParseInt);
   program.parse(['node', 'test', '-i', '1']);
   expect(program.opts().integer).toBe(1);
 });
 
 test('when increaseVerbosity -v -v -v then value is 3', () => {
   const program = new commander.Command();
-  program
-    .option('-v, --verbose', 'verbosity that can be increased', increaseVerbosity, 0);
+  program.option(
+    '-v, --verbose',
+    'verbosity that can be increased',
+    increaseVerbosity,
+    0,
+  );
   program.parse(['node', 'test', '-v', '-v', '-v']);
   expect(program.opts().verbose).toBe(3);
 });
 
 test('when collect -c a -c b -c c then value is [a, b, c]', () => {
   const program = new commander.Command();
-  program
-    .option('-c, --collect <value>', 'repeatable value', collect, []);
+  program.option('-c, --collect <value>', 'repeatable value', collect, []);
   program.parse(['node', 'test', '-c', 'a', '-c', 'b', '-c', 'c']);
   expect(program.opts().collect).toEqual(['a', 'b', 'c']);
 });
 
 test('when commaSeparatedList x,y,z then value is [x, y, z]', () => {
   const program = new commander.Command();
-  program
-    .option('-l, --list <items>', 'comma separated list', commaSeparatedList);
+  program.option(
+    '-l, --list <items>',
+    'comma separated list',
+    commaSeparatedList,
+  );
   program.parse(['node', 'test', '--list', 'x,y,z']);
   expect(program.opts().list).toEqual(['x', 'y', 'z']);
 });

--- a/tests/options.dual-options.test.js
+++ b/tests/options.dual-options.test.js
@@ -23,27 +23,21 @@ test('when negative option then stored in negativeOptions', () => {
 
 test('when unrelated positive and negative options then no dual options', () => {
   const program = new Command();
-  program
-    .option('--one')
-    .option('--no-two');
+  program.option('--one').option('--no-two');
   const helper = new DualOptions(program.options);
   expect(helper.dualOptions.size).toEqual(0);
 });
 
 test('when related positive and negative options then stored as dual option', () => {
   const program = new Command();
-  program
-    .option('--one')
-    .option('--no-one');
+  program.option('--one').option('--no-one');
   const helper = new DualOptions(program.options);
   expect(helper.dualOptions.size).toEqual(1);
 });
 
 test('when related negative and positive options then stored as dual option', () => {
   const program = new Command();
-  program
-    .option('--no-one')
-    .option('--one');
+  program.option('--no-one').option('--one');
   const helper = new DualOptions(program.options);
   expect(helper.dualOptions.size).toEqual(1);
 });

--- a/tests/options.env.test.js
+++ b/tests/options.env.test.js
@@ -1,77 +1,86 @@
 const commander = require('../');
 
 // treating optional same as required, treat as option taking value rather than as boolean
-describe.each(['-f, --foo <required-arg>', '-f, --foo [optional-arg]'])('option declared as: %s', (fooFlags) => {
-  test('when env undefined and no cli then option undefined', () => {
-    const program = new commander.Command();
-    program.addOption(new commander.Option(fooFlags).env('BAR'));
-    program.parse([], { from: 'user' });
-    expect(program.opts().foo).toBeUndefined();
-  });
+describe.each(['-f, --foo <required-arg>', '-f, --foo [optional-arg]'])(
+  'option declared as: %s',
+  (fooFlags) => {
+    test('when env undefined and no cli then option undefined', () => {
+      const program = new commander.Command();
+      program.addOption(new commander.Option(fooFlags).env('BAR'));
+      program.parse([], { from: 'user' });
+      expect(program.opts().foo).toBeUndefined();
+    });
 
-  test('when env defined and no cli then option from env', () => {
-    const program = new commander.Command();
-    process.env.BAR = 'env';
-    program.addOption(new commander.Option(fooFlags).env('BAR'));
-    program.parse([], { from: 'user' });
-    expect(program.opts().foo).toBe('env');
-    delete process.env.BAR;
-  });
+    test('when env defined and no cli then option from env', () => {
+      const program = new commander.Command();
+      process.env.BAR = 'env';
+      program.addOption(new commander.Option(fooFlags).env('BAR'));
+      program.parse([], { from: 'user' });
+      expect(program.opts().foo).toBe('env');
+      delete process.env.BAR;
+    });
 
-  test('when env defined and cli then option from cli', () => {
-    const program = new commander.Command();
-    process.env.BAR = 'env';
-    program.addOption(new commander.Option(fooFlags).env('BAR'));
-    program.parse(['--foo', 'cli'], { from: 'user' });
-    expect(program.opts().foo).toBe('cli');
-    delete process.env.BAR;
-  });
+    test('when env defined and cli then option from cli', () => {
+      const program = new commander.Command();
+      process.env.BAR = 'env';
+      program.addOption(new commander.Option(fooFlags).env('BAR'));
+      program.parse(['--foo', 'cli'], { from: 'user' });
+      expect(program.opts().foo).toBe('cli');
+      delete process.env.BAR;
+    });
 
-  test('when env defined and value source is config then option from env', () => {
-    const program = new commander.Command();
-    process.env.BAR = 'env';
-    program.addOption(new commander.Option(fooFlags).env('BAR'));
-    program.setOptionValueWithSource('foo', 'config', 'config');
-    program.parse([], { from: 'user' });
-    expect(program.opts().foo).toBe('env');
-    delete process.env.BAR;
-  });
+    test('when env defined and value source is config then option from env', () => {
+      const program = new commander.Command();
+      process.env.BAR = 'env';
+      program.addOption(new commander.Option(fooFlags).env('BAR'));
+      program.setOptionValueWithSource('foo', 'config', 'config');
+      program.parse([], { from: 'user' });
+      expect(program.opts().foo).toBe('env');
+      delete process.env.BAR;
+    });
 
-  test('when env defined and value source is unspecified then option unchanged', () => {
-    const program = new commander.Command();
-    process.env.BAR = 'env';
-    program.addOption(new commander.Option(fooFlags).env('BAR'));
-    program.setOptionValue('foo', 'client');
-    program.parse([], { from: 'user' });
-    expect(program.opts().foo).toBe('client');
-    delete process.env.BAR;
-  });
+    test('when env defined and value source is unspecified then option unchanged', () => {
+      const program = new commander.Command();
+      process.env.BAR = 'env';
+      program.addOption(new commander.Option(fooFlags).env('BAR'));
+      program.setOptionValue('foo', 'client');
+      program.parse([], { from: 'user' });
+      expect(program.opts().foo).toBe('client');
+      delete process.env.BAR;
+    });
 
-  test('when default and env undefined and no cli then option from default', () => {
-    const program = new commander.Command();
-    program.addOption(new commander.Option(fooFlags).env('BAR').default('default'));
-    program.parse([], { from: 'user' });
-    expect(program.opts().foo).toBe('default');
-  });
+    test('when default and env undefined and no cli then option from default', () => {
+      const program = new commander.Command();
+      program.addOption(
+        new commander.Option(fooFlags).env('BAR').default('default'),
+      );
+      program.parse([], { from: 'user' });
+      expect(program.opts().foo).toBe('default');
+    });
 
-  test('when default and env defined and no cli then option from env', () => {
-    const program = new commander.Command();
-    process.env.BAR = 'env';
-    program.addOption(new commander.Option(fooFlags).env('BAR').default('default'));
-    program.parse([], { from: 'user' });
-    expect(program.opts().foo).toBe('env');
-    delete process.env.BAR;
-  });
+    test('when default and env defined and no cli then option from env', () => {
+      const program = new commander.Command();
+      process.env.BAR = 'env';
+      program.addOption(
+        new commander.Option(fooFlags).env('BAR').default('default'),
+      );
+      program.parse([], { from: 'user' });
+      expect(program.opts().foo).toBe('env');
+      delete process.env.BAR;
+    });
 
-  test('when default and env defined and cli then option from cli', () => {
-    const program = new commander.Command();
-    process.env.BAR = 'env';
-    program.addOption(new commander.Option(fooFlags).env('BAR').default('default'));
-    program.parse(['--foo', 'cli'], { from: 'user' });
-    expect(program.opts().foo).toBe('cli');
-    delete process.env.BAR;
-  });
-});
+    test('when default and env defined and cli then option from cli', () => {
+      const program = new commander.Command();
+      process.env.BAR = 'env';
+      program.addOption(
+        new commander.Option(fooFlags).env('BAR').default('default'),
+      );
+      program.parse(['--foo', 'cli'], { from: 'user' });
+      expect(program.opts().foo).toBe('cli');
+      delete process.env.BAR;
+    });
+  },
+);
 
 describe('boolean flag', () => {
   test('when env undefined and no cli then option undefined', () => {
@@ -198,7 +207,11 @@ describe('custom argParser', () => {
   test('when env defined and no cli then custom parse from env', () => {
     const program = new commander.Command();
     process.env.BAR = 'env';
-    program.addOption(new commander.Option('-f, --foo <required>').env('BAR').argParser(str => str.toUpperCase()));
+    program.addOption(
+      new commander.Option('-f, --foo <required>')
+        .env('BAR')
+        .argParser((str) => str.toUpperCase()),
+    );
     program.parse([], { from: 'user' });
     expect(program.opts().foo).toBe('ENV');
     delete process.env.BAR;
@@ -209,7 +222,9 @@ describe('variadic', () => {
   test('when env defined and no cli then array from env', () => {
     const program = new commander.Command();
     process.env.BAR = 'env';
-    program.addOption(new commander.Option('-f, --foo <required...>').env('BAR'));
+    program.addOption(
+      new commander.Option('-f, --foo <required...>').env('BAR'),
+    );
     program.parse([], { from: 'user' });
     expect(program.opts().foo).toEqual(['env']);
     delete process.env.BAR;
@@ -218,7 +233,9 @@ describe('variadic', () => {
   test('when env defined and cli then array from cli', () => {
     const program = new commander.Command();
     process.env.BAR = 'env';
-    program.addOption(new commander.Option('-f, --foo <required...>').env('BAR'));
+    program.addOption(
+      new commander.Option('-f, --foo <required...>').env('BAR'),
+    );
     program.parse(['--foo', 'cli'], { from: 'user' });
     expect(program.opts().foo).toEqual(['cli']);
     delete process.env.BAR;
@@ -230,10 +247,14 @@ describe('env only processed when applies', () => {
     // Doing selective processing. Not processing env at addOption time.
     const program = new commander.Command();
     process.env.BAR = 'env';
-    program.command('one')
-      .action(() => {});
-    const two = program.command('two')
-      .addOption(new commander.Option('-f, --foo <required...>').env('BAR').default('default'))
+    program.command('one').action(() => {});
+    const two = program
+      .command('two')
+      .addOption(
+        new commander.Option('-f, --foo <required...>')
+          .env('BAR')
+          .default('default'),
+      )
       .action(() => {});
     program.parse(['one'], { from: 'user' });
     expect(two.opts().foo).toBe('default');
@@ -247,7 +268,9 @@ describe('env only processed when applies', () => {
     program.on('option:foo', optionEventMock);
     program.on('optionEnv:foo', optionEnvEventMock);
     process.env.BAR = 'env';
-    program.addOption(new commander.Option('-f, --foo <required...>').env('BAR'));
+    program.addOption(
+      new commander.Option('-f, --foo <required...>').env('BAR'),
+    );
     program.parse(['--foo', 'cli'], { from: 'user' });
     expect(optionEventMock).toHaveBeenCalledWith('cli');
     expect(optionEventMock).toHaveBeenCalledTimes(1);
@@ -259,7 +282,11 @@ describe('env only processed when applies', () => {
     const program = new commander.Command();
     const parseMock = jest.fn();
     process.env.BAR = 'env';
-    program.addOption(new commander.Option('-f, --foo <required...>').env('BAR').argParser(parseMock));
+    program.addOption(
+      new commander.Option('-f, --foo <required...>')
+        .env('BAR')
+        .argParser(parseMock),
+    );
     program.parse(['--foo', 'cli'], { from: 'user' });
     expect(parseMock).toHaveBeenCalledWith('cli', undefined);
     expect(parseMock).toHaveBeenCalledTimes(1);

--- a/tests/options.flags.test.js
+++ b/tests/options.flags.test.js
@@ -4,80 +4,70 @@ const commander = require('../');
 
 test('when only short flag defined and not specified then value is undefined', () => {
   const program = new commander.Command();
-  program
-    .option('-p', 'add pepper');
+  program.option('-p', 'add pepper');
   program.parse(['node', 'test']);
   expect(program.opts().p).toBeUndefined();
 });
 
 test('when only short flag defined and specified then value is true', () => {
   const program = new commander.Command();
-  program
-    .option('-p', 'add pepper');
+  program.option('-p', 'add pepper');
   program.parse(['node', 'test', '-p']);
   expect(program.opts().p).toBe(true);
 });
 
 test('when only long flag defined and not specified then value is undefined', () => {
   const program = new commander.Command();
-  program
-    .option('--pepper', 'add pepper');
+  program.option('--pepper', 'add pepper');
   program.parse(['node', 'test']);
   expect(program.opts().pepper).toBeUndefined();
 });
 
 test('when only long flag defined and specified then value is true', () => {
   const program = new commander.Command();
-  program
-    .option('--pepper', 'add pepper');
+  program.option('--pepper', 'add pepper');
   program.parse(['node', 'test', '--pepper']);
   expect(program.opts().pepper).toBe(true);
 });
 
 test('when "short,long" flags defined and short specified then value is true', () => {
   const program = new commander.Command();
-  program
-    .option('-p,--pepper', 'add pepper');
+  program.option('-p,--pepper', 'add pepper');
   program.parse(['node', 'test', '-p']);
   expect(program.opts().pepper).toBe(true);
 });
 
 test('when "short,long" flags defined and long specified then value is true', () => {
   const program = new commander.Command();
-  program
-    .option('-p,--pepper', 'add pepper');
+  program.option('-p,--pepper', 'add pepper');
   program.parse(['node', 'test', '--pepper']);
   expect(program.opts().pepper).toBe(true);
 });
 
 test('when "short|long" flags defined and short specified then value is true', () => {
   const program = new commander.Command();
-  program
-    .option('-p|--pepper', 'add pepper');
+  program.option('-p|--pepper', 'add pepper');
   program.parse(['node', 'test', '-p']);
   expect(program.opts().pepper).toBe(true);
 });
 
 test('when "short|long" flags defined and long specified then value is true', () => {
   const program = new commander.Command();
-  program
-    .option('-p|--pepper', 'add pepper');
+  program.option('-p|--pepper', 'add pepper');
   program.parse(['node', 'test', '--pepper']);
   expect(program.opts().pepper).toBe(true);
 });
 
 test('when "short long" flags defined and short specified then value is true', () => {
   const program = new commander.Command();
-  program
-    .option('-p --pepper', 'add pepper');
+  program.option('-p --pepper', 'add pepper');
   program.parse(['node', 'test', '-p']);
   expect(program.opts().pepper).toBe(true);
 });
 
 test('when "short long" flags defined and long specified then value is true', () => {
   const program = new commander.Command();
-  program
-    .option('-p --pepper', 'add pepper');
+  program.option('-p --pepper', 'add pepper');
   program.parse(['node', 'test', '--pepper']);
   expect(program.opts().pepper).toBe(true);
 });

--- a/tests/options.getset.test.js
+++ b/tests/options.getset.test.js
@@ -1,27 +1,30 @@
 const commander = require('../');
 
-describe.each([true, false])('storeOptionsAsProperties is %s', (storeOptionsAsProperties) => {
-  test('when option specified on CLI then value returned by getOptionValue', () => {
-    const program = new commander.Command();
-    program
-      .storeOptionsAsProperties(storeOptionsAsProperties)
-      .option('--cheese [type]', 'cheese type');
-    const cheeseType = 'blue';
-    program.parse(['node', 'test', '--cheese', cheeseType]);
-    expect(program.getOptionValue('cheese')).toBe(cheeseType);
-  });
+describe.each([true, false])(
+  'storeOptionsAsProperties is %s',
+  (storeOptionsAsProperties) => {
+    test('when option specified on CLI then value returned by getOptionValue', () => {
+      const program = new commander.Command();
+      program
+        .storeOptionsAsProperties(storeOptionsAsProperties)
+        .option('--cheese [type]', 'cheese type');
+      const cheeseType = 'blue';
+      program.parse(['node', 'test', '--cheese', cheeseType]);
+      expect(program.getOptionValue('cheese')).toBe(cheeseType);
+    });
 
-  test('when setOptionValue then value returned by opts', () => {
-    const program = new commander.Command();
-    const cheeseType = 'blue';
-    // Note: opts() only returns declared options when options stored as properties
-    program
-      .storeOptionsAsProperties(storeOptionsAsProperties)
-      .option('--cheese [type]', 'cheese type')
-      .setOptionValue('cheese', cheeseType);
-    expect(program.opts().cheese).toBe(cheeseType);
-  });
-});
+    test('when setOptionValue then value returned by opts', () => {
+      const program = new commander.Command();
+      const cheeseType = 'blue';
+      // Note: opts() only returns declared options when options stored as properties
+      program
+        .storeOptionsAsProperties(storeOptionsAsProperties)
+        .option('--cheese [type]', 'cheese type')
+        .setOptionValue('cheese', cheeseType);
+      expect(program.opts().cheese).toBe(cheeseType);
+    });
+  },
+);
 
 test('when setOptionValueWithSource then value returned by opts', () => {
   const program = new commander.Command();
@@ -43,8 +46,7 @@ test('when setOptionValueWithSource then source returned by getOptionValueSource
 test('when option value parsed from env then option source is env', () => {
   const program = new commander.Command();
   process.env.BAR = 'env';
-  program
-    .addOption(new commander.Option('-f, --foo').env('BAR'));
+  program.addOption(new commander.Option('-f, --foo').env('BAR'));
   program.parse([], { from: 'user' });
   expect(program.getOptionValueSource('foo')).toBe('env');
   delete process.env.BAR;
@@ -52,16 +54,14 @@ test('when option value parsed from env then option source is env', () => {
 
 test('when option value parsed from cli then option source is cli', () => {
   const program = new commander.Command();
-  program
-    .addOption(new commander.Option('-f, --foo').env('BAR'));
+  program.addOption(new commander.Option('-f, --foo').env('BAR'));
   program.parse(['--foo'], { from: 'user' });
   expect(program.getOptionValueSource('foo')).toBe('cli');
 });
 
 test('when setOptionValue then clears previous source', () => {
   const program = new commander.Command();
-  program
-    .option('--foo', 'description', 'default value');
+  program.option('--foo', 'description', 'default value');
   expect(program.getOptionValueSource('foo')).toBe('default');
   program.setOptionValue('foo', 'bar');
   expect(program.getOptionValueSource('foo')).toBeUndefined();

--- a/tests/options.implies.test.js
+++ b/tests/options.implies.test.js
@@ -13,7 +13,9 @@ describe('check priorities', () => {
   test('when source default and implied undefined then implied is undefined', () => {
     const program = new Command();
     program
-      .addOption(new Option('--foo').implies({ bar: 'implied' }).default('default'))
+      .addOption(
+        new Option('--foo').implies({ bar: 'implied' }).default('default'),
+      )
       .option('--bar');
     program.parse([], { from: 'user' });
     expect(program.opts()).toEqual({ foo: 'default' });
@@ -64,8 +66,7 @@ describe('check priorities', () => {
 
 test('when imply non-option then ok and stored', () => {
   const program = new Command();
-  program
-    .addOption(new Option('--foo').implies({ bar: 'implied' }));
+  program.addOption(new Option('--foo').implies({ bar: 'implied' }));
   program.parse(['--foo'], { from: 'user' });
   expect(program.opts()).toEqual({ foo: true, bar: 'implied' });
 });
@@ -83,7 +84,9 @@ test('when imply multiple values then store multiple values', () => {
 test('when imply multiple times then store multiple values', () => {
   const program = new Command();
   program
-    .addOption(new Option('--foo').implies({ one: 'ONE' }).implies({ two: 'TWO' }))
+    .addOption(
+      new Option('--foo').implies({ one: 'ONE' }).implies({ two: 'TWO' }),
+    )
     .option('--one')
     .option('--two');
   program.parse(['--foo'], { from: 'user' });
@@ -110,8 +113,7 @@ test('when imply from negative option then negative implied', () => {
 
 test('when imply from lone negative option then negative implied', () => {
   const program = new Command();
-  program
-    .addOption(new Option('--no-foo').implies({ implied: 'NEGATIVE' }));
+  program.addOption(new Option('--no-foo').implies({ implied: 'NEGATIVE' }));
   program.parse(['--no-foo'], { from: 'user' });
   expect(program.opts()).toEqual({ foo: false, implied: 'NEGATIVE' });
 });
@@ -120,7 +122,9 @@ test('when imply from negative option with preset then negative implied', () => 
   const program = new Command();
   program
     .addOption(new Option('--foo').implies({ implied: 'POSITIVE' }))
-    .addOption(new Option('--no-foo').implies({ implied: 'NEGATIVE' }).preset('FALSE'));
+    .addOption(
+      new Option('--no-foo').implies({ implied: 'NEGATIVE' }).preset('FALSE'),
+    );
   program.parse(['--no-foo'], { from: 'user' });
   expect(program.opts()).toEqual({ foo: 'FALSE', implied: 'NEGATIVE' });
 });
@@ -149,7 +153,7 @@ test('when conflict with implied value then throw', () => {
   program
     .exitOverride()
     .configureOutput({
-      writeErr: () => {}
+      writeErr: () => {},
     })
     .addOption(new Option('--unary'))
     .addOption(new Option('--binary').conflicts('unary'))
@@ -164,7 +168,9 @@ test('when requiredOption with implied value then not throw', () => {
   const program = new Command();
   program
     .requiredOption('--target <target-file>')
-    .addOption(new Option('--default-target').implies({ target: 'default-file' }));
+    .addOption(
+      new Option('--default-target').implies({ target: 'default-file' }),
+    );
 
   expect(() => {
     program.parse(['--default-target'], { from: 'user' });
@@ -173,11 +179,8 @@ test('when requiredOption with implied value then not throw', () => {
 
 test('when implies on program and use subcommand then program updated', () => {
   const program = new Command();
-  program
-    .addOption(new Option('--foo').implies({ bar: 'implied' }));
-  program
-    .command('sub')
-    .action(() => {});
+  program.addOption(new Option('--foo').implies({ bar: 'implied' }));
+  program.command('sub').action(() => {});
   program.parse(['--foo', 'sub'], { from: 'user' });
   expect(program.opts().bar).toEqual('implied');
 });
@@ -196,7 +199,9 @@ test('when implied option has custom processing then custom processing not calle
   const program = new Command();
   program
     .addOption(new Option('--foo').implies({ bar: true }))
-    .option('-b, --bar', 'description', () => { called = true; });
+    .option('-b, --bar', 'description', () => {
+      called = true;
+    });
   program.parse(['--foo'], { from: 'user' });
   expect(program.opts().bar).toEqual(true);
   expect(called).toEqual(false);

--- a/tests/options.mandatory.test.js
+++ b/tests/options.mandatory.test.js
@@ -6,9 +6,7 @@ const commander = require('../');
 describe('required program option with mandatory value specified', () => {
   test('when program has required value specified then value as specified', () => {
     const program = new commander.Command();
-    program
-      .exitOverride()
-      .requiredOption('--cheese <type>', 'cheese type');
+    program.exitOverride().requiredOption('--cheese <type>', 'cheese type');
     program.parse(['node', 'test', '--cheese', 'blue']);
     expect(program.opts().cheese).toBe('blue');
   });
@@ -33,9 +31,7 @@ describe('required program option with mandatory value specified', () => {
 
   test('when program has optional value flag specified then true', () => {
     const program = new commander.Command();
-    program
-      .exitOverride()
-      .requiredOption('--cheese [type]', 'cheese type');
+    program.exitOverride().requiredOption('--cheese [type]', 'cheese type');
     program.parse(['node', 'test', '--cheese']);
     expect(program.opts().cheese).toBe(true);
   });
@@ -106,7 +102,9 @@ describe('required program option with mandatory value not specified', () => {
   let writeErrorSpy;
 
   beforeAll(() => {
-    writeErrorSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => { });
+    writeErrorSpy = jest
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -119,9 +117,7 @@ describe('required program option with mandatory value not specified', () => {
 
   test('when program has required option not specified then error', () => {
     const program = new commander.Command();
-    program
-      .exitOverride()
-      .requiredOption('--cheese <type>', 'cheese type');
+    program.exitOverride().requiredOption('--cheese <type>', 'cheese type');
 
     expect(() => {
       program.parse(['node', 'test']);
@@ -130,9 +126,7 @@ describe('required program option with mandatory value not specified', () => {
 
   test('when program has optional option not specified then error', () => {
     const program = new commander.Command();
-    program
-      .exitOverride()
-      .requiredOption('--cheese [type]', 'cheese type');
+    program.exitOverride().requiredOption('--cheese [type]', 'cheese type');
 
     expect(() => {
       program.parse(['node', 'test']);
@@ -186,7 +180,11 @@ describe('required command option with mandatory value specified', () => {
     const program = new commander.Command();
     program
       .exitOverride()
-      .addOption(new commander.Option('-p, --port <number>', 'port number').makeOptionMandatory().env('FOO'));
+      .addOption(
+        new commander.Option('-p, --port <number>', 'port number')
+          .makeOptionMandatory()
+          .env('FOO'),
+      );
 
     process.env.FOO = 'bar';
     program.parse([], { from: 'user' });
@@ -201,7 +199,9 @@ describe('required command option with mandatory value not specified', () => {
   let writeErrorSpy;
 
   beforeAll(() => {
-    writeErrorSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => { });
+    writeErrorSpy = jest
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -232,8 +232,7 @@ describe('required command option with mandatory value not specified', () => {
       .command('sub')
       .requiredOption('--subby <type>', 'description')
       .action(() => {});
-    program
-      .command('sub2');
+    program.command('sub2');
 
     expect(() => {
       program.parse(['node', 'test', 'sub2']);
@@ -246,7 +245,7 @@ describe('missing mandatory option but help requested', () => {
   let writeSpy;
 
   beforeAll(() => {
-    writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => { });
+    writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -259,9 +258,7 @@ describe('missing mandatory option but help requested', () => {
 
   test('when program has required option not specified and --help then help', () => {
     const program = new commander.Command();
-    program
-      .exitOverride()
-      .requiredOption('--cheese <type>', 'cheese type');
+    program.exitOverride().requiredOption('--cheese <type>', 'cheese type');
 
     let caughtErr;
     try {

--- a/tests/options.optional.test.js
+++ b/tests/options.optional.test.js
@@ -4,16 +4,14 @@ const commander = require('../');
 describe('option with optional value, no default', () => {
   test('when option not specified then value is undefined', () => {
     const program = new commander.Command();
-    program
-      .option('--cheese [type]', 'cheese type');
+    program.option('--cheese [type]', 'cheese type');
     program.parse(['node', 'test']);
     expect(program.opts().cheese).toBeUndefined();
   });
 
   test('when option specified then value is as specified', () => {
     const program = new commander.Command();
-    program
-      .option('--cheese [type]', 'cheese type');
+    program.option('--cheese [type]', 'cheese type');
     const cheeseType = 'blue';
     program.parse(['node', 'test', '--cheese', cheeseType]);
     expect(program.opts().cheese).toBe(cheeseType);
@@ -21,8 +19,7 @@ describe('option with optional value, no default', () => {
 
   test('when option specified without value then value is true', () => {
     const program = new commander.Command();
-    program
-      .option('--cheese [type]', 'cheese type');
+    program.option('--cheese [type]', 'cheese type');
     program.parse(['node', 'test', '--cheese']);
     expect(program.opts().cheese).toBe(true);
   });
@@ -30,9 +27,7 @@ describe('option with optional value, no default', () => {
   test('when option specified without value and following option then value is true', () => {
     // optional options do not eat values with dashes
     const program = new commander.Command();
-    program
-      .option('--cheese [type]', 'cheese type')
-      .option('--some-option');
+    program.option('--cheese [type]', 'cheese type').option('--some-option');
     program.parse(['node', 'test', '--cheese', '--some-option']);
     expect(program.opts().cheese).toBe(true);
   });
@@ -43,8 +38,7 @@ describe('option with optional value, with default', () => {
   test('when option not specified then value is default', () => {
     const defaultValue = 'default';
     const program = new commander.Command();
-    program
-      .option('--cheese [type]', 'cheese type', defaultValue);
+    program.option('--cheese [type]', 'cheese type', defaultValue);
     program.parse(['node', 'test']);
     expect(program.opts().cheese).toBe(defaultValue);
   });
@@ -52,8 +46,7 @@ describe('option with optional value, with default', () => {
   test('when option specified then value is as specified', () => {
     const defaultValue = 'default';
     const program = new commander.Command();
-    program
-      .option('--cheese [type]', 'cheese type', defaultValue);
+    program.option('--cheese [type]', 'cheese type', defaultValue);
     const cheeseType = 'blue';
     program.parse(['node', 'test', '--cheese', cheeseType]);
     expect(program.opts().cheese).toBe(cheeseType);
@@ -62,16 +55,14 @@ describe('option with optional value, with default', () => {
   test('when option specified without value then value is true', () => {
     const defaultValue = 'default';
     const program = new commander.Command();
-    program
-      .option('--cheese [type]', 'cheese type', defaultValue);
+    program.option('--cheese [type]', 'cheese type', defaultValue);
     program.parse(['node', 'test', '--cheese']);
     expect(program.opts().cheese).toBe(true);
   });
 
   test('when option specified without value and preset then value is preset', () => {
     const program = new commander.Command();
-    program
-      .addOption(new commander.Option('--cheese [type]').preset('preset'));
+    program.addOption(new commander.Option('--cheese [type]').preset('preset'));
     program.parse(['node', 'test', '--cheese']);
     expect(program.opts().cheese).toBe('preset');
   });

--- a/tests/options.opts.test.js
+++ b/tests/options.opts.test.js
@@ -6,9 +6,7 @@ const commander = require('../');
 test('when .version used with storeOptionsAsProperties() then version in opts', () => {
   const program = new commander.Command();
   const version = '0.0.1';
-  program
-    .storeOptionsAsProperties()
-    .version(version);
+  program.storeOptionsAsProperties().version(version);
   program.parse(['node', 'test']);
   expect(program.opts()).toEqual({ version });
 });
@@ -17,58 +15,54 @@ test('when .version used with storeOptionsAsProperties(false) then version not i
   // New behaviour, stop storing version as an option value.
   const program = new commander.Command();
   const version = '0.0.1';
-  program
-    .storeOptionsAsProperties(false)
-    .version(version);
+  program.storeOptionsAsProperties(false).version(version);
   program.parse(['node', 'test']);
-  expect(program.opts()).toEqual({ });
+  expect(program.opts()).toEqual({});
 });
 
-describe.each([true, false])('storeOptionsAsProperties is %s', (storeOptionsAsProperties) => {
-  test('when boolean flag not specified then not in opts', () => {
-    const program = new commander.Command();
-    program.storeOptionsAsProperties(storeOptionsAsProperties);
-    program
-      .option('--pepper', 'add pepper');
-    program.parse(['node', 'test']);
-    expect(program.opts()).toEqual({ });
-  });
+describe.each([true, false])(
+  'storeOptionsAsProperties is %s',
+  (storeOptionsAsProperties) => {
+    test('when boolean flag not specified then not in opts', () => {
+      const program = new commander.Command();
+      program.storeOptionsAsProperties(storeOptionsAsProperties);
+      program.option('--pepper', 'add pepper');
+      program.parse(['node', 'test']);
+      expect(program.opts()).toEqual({});
+    });
 
-  test('when boolean flag specified then value true', () => {
-    const program = new commander.Command();
-    program.storeOptionsAsProperties(storeOptionsAsProperties);
-    program
-      .option('--pepper', 'add pepper');
-    program.parse(['node', 'test', '--pepper']);
-    expect(program.opts()).toEqual({ pepper: true });
-  });
+    test('when boolean flag specified then value true', () => {
+      const program = new commander.Command();
+      program.storeOptionsAsProperties(storeOptionsAsProperties);
+      program.option('--pepper', 'add pepper');
+      program.parse(['node', 'test', '--pepper']);
+      expect(program.opts()).toEqual({ pepper: true });
+    });
 
-  test('when option with required value not specified then not in opts', () => {
-    const program = new commander.Command();
-    program.storeOptionsAsProperties(storeOptionsAsProperties);
-    program
-      .option('--pepper <flavour>', 'add pepper');
-    program.parse(['node', 'test']);
-    expect(program.opts()).toEqual({ });
-  });
+    test('when option with required value not specified then not in opts', () => {
+      const program = new commander.Command();
+      program.storeOptionsAsProperties(storeOptionsAsProperties);
+      program.option('--pepper <flavour>', 'add pepper');
+      program.parse(['node', 'test']);
+      expect(program.opts()).toEqual({});
+    });
 
-  test('when option with required value specified then value as specified', () => {
-    const pepperValue = 'red';
-    const program = new commander.Command();
-    program.storeOptionsAsProperties(storeOptionsAsProperties);
-    program
-      .option('--pepper <flavour>', 'add pepper');
-    program.parse(['node', 'test', '--pepper', pepperValue]);
-    expect(program.opts()).toEqual({ pepper: pepperValue });
-  });
+    test('when option with required value specified then value as specified', () => {
+      const pepperValue = 'red';
+      const program = new commander.Command();
+      program.storeOptionsAsProperties(storeOptionsAsProperties);
+      program.option('--pepper <flavour>', 'add pepper');
+      program.parse(['node', 'test', '--pepper', pepperValue]);
+      expect(program.opts()).toEqual({ pepper: pepperValue });
+    });
 
-  test('when option with default value not specified then default value in opts', () => {
-    const pepperDefault = 'red';
-    const program = new commander.Command();
-    program.storeOptionsAsProperties(storeOptionsAsProperties);
-    program
-      .option('--pepper <flavour>', 'add pepper', pepperDefault);
-    program.parse(['node', 'test']);
-    expect(program.opts()).toEqual({ pepper: pepperDefault });
-  });
-});
+    test('when option with default value not specified then default value in opts', () => {
+      const pepperDefault = 'red';
+      const program = new commander.Command();
+      program.storeOptionsAsProperties(storeOptionsAsProperties);
+      program.option('--pepper <flavour>', 'add pepper', pepperDefault);
+      program.parse(['node', 'test']);
+      expect(program.opts()).toEqual({ pepper: pepperDefault });
+    });
+  },
+);

--- a/tests/options.optsWithGlobals.test.js
+++ b/tests/options.optsWithGlobals.test.js
@@ -19,8 +19,7 @@ describe('optsWithGlobals', () => {
   test('when options in sub and program then optsWithGlobals includes both', () => {
     const program = new commander.Command();
     let mergedOptions;
-    program
-      .option('-g, --global <value>');
+    program.option('-g, --global <value>');
     program
       .command('sub')
       .option('-l, --local <value)')
@@ -44,16 +43,16 @@ describe('optsWithGlobals', () => {
         mergedOptions = cmd.optsWithGlobals();
       });
 
-    program.parse(['sub', '-g', 'GGG', 'subsub', '-l', 'LLL'], { from: 'user' });
+    program.parse(['sub', '-g', 'GGG', 'subsub', '-l', 'LLL'], {
+      from: 'user',
+    });
     expect(mergedOptions).toEqual({ global: 'GGG', local: 'LLL' });
   });
 
   test('when same named option in sub and program then optsWithGlobals includes global', () => {
     const program = new commander.Command();
     let mergedOptions;
-    program
-      .option('-c, --common <value>')
-      .enablePositionalOptions();
+    program.option('-c, --common <value>').enablePositionalOptions();
     program
       .command('sub')
       .option('-c, --common <value)')
@@ -69,8 +68,7 @@ describe('optsWithGlobals', () => {
 describe('getOptionValueSourceWithGlobals', () => {
   test('when option used with simple command then source is defined', () => {
     const program = new commander.Command();
-    program
-      .option('-g, --global');
+    program.option('-g, --global');
 
     program.parse(['-g'], { from: 'user' });
     expect(program.getOptionValueSourceWithGlobals('global')).toEqual('cli');
@@ -78,9 +76,9 @@ describe('getOptionValueSourceWithGlobals', () => {
 
   test('when option used with program then source is defined', () => {
     const program = new commander.Command();
-    program
-      .option('-g, --global');
-    const sub = program.command('sub')
+    program.option('-g, --global');
+    const sub = program
+      .command('sub')
       .option('-l, --local')
       .action(() => {});
 
@@ -90,9 +88,9 @@ describe('getOptionValueSourceWithGlobals', () => {
 
   test('when option used with subcommand then source is defined', () => {
     const program = new commander.Command();
-    program
-      .option('-g, --global');
-    const sub = program.command('sub')
+    program.option('-g, --global');
+    const sub = program
+      .command('sub')
       .option('-l, --local')
       .action(() => {});
 
@@ -105,7 +103,8 @@ describe('getOptionValueSourceWithGlobals', () => {
     program
       .enablePositionalOptions()
       .option('-c, --common <value>', 'description', 'default value');
-    const sub = program.command('sub')
+    const sub = program
+      .command('sub')
       .option('-c, --common <value>')
       .action(() => {});
 

--- a/tests/options.preset.test.js
+++ b/tests/options.preset.test.js
@@ -37,7 +37,9 @@ test('when optional with string preset used with option-argument then value is a
 
 test('when optional with preset and coerce used then preset is coerced', () => {
   const program = new Command();
-  program.addOption(new Option('-p, --port [port]').preset('4').argParser(parseFloat));
+  program.addOption(
+    new Option('-p, --port [port]').preset('4').argParser(parseFloat),
+  );
   program.parse(['-p'], { from: 'user' });
   expect(program.opts().port).toBe(4);
 });

--- a/tests/options.registerClash.test.js
+++ b/tests/options.registerClash.test.js
@@ -22,18 +22,15 @@ describe('.option()', () => {
   test('when use help options separately then does not throw', () => {
     expect(() => {
       const program = new Command();
-      program
-        .option('-h, --help', 'display help');
+      program.option('-h, --help', 'display help');
     }).not.toThrow();
   });
 
   test('when reuse flags in subcommand then does not throw', () => {
     expect(() => {
       const program = new Command();
-      program
-        .option('e, --example');
-      program.command('sub')
-        .option('e, --example');
+      program.option('e, --example');
+      program.command('sub').option('e, --example');
     }).not.toThrow();
   });
 });

--- a/tests/options.required.test.js
+++ b/tests/options.required.test.js
@@ -4,16 +4,14 @@ const commander = require('../');
 describe('option with required value, no default', () => {
   test('when option not specified then value is undefined', () => {
     const program = new commander.Command();
-    program
-      .option('--cheese <type>', 'cheese type');
+    program.option('--cheese <type>', 'cheese type');
     program.parse(['node', 'test']);
     expect(program.opts().cheese).toBeUndefined();
   });
 
   test('when option specified then value is as specified', () => {
     const program = new commander.Command();
-    program
-      .option('--cheese <type>', 'cheese type');
+    program.option('--cheese <type>', 'cheese type');
     const cheeseType = 'blue';
     program.parse(['node', 'test', '--cheese', cheeseType]);
     expect(program.opts().cheese).toBe(cheeseType);
@@ -26,8 +24,7 @@ describe('option with required value, no default', () => {
     });
     const program = new commander.Command();
     program.optionMissingArgument = mockOptionMissingArgument;
-    program
-      .option('--cheese <type>', 'cheese type');
+    program.option('--cheese <type>', 'cheese type');
 
     // Act. The throw is due to the above mock, and not default behaviour.
     expect(() => {
@@ -44,8 +41,7 @@ describe('option with required value, with default', () => {
   test('when option not specified then value is default', () => {
     const defaultValue = 'default';
     const program = new commander.Command();
-    program
-      .option('--cheese <type>', 'cheese type', defaultValue);
+    program.option('--cheese <type>', 'cheese type', defaultValue);
     program.parse(['node', 'test']);
     expect(program.opts().cheese).toBe(defaultValue);
   });
@@ -53,8 +49,7 @@ describe('option with required value, with default', () => {
   test('when option specified then value is as specified', () => {
     const defaultValue = 'default';
     const program = new commander.Command();
-    program
-      .option('--cheese <type>', 'cheese type', defaultValue);
+    program.option('--cheese <type>', 'cheese type', defaultValue);
     const cheeseType = 'blue';
     program.parse(['node', 'test', '--cheese', cheeseType]);
     expect(program.opts().cheese).toBe(cheeseType);
@@ -68,8 +63,7 @@ describe('option with required value, with default', () => {
     const defaultValue = 'default';
     const program = new commander.Command();
     program.optionMissingArgument = mockOptionMissingArgument;
-    program
-      .option('--cheese <type>', 'cheese type', defaultValue);
+    program.option('--cheese <type>', 'cheese type', defaultValue);
 
     // Act. The throw is due to the above mock, and not default behaviour.
     expect(() => {

--- a/tests/options.values.test.js
+++ b/tests/options.values.test.js
@@ -7,11 +7,11 @@ const commander = require('../');
 //
 // option with required value, using describe.each to test all matrix of values and tests
 describe.each([['str'], ['80'], ['-'], ['-5'], ['--flag']])(
-  'option with required value specified as %s', (value) => {
+  'option with required value specified as %s',
+  (value) => {
     function createPortProgram() {
       const program = new commander.Command();
-      program
-        .option('-p,--port <number>', 'specify port');
+      program.option('-p,--port <number>', 'specify port');
       return program;
     }
 
@@ -38,14 +38,14 @@ describe.each([['str'], ['80'], ['-'], ['-5'], ['--flag']])(
       program.parse(['node', 'test', `--port=${value}`]);
       expect(program.opts().port).toBe(value);
     });
-  });
+  },
+);
 
 // option with optional value
 describe('option with optional value', () => {
   function createPortProgram() {
     const program = new commander.Command();
-    program
-      .option('-p,--port [number]', 'specify port');
+    program.option('-p,--port [number]', 'specify port');
     return program;
   }
 
@@ -75,8 +75,10 @@ describe('option with optional value', () => {
 
   test('when long flag followed empty string then value is empty string', () => {
     const program = createPortProgram();
-    program
-      .option('-c, --cheese [type]', 'optionally specify the type of cheese');
+    program.option(
+      '-c, --cheese [type]',
+      'optionally specify the type of cheese',
+    );
     program.parse(['node', 'test', '--cheese', '']);
     expect(program.opts().cheese).toBe('');
   });

--- a/tests/options.variadic.test.js
+++ b/tests/options.variadic.test.js
@@ -15,8 +15,7 @@ describe('variadic option with required value', () => {
 
   test('when variadic with one value then set in array', () => {
     const program = new commander.Command();
-    program
-      .option('-r,--required <value...>');
+    program.option('-r,--required <value...>');
 
     program.parse(['--required', 'one'], { from: 'user' });
     expect(program.opts().required).toEqual(['one']);
@@ -24,8 +23,7 @@ describe('variadic option with required value', () => {
 
   test('when variadic with two values then set in array', () => {
     const program = new commander.Command();
-    program
-      .option('-r,--required <value...>');
+    program.option('-r,--required <value...>');
 
     program.parse(['--required', 'one', 'two'], { from: 'user' });
     expect(program.opts().required).toEqual(['one', 'two']);
@@ -33,8 +31,7 @@ describe('variadic option with required value', () => {
 
   test('when variadic with repeated values then set in array', () => {
     const program = new commander.Command();
-    program
-      .option('-r,--required <value...>');
+    program.option('-r,--required <value...>');
 
     program.parse(['--required', 'one', '--required', 'two'], { from: 'user' });
     expect(program.opts().required).toEqual(['one', 'two']);
@@ -42,8 +39,9 @@ describe('variadic option with required value', () => {
 
   test('when variadic used with choices and one value then set in array', () => {
     const program = new commander.Command();
-    program
-      .addOption(new commander.Option('-r,--required <value...>').choices(['one', 'two']));
+    program.addOption(
+      new commander.Option('-r,--required <value...>').choices(['one', 'two']),
+    );
 
     program.parse(['--required', 'one'], { from: 'user' });
     expect(program.opts().required).toEqual(['one']);
@@ -51,8 +49,9 @@ describe('variadic option with required value', () => {
 
   test('when variadic used with choices and two values then set in array', () => {
     const program = new commander.Command();
-    program
-      .addOption(new commander.Option('-r,--required <value...>').choices(['one', 'two']));
+    program.addOption(
+      new commander.Option('-r,--required <value...>').choices(['one', 'two']),
+    );
 
     program.parse(['--required', 'one', 'two'], { from: 'user' });
     expect(program.opts().required).toEqual(['one', 'two']);
@@ -60,9 +59,7 @@ describe('variadic option with required value', () => {
 
   test('when variadic with short combined argument then not variadic', () => {
     const program = new commander.Command();
-    program
-      .option('-r,--required <value...>')
-      .argument('[arg]');
+    program.option('-r,--required <value...>').argument('[arg]');
 
     program.parse(['-rone', 'operand'], { from: 'user' });
     expect(program.opts().required).toEqual(['one']);
@@ -70,9 +67,7 @@ describe('variadic option with required value', () => {
 
   test('when variadic with long combined argument then not variadic', () => {
     const program = new commander.Command();
-    program
-      .option('-r,--required <value...>')
-      .argument('[arg]');
+    program.option('-r,--required <value...>').argument('[arg]');
 
     program.parse(['--required=one', 'operand'], { from: 'user' });
     expect(program.opts().required).toEqual(['one']);
@@ -93,8 +88,11 @@ describe('variadic option with required value', () => {
 
   test('when variadic with no value and default then set to default', () => {
     const program = new commander.Command();
-    program
-      .option('-r,--required <value...>', 'variadic description', 'default');
+    program.option(
+      '-r,--required <value...>',
+      'variadic description',
+      'default',
+    );
 
     program.parse([], { from: 'user' });
     expect(program.opts().required).toEqual('default');
@@ -102,8 +100,11 @@ describe('variadic option with required value', () => {
 
   test('when variadic with coercion then coercion sets value', () => {
     const program = new commander.Command();
-    program
-      .option('-r,--required <value...>', 'variadic description', parseFloat);
+    program.option(
+      '-r,--required <value...>',
+      'variadic description',
+      parseFloat,
+    );
 
     // variadic processing reads the multiple values, but up to custom coercion what it does.
     program.parse(['--required', '1e2', '1e3'], { from: 'user' });
@@ -115,8 +116,7 @@ describe('variadic option with required value', () => {
 describe('variadic option with optional value', () => {
   test('when variadic not specified then value undefined', () => {
     const program = new commander.Command();
-    program
-      .option('-o,--optional [value...]');
+    program.option('-o,--optional [value...]');
 
     program.parse([], { from: 'user' });
     expect(program.opts().optional).toBeUndefined();
@@ -124,8 +124,7 @@ describe('variadic option with optional value', () => {
 
   test('when variadic used as boolean flag then value true', () => {
     const program = new commander.Command();
-    program
-      .option('-o,--optional [value...]');
+    program.option('-o,--optional [value...]');
 
     program.parse(['--optional'], { from: 'user' });
     expect(program.opts().optional).toBe(true);
@@ -133,8 +132,7 @@ describe('variadic option with optional value', () => {
 
   test('when variadic with one value then set in array', () => {
     const program = new commander.Command();
-    program
-      .option('-o,--optional [value...]');
+    program.option('-o,--optional [value...]');
 
     program.parse(['--optional', 'one'], { from: 'user' });
     expect(program.opts().optional).toEqual(['one']);
@@ -142,8 +140,7 @@ describe('variadic option with optional value', () => {
 
   test('when variadic with two values then set in array', () => {
     const program = new commander.Command();
-    program
-      .option('-o,--optional [value...]');
+    program.option('-o,--optional [value...]');
 
     program.parse(['--optional', 'one', 'two'], { from: 'user' });
     expect(program.opts().optional).toEqual(['one', 'two']);
@@ -153,8 +150,7 @@ describe('variadic option with optional value', () => {
 describe('variadic special cases', () => {
   test('when option flags has word character before dots then is variadic', () => {
     const program = new commander.Command();
-    program
-      .option('-c,--comma [value...]');
+    program.option('-c,--comma [value...]');
 
     expect(program.options[0].variadic).toBeTruthy();
   });
@@ -162,8 +158,7 @@ describe('variadic special cases', () => {
   test('when option flags has special characters before dots then not variadic', () => {
     // This might be used to describe coercion for comma separated values, and is not variadic.
     const program = new commander.Command();
-    program
-      .option('-c,--comma [value,...]');
+    program.option('-c,--comma [value,...]');
 
     expect(program.options[0].variadic).toBeFalsy();
   });

--- a/tests/options.version.test.js
+++ b/tests/options.version.test.js
@@ -7,7 +7,9 @@ describe('.version', () => {
     const errorMessage = 'unknownOption';
     const program = new commander.Command();
     // Override unknownOption as convenient way to check fails as expected.
-    jest.spyOn(program, 'unknownOption').mockImplementation(() => { throw new Error(errorMessage); });
+    jest.spyOn(program, 'unknownOption').mockImplementation(() => {
+      throw new Error(errorMessage);
+    });
 
     expect(() => {
       program.parse(['node', 'test', '--version']);
@@ -56,8 +58,7 @@ describe('.version', () => {
   test('when default .version then helpInformation includes default version help', () => {
     const myVersion = '1.2.3';
     const program = new commander.Command();
-    program
-      .version(myVersion);
+    program.version(myVersion);
 
     const helpInformation = program.helpInformation();
 
@@ -130,8 +131,7 @@ describe('.version', () => {
     const myVersionFlags = '-r, --revision';
     const myVersionDescription = 'custom description';
     const program = new commander.Command();
-    program
-      .version(myVersion, myVersionFlags, myVersionDescription);
+    program.version(myVersion, myVersionFlags, myVersionDescription);
 
     const helpInformation = program.helpInformation();
 
@@ -142,10 +142,7 @@ describe('.version', () => {
   test('when have .version+version and specify version then command called', () => {
     const actionMock = jest.fn();
     const program = new commander.Command();
-    program
-      .version('1.2.3')
-      .command('version')
-      .action(actionMock);
+    program.version('1.2.3').command('version').action(actionMock);
 
     program.parse(['node', 'test', 'version']);
 

--- a/tests/program.test.js
+++ b/tests/program.test.js
@@ -9,7 +9,7 @@ const {
   InvalidOptionArgumentError,
   createCommand,
   createOption,
-  createArgument
+  createArgument,
 } = require('../index.js');
 
 // Do some testing of the default export(s).
@@ -50,7 +50,8 @@ test('InvalidArgumentError', () => {
   checkClass(new InvalidArgumentError('failed'), 'InvalidArgumentError');
 });
 
-test('InvalidOptionArgumentError', () => { // Deprecated
+test('InvalidOptionArgumentError', () => {
+  // Deprecated
   checkClass(new InvalidOptionArgumentError('failed'), 'InvalidArgumentError');
 });
 

--- a/tests/ts-imports.test.ts
+++ b/tests/ts-imports.test.ts
@@ -1,4 +1,13 @@
-import { program, Command, Option, CommanderError, InvalidArgumentError, InvalidOptionArgumentError, Help, createCommand } from '../';
+import {
+  program,
+  Command,
+  Option,
+  CommanderError,
+  InvalidArgumentError,
+  InvalidOptionArgumentError,
+  Help,
+  createCommand,
+} from '../';
 
 // Do some simple checks that expected imports are available at runtime.
 // Similar tests to esm-imports-test.js
@@ -35,7 +44,8 @@ test('InvalidArgumentError', () => {
   checkClass(new InvalidArgumentError('failed'), 'InvalidArgumentError');
 });
 
-test('InvalidOptionArgumentError', () => { // Deprecated
+test('InvalidOptionArgumentError', () => {
+  // Deprecated
   checkClass(new InvalidOptionArgumentError('failed'), 'InvalidArgumentError');
 });
 

--- a/tsconfig.js.json
+++ b/tsconfig.js.json
@@ -1,4 +1,5 @@
-{ /* 
+{
+  /* 
     Simple override including just JavaScript files.
     Used by npm run-script typecheck:js
   */
@@ -7,8 +8,8 @@
   "include": [
     /* All JavaScript targets from tsconfig.json include. */
     "*.js",
-    ".prettierrc.js", /* missed by above pattern */
+    ".prettierrc.js" /* missed by above pattern */,
     "*.mjs",
-    "lib/**/*.js"
+    "lib/**/*.js",
   ],
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,34 +16,29 @@
 
     "allowJs": true,
     "checkJs": true,
-    
+
     /* Strict by default, but dial it down to reduce churn in our JavaScript code. */
     "strict": true,
-    "noImplicitAny": false, 
+    "noImplicitAny": false,
     "strictNullChecks": false,
     "useUnknownInCatchVariables": false,
 
-    "types": [
-      "node",
-      "jest"
-    ],
-    "noEmit": true, /* just type checking and not emitting transpiled files */
-    "skipLibCheck": false, /* we want to check our hand crafted definitions */
+    "types": ["node", "jest"],
+    "noEmit": true /* just type checking and not emitting transpiled files */,
+    "skipLibCheck": false /* we want to check our hand crafted definitions */,
     "forceConsistentCasingInFileNames": true,
-    "esModuleInterop": true, /* common TypeScript config */
-    "resolveJsonModule": true, /* needed for globals in node_modules?! */
+    "esModuleInterop": true /* common TypeScript config */,
+    "resolveJsonModule": true /* needed for globals in node_modules?! */,
   },
   "include": [
     /* JavaScript. Should match includes in tsconfig.js.json. */
     "*.js",
-    ".prettierrc.js", /* missed by above pattern */
+    ".prettierrc.js" /* missed by above pattern */,
     "*.mjs",
     "lib/**/*.js",
     /* TypeScript. Should match includes in tsconfig.ts.json. */
     "**/*.ts",
-    "**/*.mts"
+    "**/*.mts",
   ],
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"],
 }

--- a/tsconfig.ts.json
+++ b/tsconfig.ts.json
@@ -1,4 +1,5 @@
-{ /* 
+{
+  /* 
     Override to include just TypeScript files and use stricter settings than we do with JavaScript.
     Used by:
     - npm run-script typecheck:ts
@@ -7,13 +8,13 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     /* Full strict is fine for the TypeScript files, so turn back on the checks we turned off for mixed-use. */
-    "noImplicitAny": true, 
+    "noImplicitAny": true,
     "strictNullChecks": true,
     "useUnknownInCatchVariables": true,
   },
   "include": [
     /* All TypeScript targets from tsconfig.json include. */
     "**/*.ts",
-    "**/*.mts"
+    "**/*.mts",
   ],
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -11,7 +11,9 @@
 // - https://github.com/microsoft/TypeScript/issues/29729
 // - https://github.com/sindresorhus/type-fest/blob/main/source/literal-union.d.ts
 // - https://github.com/sindresorhus/type-fest/blob/main/source/primitive.d.ts
-type LiteralUnion<LiteralType, BaseType extends string | number> = LiteralType | (BaseType & Record<never, never>);
+type LiteralUnion<LiteralType, BaseType extends string | number> =
+  | LiteralType
+  | (BaseType & Record<never, never>);
 
 export class CommanderError extends Error {
   code: string;
@@ -39,7 +41,8 @@ export class InvalidArgumentError extends CommanderError {
 }
 export { InvalidArgumentError as InvalidOptionArgumentError }; // deprecated old name
 
-export interface ErrorOptions { // optional parameter for error()
+export interface ErrorOptions {
+  // optional parameter for error()
   /** an id string representing the error */
   code?: string;
   /** suggested exit code which could be used with process.exit */
@@ -257,7 +260,12 @@ export class Help {
    * Wrap the given string to width characters per line, with lines after the first indented.
    * Do not wrap if insufficient room for wrapping (minColumnWidth), or string is manually formatted.
    */
-  wrap(str: string, width: number, indent: number, minColumnWidth?: number): string;
+  wrap(
+    str: string,
+    width: number,
+    indent: number,
+    minColumnWidth?: number,
+  ): string;
 
   /** Generate the built-in help text. */
   formatHelp(cmd: Command, helper: Help): string;
@@ -267,10 +275,12 @@ export type HelpConfiguration = Partial<Help>;
 export interface ParseOptions {
   from: 'node' | 'electron' | 'user';
 }
-export interface HelpContext { // optional parameter for .help() and .outputHelp()
+export interface HelpContext {
+  // optional parameter for .help() and .outputHelp()
   error: boolean;
 }
-export interface AddHelpTextContext { // passed to text function used with .addHelpText()
+export interface AddHelpTextContext {
+  // passed to text function used with .addHelpText()
   error: boolean;
   command: Command;
 }
@@ -280,13 +290,14 @@ export interface OutputConfiguration {
   getOutHelpWidth?(): number;
   getErrHelpWidth?(): number;
   outputError?(str: string, write: (str: string) => void): void;
-
 }
 
 export type AddHelpTextPosition = 'beforeAll' | 'before' | 'after' | 'afterAll';
 export type HookEvent = 'preSubcommand' | 'preAction' | 'postAction';
 // The source is a string so author can define their own too.
-export type OptionValueSource = LiteralUnion<'default' | 'config' | 'env' | 'cli' | 'implied', string> | undefined;
+export type OptionValueSource =
+  | LiteralUnion<'default' | 'config' | 'env' | 'cli' | 'implied', string>
+  | undefined;
 
 export type OptionValues = Record<string, any>;
 
@@ -334,7 +345,10 @@ export class Command {
    * @param opts - configuration options
    * @returns new command
    */
-  command(nameAndArgs: string, opts?: CommandOptions): ReturnType<this['createCommand']>;
+  command(
+    nameAndArgs: string,
+    opts?: CommandOptions,
+  ): ReturnType<this['createCommand']>;
   /**
    * Define a command, implemented in a separate executable file.
    *
@@ -353,7 +367,11 @@ export class Command {
    * @param opts - configuration options
    * @returns `this` command for chaining
    */
-  command(nameAndArgs: string, description: string, opts?: ExecutableCommandOptions): this;
+  command(
+    nameAndArgs: string,
+    description: string,
+    opts?: ExecutableCommandOptions,
+  ): this;
 
   /**
    * Factory routine to create a new unattached command.
@@ -394,7 +412,12 @@ export class Command {
    *
    * @returns `this` command for chaining
    */
-  argument<T>(flags: string, description: string, fn: (value: string, previous: T) => T, defaultValue?: T): this;
+  argument<T>(
+    flags: string,
+    description: string,
+    fn: (value: string, previous: T) => T,
+    defaultValue?: T,
+  ): this;
   argument(name: string, description?: string, defaultValue?: unknown): this;
 
   /**
@@ -444,7 +467,13 @@ export class Command {
   /**
    * Add hook for life cycle event.
    */
-  hook(event: HookEvent, listener: (thisCommand: Command, actionCommand: Command) => void | Promise<void>): this;
+  hook(
+    event: HookEvent,
+    listener: (
+      thisCommand: Command,
+      actionCommand: Command,
+    ) => void | Promise<void>,
+  ): this;
 
   /**
    * Register callback to use as replacement for calling process.exit.
@@ -544,10 +573,24 @@ export class Command {
    *
    * @returns `this` command for chaining
    */
-  option(flags: string, description?: string, defaultValue?: string | boolean | string[]): this;
-  option<T>(flags: string, description: string, parseArg: (value: string, previous: T) => T, defaultValue?: T): this;
+  option(
+    flags: string,
+    description?: string,
+    defaultValue?: string | boolean | string[],
+  ): this;
+  option<T>(
+    flags: string,
+    description: string,
+    parseArg: (value: string, previous: T) => T,
+    defaultValue?: T,
+  ): this;
   /** @deprecated since v7, instead use choices or a custom function */
-  option(flags: string, description: string, regexp: RegExp, defaultValue?: string | boolean | string[]): this;
+  option(
+    flags: string,
+    description: string,
+    regexp: RegExp,
+    defaultValue?: string | boolean | string[],
+  ): this;
 
   /**
    * Define a required option, which must have a value after parsing. This usually means
@@ -555,10 +598,24 @@ export class Command {
    *
    * The `flags` string contains the short and/or long flags, separated by comma, a pipe or space.
    */
-  requiredOption(flags: string, description?: string, defaultValue?: string | boolean | string[]): this;
-  requiredOption<T>(flags: string, description: string, parseArg: (value: string, previous: T) => T, defaultValue?: T): this;
+  requiredOption(
+    flags: string,
+    description?: string,
+    defaultValue?: string | boolean | string[],
+  ): this;
+  requiredOption<T>(
+    flags: string,
+    description: string,
+    parseArg: (value: string, previous: T) => T,
+    defaultValue?: T,
+  ): this;
   /** @deprecated since v7, instead use choices or a custom function */
-  requiredOption(flags: string, description: string, regexp: RegExp, defaultValue?: string | boolean | string[]): this;
+  requiredOption(
+    flags: string,
+    description: string,
+    regexp: RegExp,
+    defaultValue?: string | boolean | string[],
+  ): this;
 
   /**
    * Factory routine to create a new unattached option.
@@ -583,7 +640,9 @@ export class Command {
    * @returns `this` command for chaining
    */
   storeOptionsAsProperties<T extends OptionValues>(): this & T;
-  storeOptionsAsProperties<T extends OptionValues>(storeAsProperties: true): this & T;
+  storeOptionsAsProperties<T extends OptionValues>(
+    storeAsProperties: true,
+  ): this & T;
   storeOptionsAsProperties(storeAsProperties?: boolean): this;
 
   /**
@@ -599,7 +658,11 @@ export class Command {
   /**
    * Store option value and where the value came from.
    */
-  setOptionValueWithSource(key: string, value: unknown, source: OptionValueSource): this;
+  setOptionValueWithSource(
+    key: string,
+    value: unknown,
+    source: OptionValueSource,
+  ): this;
 
   /**
    * Get source of option value.
@@ -607,7 +670,7 @@ export class Command {
   getOptionValueSource(key: string): OptionValueSource | undefined;
 
   /**
-    * Get source of option value. See also .optsWithGlobals().
+   * Get source of option value. See also .optsWithGlobals().
    */
   getOptionValueSourceWithGlobals(key: string): OptionValueSource | undefined;
 
@@ -869,7 +932,10 @@ export class Command {
    * and 'beforeAll' or 'afterAll' to affect this command and all its subcommands.
    */
   addHelpText(position: AddHelpTextPosition, text: string): this;
-  addHelpText(position: AddHelpTextPosition, text: (context: AddHelpTextContext) => string): this;
+  addHelpText(
+    position: AddHelpTextPosition,
+    text: (context: AddHelpTextContext) => string,
+  ): this;
 
   /**
    * Add a listener (callback) for when events occur. (Implemented using EventEmitter.)

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -17,9 +17,15 @@ expectType<commander.Command>(commander.program);
 expectType<commander.Command>(new commander.Command());
 expectType<commander.Command>(new commander.Command('name'));
 expectType<commander.Option>(new commander.Option('-f'));
-expectType<commander.CommanderError>(new commander.CommanderError(1, 'code', 'message'));
-expectType<commander.InvalidArgumentError>(new commander.InvalidArgumentError('message'));
-expectType<commander.InvalidArgumentError>(new commander.InvalidOptionArgumentError('message'));
+expectType<commander.CommanderError>(
+  new commander.CommanderError(1, 'code', 'message'),
+);
+expectType<commander.InvalidArgumentError>(
+  new commander.InvalidArgumentError('message'),
+);
+expectType<commander.InvalidArgumentError>(
+  new commander.InvalidOptionArgumentError('message'),
+);
 expectType<commander.Command>(commander.createCommand());
 expectType<commander.Option>(commander.createOption('--demo'));
 expectType<commander.Argument>(commander.createArgument('<foo>'));
@@ -36,14 +42,25 @@ expectType<commander.Command | null>(program.parent);
 // version
 expectType<commander.Command>(program.version('1.2.3'));
 expectType<commander.Command>(program.version('1.2.3', '-r,--revision'));
-expectType<commander.Command>(program.version('1.2.3', '-r,--revision', 'show revision information'));
+expectType<commander.Command>(
+  program.version('1.2.3', '-r,--revision', 'show revision information'),
+);
 expectType<string | undefined>(program.version());
 
 // command (and CommandOptions)
 expectType<commander.Command>(program.command('action'));
-expectType<commander.Command>(program.command('action', { isDefault: true, hidden: true, noHelp: true }));
+expectType<commander.Command>(
+  program.command('action', { isDefault: true, hidden: true, noHelp: true }),
+);
 expectType<commander.Command>(program.command('exec', 'exec description'));
-expectType<commander.Command>(program.command('exec', 'exec description', { isDefault: true, hidden: true, noHelp: true, executableFile: 'foo' }));
+expectType<commander.Command>(
+  program.command('exec', 'exec description', {
+    isDefault: true,
+    hidden: true,
+    noHelp: true,
+    executableFile: 'foo',
+  }),
+);
 
 // addCommand
 expectType<commander.Command>(program.addCommand(new commander.Command('abc')));
@@ -51,40 +68,56 @@ expectType<commander.Command>(program.addCommand(new commander.Command('abc')));
 // argument
 expectType<commander.Command>(program.argument('<value>'));
 expectType<commander.Command>(program.argument('<value>', 'description'));
-expectType<commander.Command>(program.argument('[value]', 'description', 'default'));
-expectType<commander.Command>(program.argument('[value]', 'description', parseFloat));
-expectType<commander.Command>(program.argument('[value]', 'description', parseFloat, 1.23));
+expectType<commander.Command>(
+  program.argument('[value]', 'description', 'default'),
+);
+expectType<commander.Command>(
+  program.argument('[value]', 'description', parseFloat),
+);
+expectType<commander.Command>(
+  program.argument('[value]', 'description', parseFloat, 1.23),
+);
 
 // arguments
 expectType<commander.Command>(program.arguments('<cmd> [env]'));
 
 // addHelpCommand
-expectType<commander.Command>(program.addHelpCommand(new commander.Command('assist')));
+expectType<commander.Command>(
+  program.addHelpCommand(new commander.Command('assist')),
+);
 // Deprecated uses
 expectType<commander.Command>(program.addHelpCommand());
 expectType<commander.Command>(program.addHelpCommand(false));
 expectType<commander.Command>(program.addHelpCommand(true));
 expectType<commander.Command>(program.addHelpCommand('assist [cmd]'));
-expectType<commander.Command>(program.addHelpCommand('assist [file]', 'display help'));
+expectType<commander.Command>(
+  program.addHelpCommand('assist [file]', 'display help'),
+);
 
 // helpCommand
 expectType<commander.Command>(program.helpCommand(false));
 expectType<commander.Command>(program.helpCommand(true));
 expectType<commander.Command>(program.helpCommand('assist [cmd]'));
-expectType<commander.Command>(program.helpCommand('assist [file]', 'display help'));
+expectType<commander.Command>(
+  program.helpCommand('assist [file]', 'display help'),
+);
 
 // exitOverride
 expectType<commander.Command>(program.exitOverride());
-expectType<commander.Command>(program.exitOverride((err): never => {
-  return process.exit(err.exitCode);
-}));
-expectType<commander.Command>(program.exitOverride((err): void => {
-  if (err.code !== 'commander.executeSubCommandAsync') {
-    throw err;
-  } else {
-    // Async callback from spawn events, not useful to throw.
-  }
-}));
+expectType<commander.Command>(
+  program.exitOverride((err): never => {
+    return process.exit(err.exitCode);
+  }),
+);
+expectType<commander.Command>(
+  program.exitOverride((err): void => {
+    if (err.code !== 'commander.executeSubCommandAsync') {
+      throw err;
+    } else {
+      // Async callback from spawn events, not useful to throw.
+    }
+  }),
+);
 
 // error
 expectType<never>(program.error('Goodbye'));
@@ -95,29 +128,39 @@ expectType<never>(program.error('Goodbye', { code: 'my.error', exitCode: 2 }));
 // hook
 expectType<commander.Command>(program.hook('preAction', () => {}));
 expectType<commander.Command>(program.hook('postAction', () => {}));
-expectType<commander.Command>(program.hook('preAction', async() => {}));
-expectType<commander.Command>(program.hook('preAction', (thisCommand, actionCommand) => {
-  // implicit parameter types
-  expectType<commander.Command>(thisCommand);
-  expectType<commander.Command>(actionCommand);
-}));
+expectType<commander.Command>(program.hook('preAction', async () => {}));
+expectType<commander.Command>(
+  program.hook('preAction', (thisCommand, actionCommand) => {
+    // implicit parameter types
+    expectType<commander.Command>(thisCommand);
+    expectType<commander.Command>(actionCommand);
+  }),
+);
 expectType<commander.Command>(program.hook('preSubcommand', () => {}));
-expectType<commander.Command>(program.hook('preSubcommand', (thisCommand, subcommand) => {
-  // implicit parameter types
-  expectType<commander.Command>(thisCommand);
-  expectType<commander.Command>(subcommand);
-}));
+expectType<commander.Command>(
+  program.hook('preSubcommand', (thisCommand, subcommand) => {
+    // implicit parameter types
+    expectType<commander.Command>(thisCommand);
+    expectType<commander.Command>(subcommand);
+  }),
+);
 
 // action
 expectType<commander.Command>(program.action(() => {}));
-expectType<commander.Command>(program.action(async() => {}));
+expectType<commander.Command>(program.action(async () => {}));
 
 // option
 expectType<commander.Command>(program.option('-a,--alpha'));
 expectType<commander.Command>(program.option('-p, --peppers', 'Add peppers'));
-expectType<commander.Command>(program.option('-s, --string [value]', 'default string', 'value'));
-expectType<commander.Command>(program.option('-b, --boolean', 'default boolean', false));
-expectType<commander.Command>(program.option('--drink <size', 'drink size', /small|medium|large/)); // deprecated
+expectType<commander.Command>(
+  program.option('-s, --string [value]', 'default string', 'value'),
+);
+expectType<commander.Command>(
+  program.option('-b, --boolean', 'default boolean', false),
+);
+expectType<commander.Command>(
+  program.option('--drink <size', 'drink size', /small|medium|large/),
+); // deprecated
 
 // example coercion functions from README
 
@@ -137,39 +180,118 @@ function commaSeparatedList(value: string): string[] {
   return value.split(',');
 }
 
-expectType<commander.Command>(program.option('-f, --float <number>', 'float argument', parseFloat));
-expectType<commander.Command>(program.option('-f, --float <number>', 'float argument', parseFloat, 3.2));
-expectType<commander.Command>(program.option('-i, --integer <number>', 'integer argument', myParseInt));
-expectType<commander.Command>(program.option('-i, --integer <number>', 'integer argument', myParseInt, 5));
-expectType<commander.Command>(program.option('-v, --verbose', 'verbosity that can be increased', increaseVerbosity, 0));
-expectType<commander.Command>(program.option('-c, --collect <value>', 'repeatable value', collect, []));
-expectType<commander.Command>(program.option('-l, --list <items>', 'comma separated list', commaSeparatedList));
+expectType<commander.Command>(
+  program.option('-f, --float <number>', 'float argument', parseFloat),
+);
+expectType<commander.Command>(
+  program.option('-f, --float <number>', 'float argument', parseFloat, 3.2),
+);
+expectType<commander.Command>(
+  program.option('-i, --integer <number>', 'integer argument', myParseInt),
+);
+expectType<commander.Command>(
+  program.option('-i, --integer <number>', 'integer argument', myParseInt, 5),
+);
+expectType<commander.Command>(
+  program.option(
+    '-v, --verbose',
+    'verbosity that can be increased',
+    increaseVerbosity,
+    0,
+  ),
+);
+expectType<commander.Command>(
+  program.option('-c, --collect <value>', 'repeatable value', collect, []),
+);
+expectType<commander.Command>(
+  program.option(
+    '-l, --list <items>',
+    'comma separated list',
+    commaSeparatedList,
+  ),
+);
 
 // requiredOption, same tests as option
 expectType<commander.Command>(program.requiredOption('-a,--alpha'));
-expectType<commander.Command>(program.requiredOption('-p, --peppers', 'Add peppers'));
-expectType<commander.Command>(program.requiredOption('-s, --string [value]', 'default string', 'value'));
-expectType<commander.Command>(program.requiredOption('-b, --boolean', 'default boolean', false));
-expectType<commander.Command>(program.requiredOption('--drink <size', 'drink size', /small|medium|large/)); // deprecated
+expectType<commander.Command>(
+  program.requiredOption('-p, --peppers', 'Add peppers'),
+);
+expectType<commander.Command>(
+  program.requiredOption('-s, --string [value]', 'default string', 'value'),
+);
+expectType<commander.Command>(
+  program.requiredOption('-b, --boolean', 'default boolean', false),
+);
+expectType<commander.Command>(
+  program.requiredOption('--drink <size', 'drink size', /small|medium|large/),
+); // deprecated
 
-expectType<commander.Command>(program.requiredOption('-f, --float <number>', 'float argument', parseFloat));
-expectType<commander.Command>(program.requiredOption('-f, --float <number>', 'float argument', parseFloat, 3.2));
-expectType<commander.Command>(program.requiredOption('-i, --integer <number>', 'integer argument', myParseInt));
-expectType<commander.Command>(program.requiredOption('-i, --integer <number>', 'integer argument', myParseInt, 5));
-expectType<commander.Command>(program.requiredOption('-v, --verbose', 'verbosity that can be increased', increaseVerbosity, 0));
-expectType<commander.Command>(program.requiredOption('-c, --collect <value>', 'repeatable value', collect, []));
-expectType<commander.Command>(program.requiredOption('-l, --list <items>', 'comma separated list', commaSeparatedList));
+expectType<commander.Command>(
+  program.requiredOption('-f, --float <number>', 'float argument', parseFloat),
+);
+expectType<commander.Command>(
+  program.requiredOption(
+    '-f, --float <number>',
+    'float argument',
+    parseFloat,
+    3.2,
+  ),
+);
+expectType<commander.Command>(
+  program.requiredOption(
+    '-i, --integer <number>',
+    'integer argument',
+    myParseInt,
+  ),
+);
+expectType<commander.Command>(
+  program.requiredOption(
+    '-i, --integer <number>',
+    'integer argument',
+    myParseInt,
+    5,
+  ),
+);
+expectType<commander.Command>(
+  program.requiredOption(
+    '-v, --verbose',
+    'verbosity that can be increased',
+    increaseVerbosity,
+    0,
+  ),
+);
+expectType<commander.Command>(
+  program.requiredOption(
+    '-c, --collect <value>',
+    'repeatable value',
+    collect,
+    [],
+  ),
+);
+expectType<commander.Command>(
+  program.requiredOption(
+    '-l, --list <items>',
+    'comma separated list',
+    commaSeparatedList,
+  ),
+);
 
 // createOption
 expectType<commander.Option>(program.createOption('a, --alpha'));
 expectType<commander.Option>(program.createOption('a, --alpha', 'description'));
 
 // addOption
-expectType<commander.Command>(program.addOption(new commander.Option('-s,--simple')));
+expectType<commander.Command>(
+  program.addOption(new commander.Option('-s,--simple')),
+);
 
 // storeOptionsAsProperties
-expectType<commander.Command & commander.OptionValues>(program.storeOptionsAsProperties());
-expectType<commander.Command & commander.OptionValues>(program.storeOptionsAsProperties(true));
+expectType<commander.Command & commander.OptionValues>(
+  program.storeOptionsAsProperties(),
+);
+expectType<commander.Command & commander.OptionValues>(
+  program.storeOptionsAsProperties(true),
+);
 expectType<commander.Command>(program.storeOptionsAsProperties(false));
 
 // getOptionValue
@@ -180,13 +302,19 @@ expectType<commander.Command>(program.setOptionValue('example', 'value'));
 expectType<commander.Command>(program.setOptionValue('example', true));
 
 // setOptionValueWithSource
-expectType<commander.Command>(program.setOptionValueWithSource('example', [], 'cli'));
+expectType<commander.Command>(
+  program.setOptionValueWithSource('example', [], 'cli'),
+);
 
 // getOptionValueSource
-expectType<commander.OptionValueSource | undefined>(program.getOptionValueSource('example'));
+expectType<commander.OptionValueSource | undefined>(
+  program.getOptionValueSource('example'),
+);
 
 // getOptionValueSourceWithGlobals
-expectType<commander.OptionValueSource | undefined>(program.getOptionValueSourceWithGlobals('example'));
+expectType<commander.OptionValueSource | undefined>(
+  program.getOptionValueSourceWithGlobals('example'),
+);
 
 // combineFlagAndOptionalValue
 expectType<commander.Command>(program.combineFlagAndOptionalValue());
@@ -211,21 +339,35 @@ expectType<commander.Command>(program.passThroughOptions(false));
 // parse
 expectType<commander.Command>(program.parse());
 expectType<commander.Command>(program.parse(process.argv));
-expectType<commander.Command>(program.parse(['node', 'script.js'], { from: 'node' }));
-expectType<commander.Command>(program.parse(['node', 'script.js'], { from: 'electron' }));
+expectType<commander.Command>(
+  program.parse(['node', 'script.js'], { from: 'node' }),
+);
+expectType<commander.Command>(
+  program.parse(['node', 'script.js'], { from: 'electron' }),
+);
 expectType<commander.Command>(program.parse(['--option'], { from: 'user' }));
 expectType<commander.Command>(program.parse(['node', 'script.js'] as const));
 
 // parseAsync, same tests as parse
 expectType<Promise<commander.Command>>(program.parseAsync());
 expectType<Promise<commander.Command>>(program.parseAsync(process.argv));
-expectType<Promise<commander.Command>>(program.parseAsync(['node', 'script.js'], { from: 'node' }));
-expectType<Promise<commander.Command>>(program.parseAsync(['node', 'script.js'], { from: 'electron' }));
-expectType<Promise<commander.Command>>(program.parseAsync(['--option'], { from: 'user' }));
-expectType<Promise<commander.Command>>(program.parseAsync(['node', 'script.js'] as const));
+expectType<Promise<commander.Command>>(
+  program.parseAsync(['node', 'script.js'], { from: 'node' }),
+);
+expectType<Promise<commander.Command>>(
+  program.parseAsync(['node', 'script.js'], { from: 'electron' }),
+);
+expectType<Promise<commander.Command>>(
+  program.parseAsync(['--option'], { from: 'user' }),
+);
+expectType<Promise<commander.Command>>(
+  program.parseAsync(['node', 'script.js'] as const),
+);
 
 // parseOptions (and ParseOptionsResult)
-expectType<{ operands: string[]; unknown: string[] }>(program.parseOptions(['node', 'script.js', 'hello']));
+expectType<{ operands: string[]; unknown: string[] }>(
+  program.parseOptions(['node', 'script.js', 'hello']),
+);
 
 // opts
 const opts = program.opts();
@@ -257,7 +399,11 @@ expectType(myCheeseOptionWithGlobals.foo);
 // description
 expectType<commander.Command>(program.description('my description'));
 expectType<string>(program.description());
-expectType<commander.Command>(program.description('my description of command with arg foo', { foo: 'foo description' })); // deprecated
+expectType<commander.Command>(
+  program.description('my description of command with arg foo', {
+    foo: 'foo description',
+  }),
+); // deprecated
 
 // summary
 expectType<commander.Command>(program.summary('my summary'));
@@ -269,7 +415,9 @@ expectType<string>(program.alias());
 
 // aliases
 expectType<commander.Command>(program.aliases(['first-alias', 'second-alias']));
-expectType<commander.Command>(program.aliases(['first-alias', 'second-alias'] as const));
+expectType<commander.Command>(
+  program.aliases(['first-alias', 'second-alias'] as const),
+);
 expectType<string[]>(program.aliases());
 
 // usage
@@ -291,13 +439,21 @@ expectType<string | null>(program.executableDir());
 // eslint-disable-next-line @typescript-eslint/no-invalid-void-type, @typescript-eslint/no-confusing-void-expression
 expectType<void>(program.outputHelp());
 // eslint-disable-next-line @typescript-eslint/no-invalid-void-type, @typescript-eslint/no-confusing-void-expression
-expectType<void>(program.outputHelp((str: string) => { return str; }));
+expectType<void>(
+  program.outputHelp((str: string) => {
+    return str;
+  }),
+);
 // eslint-disable-next-line @typescript-eslint/no-invalid-void-type, @typescript-eslint/no-confusing-void-expression
 expectType<void>(program.outputHelp({ error: true }));
 
 // help
 expectType<never>(program.help());
-expectType<never>(program.help((str: string) => { return str; }));
+expectType<never>(
+  program.help((str: string) => {
+    return str;
+  }),
+);
 expectType<never>(program.help({ error: true }));
 
 // helpInformation
@@ -306,22 +462,30 @@ expectType<string>(program.helpInformation({ error: true }));
 
 // helpOption
 expectType<commander.Command>(program.helpOption('-h,--help'));
-expectType<commander.Command>(program.helpOption('-h,--help', 'custom description'));
-expectType<commander.Command>(program.helpOption(undefined, 'custom description'));
+expectType<commander.Command>(
+  program.helpOption('-h,--help', 'custom description'),
+);
+expectType<commander.Command>(
+  program.helpOption(undefined, 'custom description'),
+);
 expectType<commander.Command>(program.helpOption(false));
 
 // addHelpOption
-expectType<commander.Command>(program.addHelpOption(new commander.Option('-h,--help')));
+expectType<commander.Command>(
+  program.addHelpOption(new commander.Option('-h,--help')),
+);
 
 // addHelpText
 expectType<commander.Command>(program.addHelpText('after', 'text'));
 expectType<commander.Command>(program.addHelpText('afterAll', 'text'));
 expectType<commander.Command>(program.addHelpText('before', () => 'before'));
-expectType<commander.Command>(program.addHelpText('beforeAll', (context) => {
-  expectType<boolean>(context.error);
-  expectType<commander.Command>(context.command);
-  return '';
-}));
+expectType<commander.Command>(
+  program.addHelpText('beforeAll', (context) => {
+    expectType<boolean>(context.error);
+    expectType<commander.Command>(context.command);
+    return '';
+  }),
+);
 
 // on
 expectType<commander.Command>(program.on('command:foo', () => {}));
@@ -344,14 +508,18 @@ expectType<MyCommand>(myProgram.command('sub'));
 
 // configureHelp
 expectType<commander.Help>(program.createHelp());
-expectType<commander.Command>(program.configureHelp({
-  sortSubcommands: true, // override property
-  visibleCommands: () => [] // override method
-}));
+expectType<commander.Command>(
+  program.configureHelp({
+    sortSubcommands: true, // override property
+    visibleCommands: () => [], // override method
+  }),
+);
 expectType<commander.HelpConfiguration>(program.configureHelp());
 
 // copyInheritedSettings
-expectType<commander.Command>(program.copyInheritedSettings(new commander.Command()));
+expectType<commander.Command>(
+  program.copyInheritedSettings(new commander.Command()),
+);
 
 // showHelpAfterError
 expectType<commander.Command>(program.showHelpAfterError());
@@ -363,16 +531,24 @@ expectType<commander.Command>(program.showSuggestionAfterError());
 expectType<commander.Command>(program.showSuggestionAfterError(false));
 
 // configureOutput
-expectType<commander.Command>(program.configureOutput({ }));
+expectType<commander.Command>(program.configureOutput({}));
 expectType<commander.OutputConfiguration>(program.configureOutput());
 
-expectType<commander.Command>(program.configureOutput({
-  writeOut: (str: string) => { console.log(str); },
-  writeErr: (str: string) => { console.error(str); },
-  getOutHelpWidth: () => 80,
-  getErrHelpWidth: () => 80,
-  outputError: (str: string, write: (str: string) => void) => { write(str); }
-}));
+expectType<commander.Command>(
+  program.configureOutput({
+    writeOut: (str: string) => {
+      console.log(str);
+    },
+    writeErr: (str: string) => {
+      console.error(str);
+    },
+    getOutHelpWidth: () => 80,
+    getErrHelpWidth: () => 80,
+    outputError: (str: string, write: (str: string) => void) => {
+      write(str);
+    },
+  }),
+);
 
 // Help
 const helper = new commander.Help();
@@ -445,8 +621,14 @@ expectType<commander.Option>(baseOption.env('PORT'));
 expectType<string>(baseOption.fullDescription());
 
 // argParser
-expectType<commander.Option>(baseOption.argParser((value: string) => parseInt(value)));
-expectType<commander.Option>(baseOption.argParser((value: string, previous: string[]) => { return previous.concat(value); }));
+expectType<commander.Option>(
+  baseOption.argParser((value: string) => parseInt(value)),
+);
+expectType<commander.Option>(
+  baseOption.argParser((value: string, previous: string[]) => {
+    return previous.concat(value);
+  }),
+);
 
 // makeOptionMandatory
 expectType<commander.Option>(baseOption.makeOptionMandatory());
@@ -466,7 +648,9 @@ expectType<commander.Option>(baseOption.conflicts('a'));
 expectType<commander.Option>(baseOption.conflicts(['a', 'b']));
 
 // implies
-expectType<commander.Option>(baseOption.implies({ option: 'VALUE', colour: false }));
+expectType<commander.Option>(
+  baseOption.implies({ option: 'VALUE', colour: false }),
+);
 
 // name
 expectType<string>(baseOption.name());
@@ -497,8 +681,14 @@ expectType<commander.Argument>(baseArgument.default(3));
 expectType<commander.Argument>(baseArgument.default(60, 'one minute'));
 
 // argParser
-expectType<commander.Argument>(baseArgument.argParser((value: string) => parseInt(value)));
-expectType<commander.Argument>(baseArgument.argParser((value: string, previous: string[]) => { return previous.concat(value); }));
+expectType<commander.Argument>(
+  baseArgument.argParser((value: string) => parseInt(value)),
+);
+expectType<commander.Argument>(
+  baseArgument.argParser((value: string, previous: string[]) => {
+    return previous.concat(value);
+  }),
+);
 
 // choices
 expectType<commander.Argument>(baseArgument.choices(['a', 'b']));


### PR DESCRIPTION
Use Prettier to format source files using `npm run fix:format`.

(No other changes.)

See: #2104

## ChangeLog

- Changed: format source files with Prettier