### PR TITLE
Respect negate property in attributeName

### DIFF
--- a/lib/option.js
+++ b/lib/option.js
@@ -213,7 +213,10 @@ class Option {
    */
 
   attributeName() {
-    return camelcase(this.name().replace(/^no-/, ''));
+    if (this.negate) {
+      return camelcase(this.name().replace(/^no-/, ''));
+    }
+    return camelcase(this.name());
   }
 
   /**


### PR DESCRIPTION
# Pull Request

## Problem

`attributeName` was unconditionally stripping the leading `no-` from the option name. The rest of the code respects the `negate` property, allowing an author to override the `negate` property and have an option name `noFoo`.

This is a trimmed down version of #2238, which had tests. 

## Solution

Use the `negate` property in `attributeName()` which is consistent with rest of code testing for negation.

Not adding tests as do not wish to commit to supporting overriding negation in this way. Adding this change as a reasonable thing to do locally.

Added @bernard-wagner as co-author on commit. If you are approve this PR @abetomo, I'll do the merge to try and make sure the co-author attribution gets preserved (bit fragile).