### PR TITLE
Variadic arguments: fix "--" processing

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -55,6 +55,8 @@ class Command extends EventEmitter {
     /** @type {(boolean | string)} */
     this._showHelpAfterError = false;
     this._showSuggestionAfterError = true;
+    /** @type {(undefined | number)} */
+    this.lastArgIndex = undefined
 
     // see .configureOutput() for docs
     this._outputConfiguration = {
@@ -1347,7 +1349,12 @@ Expecting one of '${allowedValues.join("', '")}'`);
       if (declaredArg.variadic) {
         // Collect together remaining arguments for passing together as an array.
         if (index < this.args.length) {
-          value = this.args.slice(index);
+          if(this.lastArgIndex === undefined){
+            value = this.args.slice(index);
+          }else{
+            value = this.args.slice(index, this.lastArgIndex);
+          }
+
           if (declaredArg.parseArg) {
             value = value.reduce((processed, v) => {
               return myParseArg(declaredArg, v, processed);
@@ -1452,6 +1459,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     operands = operands.concat(parsed.operands);
     unknown = parsed.unknown;
     this.args = operands.concat(unknown);
+    this.lastArgIndex = parsed.lastArgIndex
 
     if (operands && this._findCommand(operands[0])) {
       return this._dispatchSubcommand(operands[0], operands.slice(1), unknown);
@@ -1638,13 +1646,14 @@ Expecting one of '${allowedValues.join("', '")}'`);
    *     sub -- --unknown uuu op => [sub --unknown uuu op], []
    *
    * @param {string[]} argv
-   * @return {{operands: string[], unknown: string[]}}
+   * @return {{operands: string[], unknown: string[],lastArgIndex:undefined | number}}
    */
 
   parseOptions(argv) {
     const operands = []; // operands, not options or values
     const unknown = []; // first unknown option and remaining unknown args
     let dest = operands;
+    let lastArgIndex = undefined;
     const args = argv.slice();
 
     function maybeOption(arg) {
@@ -1659,6 +1668,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
       // literal
       if (arg === '--') {
         if (dest === unknown) dest.push(arg);
+        lastArgIndex = dest.length;
         dest.push(...args);
         break;
       }
@@ -1764,8 +1774,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
       // add arg
       dest.push(arg);
     }
-
-    return { operands, unknown };
+    return { operands, unknown, lastArgIndex };
   }
 
   /**

--- a/tests/argument.variadic.test.js
+++ b/tests/argument.variadic.test.js
@@ -32,6 +32,27 @@ describe('variadic argument', () => {
     );
   });
 
+  test('when arguments includes -- then stop processing variadic arguments', () => {
+    const actionMock = jest.fn();
+    const program = new commander.Command();
+    program.argument('[variadicArg...]').action(actionMock);
+    const extraArguments = ['a', 'b', 'c'];
+
+    program.parse([
+      'node',
+      'test',
+      ...extraArguments,
+      '--',
+      'NOT AN ARGUMENT',
+    ]);
+
+    expect(actionMock).toHaveBeenCalledWith(
+      extraArguments,
+      program.opts(),
+      program,
+    );
+  });
+
   test('when no extra arguments specified for command then variadic arg is empty array', () => {
     const actionMock = jest.fn();
     const program = new commander.Command();

--- a/tests/argument.variadic.test.js
+++ b/tests/argument.variadic.test.js
@@ -38,15 +38,35 @@ describe('variadic argument', () => {
     program.argument('[variadicArg...]').action(actionMock);
     const extraArguments = ['a', 'b', 'c'];
 
+    program.parse(['node', 'test', ...extraArguments, '--', 'NOT AN ARGUMENT']);
+
+    expect(actionMock).toHaveBeenCalledWith(
+      extraArguments,
+      program.opts(),
+      program,
+    );
+  });
+
+  test('when arguments includes -- then stop processing variadic arguments, should also work with multiple arguments', () => {
+    const actionMock = jest.fn();
+    const program = new commander.Command();
+    program
+      .addArgument(new commander.Argument('<id>'))
+      .argument('[variadicArg...]')
+      .action(actionMock);
+    const extraArguments = ['a', 'b', 'c'];
+
     program.parse([
       'node',
       'test',
+      'id',
       ...extraArguments,
       '--',
       'NOT AN ARGUMENT',
     ]);
 
     expect(actionMock).toHaveBeenCalledWith(
+      'id',
       extraArguments,
       program.opts(),
       program,

--- a/tests/command.parseOptions.test.js
+++ b/tests/command.parseOptions.test.js
@@ -147,13 +147,21 @@ describe('parseOptions', () => {
   test('when program has literal before known flag then option returned as operand', () => {
     const program = createProgram();
     const result = program.parseOptions('-- --global-flag'.split(' '));
-    expect(result).toEqual({ operands: ['--global-flag'], unknown: [] });
+    expect(result).toEqual({
+      operands: ['--global-flag'],
+      unknown: [],
+      lastArgIndex: 0,
+    });
   });
 
   test('when program has literal before unknown option then option returned as operand', () => {
     const program = createProgram();
     const result = program.parseOptions('-- --unknown uuu'.split(' '));
-    expect(result).toEqual({ operands: ['--unknown', 'uuu'], unknown: [] });
+    expect(result).toEqual({
+      operands: ['--unknown', 'uuu'],
+      unknown: [],
+      lastArgIndex: 0,
+    });
   });
 
   test('when program has literal after unknown option then literal preserved too', () => {
@@ -162,6 +170,7 @@ describe('parseOptions', () => {
     expect(result).toEqual({
       operands: [],
       unknown: ['--unknown1', '--', '--unknown2'],
+      lastArgIndex: 2,
     });
   });
 });


### PR DESCRIPTION
# Pull Request

This PR fixes the behavior of variadic arguments in the context of the usage of "--"

## Problem

When passing arguments `["a","b","c","--","ERROR"]` to a variadic argument, it should only include `["a","b","c"]` and not the string `"ERROR"` at the end.

## Solution

Since this package is really complex, I just added a property to the `Command` class.
```js
   /** @type {(undefined | number)} */
    this.lastArgIndex = undefined

```
This keeps track of the "--" location, aka. the length of valid arguments. I adjusted the JSDoc types everywhere and also wrote two tests, that failed before this fix, expecting the correct behavior. They pass after this fix. 

I adjusted 3 tests, that tested the raw parser, where `lastArgIndex` was a number, so that it matches the current behavior.

The way I solved this, seems the easiest, and correctest way of doing this IMO. It also assures, that `parsed.processedArgs` and `parsed.args` is correct in all cases


## ChangeLog

Variadic Argument: don't add arguments after "--" to the list of `processedArgs`