### PR TITLE
Simplified subcommand term

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -2186,7 +2186,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
         .concat(
           this.options.length || this._helpOption !== null ? '[options]' : [],
           this.commands.length ? '[command]' : [],
-          this.registeredArguments.length ? args : [],
+          args,
         )
         .join(' ');
     }

--- a/lib/help.js
+++ b/lib/help.js
@@ -147,16 +147,13 @@ class Help {
    */
 
   subcommandTerm(cmd) {
-    // Legacy. Ignores custom usage string, and nested commands.
-    const args = cmd.registeredArguments
-      .map((arg) => humanReadableArgName(arg))
+    // Short usage. Just show arguments, not options or alias.
+    const args = cmd.registeredArguments.map((arg) => {
+      return humanReadableArgName(arg);
+    });
+    return [cmd.name()]
+      .concat(cmd.commands.length ? '[command]' : [], args)
       .join(' ');
-    return (
-      cmd._name +
-      (cmd._aliases[0] ? '|' + cmd._aliases[0] : '') +
-      (cmd.options.length ? ' [options]' : '') + // simplistic check for non-help option
-      (args ? ' ' + args : '')
-    );
   }
 
   /**

--- a/tests/command.alias.test.js
+++ b/tests/command.alias.test.js
@@ -3,21 +3,21 @@ const commander = require('../');
 // Running alias commands is tested in command.executableSubcommand.lookup.test.js
 // Test various other behaviours for .alias
 
-test('when command has alias then appears in help', () => {
+test.skip('when command has alias then appears in help', () => {
   const program = new commander.Command();
   program.command('info [thing]').alias('i');
   const helpInformation = program.helpInformation();
   expect(helpInformation).toMatch('info|i');
 });
 
-test('when command has aliases added separately then only first appears in help', () => {
+test.skip('when command has aliases added separately then only first appears in help', () => {
   const program = new commander.Command();
   program.command('list [thing]').alias('ls').alias('dir');
   const helpInformation = program.helpInformation();
   expect(helpInformation).toMatch('list|ls ');
 });
 
-test('when command has aliases then only first appears in help', () => {
+test.skip('when command has aliases then only first appears in help', () => {
   const program = new commander.Command();
   program.command('list [thing]').aliases(['ls', 'dir']);
   const helpInformation = program.helpInformation();

--- a/tests/help.commandTerm.test.js
+++ b/tests/help.commandTerm.test.js
@@ -11,13 +11,13 @@ describe('subcommandTerm', () => {
     expect(helper.subcommandTerm(command)).toEqual('program');
   });
 
-  test('when command has alias then returns name|alias', () => {
+  test.skip('when command has alias then returns name|alias', () => {
     const command = new commander.Command('program').alias('alias');
     const helper = new commander.Help();
     expect(helper.subcommandTerm(command)).toEqual('program|alias');
   });
 
-  test('when command has options then returns name [options]', () => {
+  test.skip('when command has options then returns name [options]', () => {
     const command = new commander.Command('program').option('-a,--all');
     const helper = new commander.Help();
     expect(helper.subcommandTerm(command)).toEqual('program [options]');
@@ -29,7 +29,7 @@ describe('subcommandTerm', () => {
     expect(helper.subcommandTerm(command)).toEqual('program <argument>');
   });
 
-  test('when command has everything then returns name|alias [options] <argument>', () => {
+  test.skip('when command has everything then returns name|alias [options] <argument>', () => {
     const command = new commander.Command('program')
       .alias('alias')
       .option('-a,--all')


### PR DESCRIPTION
# Pull Request


## Problem

The subcommand usage being slightly different than the command usage has always annoyed me a little. It may be a historical accident rather than by design.

In particular people who write a custom usage are surprised it does not show (#1853 #1885 #2148). But I am concerned about potential length of showing full usage by default: https://github.com/tj/commander.js/pull/1853#issuecomment-1465031565

Subcommand list was not showing `[command]` for subcommands with nested subcommands. (Missed when added nested subcommands.)

## Solution

Show just the arguments (or `[command]` for nested subcommands). No alias. No `'[options]`.

This makes the subcommand term clearly different that the usage, and the terms a bit shorter.

Tests skipped while thinking about approach! See first comment, as taking it further could show just the name!

## ChangeLog

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->
