### PR TITLE
Allow bypassing negation

### DIFF
--- a/lib/option.js
+++ b/lib/option.js
@@ -213,7 +213,10 @@ class Option {
    */
 
   attributeName() {
-    return camelcase(this.name().replace(/^no-/, ''));
+    if (this.negate) {
+      return camelcase(this.name().replace(/^no-/, ''));
+    }
+    return camelcase(this.name());
   }
 
   /**

--- a/tests/options.bool.test.js
+++ b/tests/options.bool.test.js
@@ -32,13 +32,11 @@ describe('boolean flag on program', () => {
     expect(program.opts().cheese).toBe(false);
   });
 
-  test('when bypassing negatable then value is true', () => {
+  test('when negatable boolean flag specified then negative value is undefined', () => {
     const program = new commander.Command();
-    var option = program.createOption('--no-cheese', 'remove cheese');
-    option.negate = false;
-    program.addOption(option);
+    program.option('--no-cheese', 'remove cheese');
     program.parse(['node', 'test', '--no-cheese']);
-    expect(program.opts().noCheese).toBe(true);
+    expect(program.opts().noCheese).toBeUndefined();
   });
 });
 
@@ -94,6 +92,26 @@ describe('boolean flag on command', () => {
       });
     program.parse(['node', 'test', 'sub', '--no-cheese']);
     expect(subCommandOptions.cheese).toBe(false);
+  });
+});
+
+describe('overridden negatable boolean flag', () => {
+  test('when negatable boolean flag is specified and negatable is overridden then negative value is true', () => {
+    const program = new commander.Command();
+    var option = program.createOption('--no-cheese', 'remove cheese');
+    option.negate = false;
+    program.addOption(option);
+    program.parse(['node', 'test', '--no-cheese']);
+    expect(program.opts().noCheese).toBe(true);
+  });
+
+  test('when negatable boolean flag is specified and negatable is overridden then positive value is undefined', () => {
+    const program = new commander.Command();
+    var option = program.createOption('--no-cheese', 'remove cheese');
+    option.negate = false;
+    program.addOption(option);
+    program.parse(['node', 'test', '--no-cheese']);
+    expect(program.opts().cheese).toBeUndefined();
   });
 });
 

--- a/tests/options.bool.test.js
+++ b/tests/options.bool.test.js
@@ -18,6 +18,13 @@ describe('boolean flag on program', () => {
     expect(program.opts().pepper).toBe(true);
   });
 
+  test('when boolean flag specified then option should be camelcase', () => {
+    const program = new commander.Command();
+    program.option('--pepper-and-salt', 'add pepper and salt');
+    program.parse(['node', 'test', '--pepper-and-salt']);
+    expect(program.opts().pepperAndSalt).toBe(true);
+  });
+
   test('when negatable boolean flag not specified then value is true', () => {
     const program = new commander.Command();
     program.option('--no-cheese', 'remove cheese');
@@ -37,6 +44,13 @@ describe('boolean flag on program', () => {
     program.option('--no-cheese', 'remove cheese');
     program.parse(['node', 'test', '--no-cheese']);
     expect(program.opts().noCheese).toBeUndefined();
+  });
+
+  test('when negatable boolean flag specified then positive option is camelcase', () => {
+    const program = new commander.Command();
+    program.option('--no-cheese-or-wine', 'remove cheese or wine');
+    program.parse(['node', 'test']);
+    expect(program.opts().cheeseOrWine).toBe(true);
   });
 });
 
@@ -96,7 +110,7 @@ describe('boolean flag on command', () => {
 });
 
 describe('overridden negatable boolean flag', () => {
-  test('when negatable boolean flag is specified and negatable is overridden then negative value is true', () => {
+  test('when negatable boolean flag is specified and negate is overridden then negative value is true', () => {
     const program = new commander.Command();
     var option = program.createOption('--no-cheese', 'remove cheese');
     option.negate = false;
@@ -112,6 +126,15 @@ describe('overridden negatable boolean flag', () => {
     program.addOption(option);
     program.parse(['node', 'test', '--no-cheese']);
     expect(program.opts().cheese).toBeUndefined();
+  });
+
+  test('when negatable boolean flag is specified negate is overridden negative option should be camelcase', () => {
+    const program = new commander.Command();
+    var option = program.createOption('--no-cheese-or-wine', 'remove cheese');
+    option.negate = false;
+    program.addOption(option);
+    program.parse(['node', 'test', '--no-cheese-or-wine']);
+    expect(program.opts().noCheeseOrWine).toBe(true);
   });
 });
 

--- a/tests/options.bool.test.js
+++ b/tests/options.bool.test.js
@@ -110,6 +110,15 @@ describe('boolean flag on command', () => {
 });
 
 describe('overridden negatable boolean flag', () => {
+  test('when negatable boolean flag is unspecified and negate is overridden then positive value is undefined', () => {
+    const program = new commander.Command();
+    var option = program.createOption('--no-cheese', 'remove cheese');
+    option.negate = false;
+    program.addOption(option);
+    program.parse(['node', 'test']);
+    expect(program.opts().cheese).toBeUndefined();
+  });
+
   test('when negatable boolean flag is specified and negate is overridden then negative value is true', () => {
     const program = new commander.Command();
     var option = program.createOption('--no-cheese', 'remove cheese');

--- a/tests/options.bool.test.js
+++ b/tests/options.bool.test.js
@@ -119,7 +119,7 @@ describe('overridden negatable boolean flag', () => {
     expect(program.opts().noCheese).toBe(true);
   });
 
-  test('when negatable boolean flag is specified and negatable is overridden then positive value is undefined', () => {
+  test('when negatable boolean flag is specified and negate is overridden then positive value is undefined', () => {
     const program = new commander.Command();
     var option = program.createOption('--no-cheese', 'remove cheese');
     option.negate = false;
@@ -128,7 +128,7 @@ describe('overridden negatable boolean flag', () => {
     expect(program.opts().cheese).toBeUndefined();
   });
 
-  test('when negatable boolean flag is specified negate is overridden negative option should be camelcase', () => {
+  test('when negatable boolean flag is specified and negate is overridden then negative option should be camelcase', () => {
     const program = new commander.Command();
     var option = program.createOption('--no-cheese-or-wine', 'remove cheese');
     option.negate = false;

--- a/tests/options.bool.test.js
+++ b/tests/options.bool.test.js
@@ -31,6 +31,15 @@ describe('boolean flag on program', () => {
     program.parse(['node', 'test', '--no-cheese']);
     expect(program.opts().cheese).toBe(false);
   });
+
+  test('when bypassing negatable then value is true', () => {
+    const program = new commander.Command();
+    var option = program.createOption('--no-cheese', 'remove cheese');
+    option.negate = false;
+    program.addOption(option);
+    program.parse(['node', 'test', '--no-cheese']);
+    expect(program.opts().noCheese).toBe(true);
+  });
 });
 
 // boolean flag on command


### PR DESCRIPTION
# Pull Request

## Problem

Sometimes it is desired to have an option starting with `--no` to be treated as a regular boolean argument. I encountered this when writing a wrapper for another command and needing to pass the options as is to the sub-process.

## Solution

Since `negate` will be `true` for any option starting with `--no`, the default behavior can be overridden by explicitly changing `negate` to `false`.
