### PR TITLE
Remove unimplemented fullDescription from TypeScript

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -164,11 +164,6 @@ export class Option {
   env(name: string): this;
 
   /**
-   * Calculate the full description, including defaultValue etc.
-   */
-  fullDescription(): string;
-
-  /**
    * Set the custom handler for processing CLI option arguments into option values.
    */
   argParser<T>(fn: (value: string, previous: T) => T): this;

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -617,9 +617,6 @@ expectType<commander.Option>(baseOption.preset('abc'));
 // env
 expectType<commander.Option>(baseOption.env('PORT'));
 
-// fullDescription
-expectType<string>(baseOption.fullDescription());
-
 // argParser
 expectType<commander.Option>(
   baseOption.argParser((value: string) => parseInt(value)),


### PR DESCRIPTION
# Pull Request

## Problem

`fullDescription` appears in the TypeScript definition for `Option`, but is no longer present in the source.

See #2190

## Solution

Delete it!

## ChangeLog

- Deleted: remove unimplemented `Option.fullDescription` from TypeScript definition