### PR TITLE
Show `defaultValueDescription` even if `defaultValue` is not set

### DIFF
--- a/lib/help.js
+++ b/lib/help.js
@@ -302,7 +302,10 @@ class Help {
         `choices: ${option.argChoices.map((choice) => JSON.stringify(choice)).join(', ')}`,
       );
     }
-    if (option.defaultValue !== undefined) {
+    if (
+      option.defaultValue !== undefined ||
+      option.defaultValueDescription !== undefined
+    ) {
       // default for boolean and negated more for programmer than end user,
       // but show true/false for boolean option as may be for hand-rolled env or config processing.
       const showDefault =
@@ -344,7 +347,10 @@ class Help {
         `choices: ${argument.argChoices.map((choice) => JSON.stringify(choice)).join(', ')}`,
       );
     }
-    if (argument.defaultValue !== undefined) {
+    if (
+      argument.defaultValue !== undefined ||
+      argument.defaultValueDescription !== undefined
+    ) {
       extraInfo.push(
         `default: ${argument.defaultValueDescription || JSON.stringify(argument.defaultValue)}`,
       );

--- a/tests/help.optionDescription.test.js
+++ b/tests/help.optionDescription.test.js
@@ -70,6 +70,19 @@ describe('optionDescription', () => {
     );
   });
 
+  test('when option has default value description without default value then return description and custom default description', () => {
+    const description = 'description';
+    const defaultValueDescription = 'custom';
+    const option = new commander.Option('-a <value>', description).default(
+      undefined,
+      defaultValueDescription,
+    );
+    const helper = new commander.Help();
+    expect(helper.optionDescription(option)).toEqual(
+      `description (default: ${defaultValueDescription})`,
+    );
+  });
+
   test('when option has choices then return description and choices', () => {
     const description = 'description';
     const choices = ['one', 'two'];


### PR DESCRIPTION
# Pull Request

## Problem

I have an option that gets passed to the underlying library. I want to describe its default behaviour, but I can't pass any default value there except `undefined`. In case `undefined` the default value description is not printed in help.

```js
const { program, Option } = require('commander');

const ttl = new Option('--ttl [ttl]', 'Transaction can be mined before provided height')
  .default(undefined, 'current height increased by 3');

program.addOption(ttl);
program.parse(process.argv);
```

Output:
```
$ node ./test.js --help
Usage: test [options]

Options:
  --ttl [ttl]  Transaction can be mined before provided height
  -h, --help   display help for command
```

## Solution

I'm proposing to print `defaultValueDescription` even if it is provided without `defaultValue`. Though I'm not sure that it is not a misuse of "default value" concept.

Expected output:
```
$ ./test.js --help
Usage: test [options]

Options:
  --ttl [ttl]  Transaction can be mined before provided height (default: current height increased by 3)
  -h, --help   display help for command
```

## ChangeLog

Added: show `defaultValueDescription` even if `defaultValue` is not set

This PR is supported by the Æternity Foundation