### PR TITLE
Add sections to allow some customisation of help layout

### DIFF
--- a/lib/help.js
+++ b/lib/help.js
@@ -360,6 +360,21 @@ class Help {
   }
 
   /**
+   * visibleSections
+   *
+   * @typedef {object} Section
+   * @property {string} name
+   * @property {string} title - may be empty
+   * @property {string} body
+   *
+   * @param {Section[]} sections
+   * @returns
+   */
+  visibleSections(sections) {
+    return sections.filter((section) => !!section.body);
+  }
+
+  /**
    * Generate the built-in help text.
    *
    * @param {Command} cmd
@@ -384,20 +399,27 @@ class Help {
       return term;
     }
     function formatList(textArray) {
+      if (textArray.length === 0) return '';
       return textArray.join('\n').replace(/^/gm, ' '.repeat(itemIndentWidth));
     }
 
+    // @type {Section[]}
+    const sections = [];
+
     // Usage
-    let output = [`Usage: ${helper.commandUsage(cmd)}`, ''];
+    sections.push({
+      name: 'usage',
+      title: '',
+      body: `Usage: ${helper.commandUsage(cmd)}`,
+    });
 
     // Description
     const commandDescription = helper.commandDescription(cmd);
-    if (commandDescription.length > 0) {
-      output = output.concat([
-        helper.wrap(commandDescription, helpWidth, 0),
-        '',
-      ]);
-    }
+    sections.push({
+      name: 'description',
+      title: '',
+      body: helper.wrap(commandDescription, helpWidth, 0),
+    });
 
     // Arguments
     const argumentList = helper.visibleArguments(cmd).map((argument) => {
@@ -406,9 +428,11 @@ class Help {
         helper.argumentDescription(argument),
       );
     });
-    if (argumentList.length > 0) {
-      output = output.concat(['Arguments:', formatList(argumentList), '']);
-    }
+    sections.push({
+      name: 'arguments',
+      title: 'Arguments:',
+      body: formatList(argumentList),
+    });
 
     // Options
     const optionList = helper.visibleOptions(cmd).map((option) => {
@@ -417,9 +441,11 @@ class Help {
         helper.optionDescription(option),
       );
     });
-    if (optionList.length > 0) {
-      output = output.concat(['Options:', formatList(optionList), '']);
-    }
+    sections.push({
+      name: 'options',
+      title: 'Options:',
+      body: formatList(optionList),
+    });
 
     if (this.showGlobalOptions) {
       const globalOptionList = helper
@@ -430,13 +456,11 @@ class Help {
             helper.optionDescription(option),
           );
         });
-      if (globalOptionList.length > 0) {
-        output = output.concat([
-          'Global Options:',
-          formatList(globalOptionList),
-          '',
-        ]);
-      }
+      sections.push({
+        name: 'globalOptions',
+        title: 'Global Options:',
+        body: formatList(globalOptionList),
+      });
     }
 
     // Commands
@@ -447,10 +471,20 @@ class Help {
       );
     });
     if (commandList.length > 0) {
-      output = output.concat(['Commands:', formatList(commandList), '']);
+      sections.push({
+        name: 'commands',
+        title: 'Commands:',
+        body: formatList(commandList),
+      });
     }
 
-    return output.join('\n');
+    const visibleSections = this.visibleSections(sections);
+
+    const chunks = visibleSections.reduce((chunks, section) => {
+      if (section.title) return chunks.concat(section.title, section.body, '');
+      return chunks.concat(section.body, '');
+    }, []);
+    return chunks.join('\n');
   }
 
   /**


### PR DESCRIPTION
# Pull Request

I wanted to give this a try, but not sure it adds enough value or is easy enough to use. Opening a draft with proof of concept.

## Problem

It isn't convenient to customise the order of sections in the Help.

See #1870

## Solution

Create "sections" in `formatHelp` and call `visibleSections` which can be overridden to customise the list. Some possible use cases:

- reorder sections
- hide sections
- alter section titles, like make bold or all capitals
- add own (pre-formatted) sections, like "Environment Variables" or "Examples"
- (maybe) replace single-line Usage with multi-line usages

Example client code to put options after commands:

```js
program.configureHelp({
  visibleSections: (sections) => {
    // Hide empty sections.
    const visible = sections.filter((section) => !!section.body);
    // Reorder sections.
    const order = ['usage', 'description', 'arguments', 'commands', 'options', 'globalOptions'];
    return visible.sort((a, b) => {
      return order.indexOf(a.name) - order.indexOf(b.name);
    });
  }
});
```

## ChangeLog

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->
