### PR TITLE
Feature/run all checks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# disable line-ending changes (otherwise Windows developers with default settings from git install see Prettier wanting to fix every file)
+* -text

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,5 @@ jobs:
       run: npm ci
     - name: npm test
       run: npm test
-    - name: npm run check:lint
-      # switch to full check when have run prettier on all files
-      run: npm run check:lint
+    - name: npm run check
+      run: npm run check

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -148,10 +148,9 @@ expectType<commander.Command>(
 // action
 expectType<commander.Command>(program.action(() => {}));
 expectType<commander.Command>(program.action(async () => {}));
-program
-  .action(function () {
-    expectType<typeof program>(this)
-  })
+program.action(function () {
+  expectType<typeof program>(this);
+});
 
 // option
 expectType<commander.Command>(program.option('-a,--alpha'));


### PR DESCRIPTION
# Pull Request

## Problem

Was not running all tests after finishing the eslint and Prettier work.

## Solution

Update GitHub action to run all `npm run check`.

This picks up a file in a recent PR which did not get Prettier applied.

NB: tests will currently fail due to issue fixed in #2209