### PR TITLE
Remove unneeded header from Pull Request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,3 @@
-# Pull Request
-
 <!--
 The text in these markdown comments is instructions that will not appear in the displayed pull request,
 and can be deleted.
@@ -10,7 +8,7 @@ Follow the existing code style. Check the tests succeed, including format and li
   npm run test
   npm run check
 
-Don't update the CHANGELOG or command version number. That gets done by maintainers when preparing the release.
+Don't update the CHANGELOG or package version number. That gets done by maintainers when preparing the release.
 
 Commander currently has zero production dependencies. That isn't a hard requirement, but is a simple story. Requests which 
 add a dependency are much less likely to be accepted, and we are likely to ask if there alternative approaches to avoid the dependency.


### PR DESCRIPTION
# ~~Pull Request~~

## Problem

The top level heading of `Pull Request` does not add any value.

I somewhat liked having no missing heading levels and some text before the first comment for editing, but really it is just taking up space in the displayed description.

## Solution

Remove the level 1 `Pull Request` header. 