### PR TITLE
Coerce process.exitCode to number to match local usage

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -2392,7 +2392,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
   help(contextOptions) {
     this.outputHelp(contextOptions);
-    let exitCode = process.exitCode || 0;
+    let exitCode = Number(process.exitCode ?? 0); // process.exitCode does allow a string of an integer, but we prefer just a number
     if (
       exitCode === 0 &&
       contextOptions &&


### PR DESCRIPTION
# Pull Request

## Problem

An update to `@types/node` showed up a subtle issue. `process.exitCode` allows a string representation of an integer. The Commander typings for the exit code are for a number, and the code assumes a number. So as well as the type not matching, there would actually be the wrong behaviour in the following line if the `exitCode` was `"0"`!

```
% npm run check:type:js

> commander@12.1.0 check:type:js
> tsc -p tsconfig.js.json

lib/command.js:2405:16 - error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
  Type 'string' is not assignable to type 'number'.

2405     this._exit(exitCode, 'commander.help', '(outputHelp)');
                    ~~~~~~~~


Found 1 error in lib/command.js:2405
```

## Solution

Convert `process.exitCode to a number to keep things simple.

(So unlikely that this makes a difference to a real program that not including a changelog entry.)