### PR TITLE
fix: update types for defaultValue

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -411,7 +411,7 @@ export class Command {
     fn: (value: string, previous: T) => T,
     defaultValue?: T,
   ): this;
-  argument(name: string, description?: string, defaultValue?: unknown): this;
+  argument(name: string, description?: string, defaultValue?: any): this;
 
   /**
    * Define argument syntax for command, adding a prepared argument.
@@ -569,7 +569,7 @@ export class Command {
   option(
     flags: string,
     description?: string,
-    defaultValue?: string | boolean | string[],
+    defaultValue?: any,
   ): this;
   option<T>(
     flags: string,
@@ -582,7 +582,7 @@ export class Command {
     flags: string,
     description: string,
     regexp: RegExp,
-    defaultValue?: string | boolean | string[],
+    defaultValue?: any,
   ): this;
 
   /**
@@ -594,7 +594,7 @@ export class Command {
   requiredOption(
     flags: string,
     description?: string,
-    defaultValue?: string | boolean | string[],
+    defaultValue?: any,
   ): this;
   requiredOption<T>(
     flags: string,
@@ -607,7 +607,7 @@ export class Command {
     flags: string,
     description: string,
     regexp: RegExp,
-    defaultValue?: string | boolean | string[],
+    defaultValue?: any,
   ): this;
 
   /**


### PR DESCRIPTION
## Problem

Wrong typings for `defaultValue`
ref: https://github.com/tj/commander.js/issues/2236

## Solution

Force `defaultValue` to `any` type. 
Commander actually don't check types at code (except `undefined`) when use value.

We see that the tests pass successfully with types other then defined now.
https://github.com/tj/commander.js/blob/4e87829ba3d41dcb6109dea9899bf9a7e8f44cda/tests/argument.custom-processing.test.js#L52-L62