### PR TITLE
Split Help.styleItemDescription into option/subcommand/argument

### DIFF
--- a/examples/color-help-replacement.mjs
+++ b/examples/color-help-replacement.mjs
@@ -47,7 +47,7 @@ class MyHelp extends Help {
   styleCommandDescription(str) {
     return this.chalk.magenta(str);
   }
-  styleItemDescription(str) {
+  styleDescriptionText(str) {
     return this.chalk.italic(str);
   }
   styleOptionText(str) {

--- a/examples/color-help.mjs
+++ b/examples/color-help.mjs
@@ -9,7 +9,7 @@ program.configureHelp({
   styleTitle: (str) => styleText('bold', str),
   styleCommandText: (str) => styleText('cyan', str),
   styleCommandDescription: (str) => styleText('magenta', str),
-  styleItemDescription: (str) => styleText('italic', str),
+  styleDescriptionText: (str) => styleText('italic', str),
   styleOptionText: (str) => styleText('green', str),
   styleArgumentText: (str) => styleText('yellow', str),
   styleSubcommandText: (str) => styleText('blue', str),

--- a/lib/help.js
+++ b/lib/help.js
@@ -401,12 +401,7 @@ class Help {
     const helpWidth = helper.helpWidth ?? 80; // in case prepareContext() was not called
 
     function callFormatItem(term, description) {
-      return helper.formatItem(
-        term,
-        termWidth,
-        helper.styleItemDescription(description),
-        helper,
-      );
+      return helper.formatItem(term, termWidth, description, helper);
     }
 
     // Usage
@@ -431,7 +426,7 @@ class Help {
     const argumentList = helper.visibleArguments(cmd).map((argument) => {
       return callFormatItem(
         helper.styleArgumentTerm(helper.argumentTerm(argument)),
-        helper.argumentDescription(argument),
+        helper.styleArgumentDescription(helper.argumentDescription(argument)),
       );
     });
     if (argumentList.length > 0) {
@@ -446,7 +441,7 @@ class Help {
     const optionList = helper.visibleOptions(cmd).map((option) => {
       return callFormatItem(
         helper.styleOptionTerm(helper.optionTerm(option)),
-        helper.optionDescription(option),
+        helper.styleOptionDescription(helper.optionDescription(option)),
       );
     });
     if (optionList.length > 0) {
@@ -463,7 +458,7 @@ class Help {
         .map((option) => {
           return callFormatItem(
             helper.styleOptionTerm(helper.optionTerm(option)),
-            helper.optionDescription(option),
+            helper.styleOptionDescription(helper.optionDescription(option)),
           );
         });
       if (globalOptionList.length > 0) {
@@ -479,7 +474,7 @@ class Help {
     const commandList = helper.visibleCommands(cmd).map((cmd) => {
       return callFormatItem(
         helper.styleSubcommandTerm(helper.subcommandTerm(cmd)),
-        helper.subcommandDescription(cmd),
+        helper.styleSubcommandDescription(helper.subcommandDescription(cmd)),
       );
     });
     if (commandList.length > 0) {
@@ -527,10 +522,16 @@ class Help {
       })
       .join(' ');
   }
-  styleItemDescription(str) {
+  styleCommandDescription(str) {
     return this.styleDescriptionText(str);
   }
-  styleCommandDescription(str) {
+  styleOptionDescription(str) {
+    return this.styleDescriptionText(str);
+  }
+  styleSubcommandDescription(str) {
+    return this.styleDescriptionText(str);
+  }
+  styleArgumentDescription(str) {
     return this.styleDescriptionText(str);
   }
   styleDescriptionText(str) {

--- a/tests/help.style.test.js
+++ b/tests/help.style.test.js
@@ -54,21 +54,6 @@ describe('override style methods and check help information', () => {
     );
   });
 
-  test('styleItemDescription', () => {
-    const program = makeProgram();
-    program.configureHelp({
-      styleItemDescription: (str) => red(str),
-      displayWidth,
-    });
-    const helpText = program.helpInformation();
-    expect(helpText).toEqual(
-      plainHelpInformation
-        .replace('arg description', red('arg description'))
-        .replace('sub description', red('sub description'))
-        .replace(/display help for command/g, red('display help for command')),
-    );
-  });
-
   test('styleCommandDescription', () => {
     const program = makeProgram();
     program.configureHelp({
@@ -81,6 +66,53 @@ describe('override style methods and check help information', () => {
         'program description',
         red('program description'),
       ),
+    );
+  });
+
+  test('styleOptionDescription', () => {
+    const program = makeProgram();
+    program.configureHelp({
+      styleOptionDescription: (str) => red(str),
+      displayWidth,
+    });
+    const helpText = program.helpInformation();
+    expect(helpText).toEqual(
+      plainHelpInformation.replace(
+        /(-h, --help *)(display help for command)/,
+        (match, p1, p2) => p1 + red(p2),
+      ),
+    );
+  });
+
+  test('styleSubcommandDescription', () => {
+    const program = makeProgram();
+    program.configureHelp({
+      styleSubcommandDescription: (str) => red(str),
+      displayWidth,
+    });
+    const helpText = program.helpInformation();
+    expect(helpText).toEqual(
+      plainHelpInformation
+        .replace(
+          /(\[subarg\] *)(sub description)/,
+          (match, p1, p2) => p1 + red(p2),
+        )
+        .replace(
+          /(help \[command\] *)(display help for command)/,
+          (match, p1, p2) => p1 + red(p2),
+        ),
+    );
+  });
+
+  test('styleArgumentDescription', () => {
+    const program = makeProgram();
+    program.configureHelp({
+      styleArgumentDescription: (str) => red(str),
+      displayWidth,
+    });
+    const helpText = program.helpInformation();
+    expect(helpText).toEqual(
+      plainHelpInformation.replace('arg description', red('arg description')),
     );
   });
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -271,8 +271,10 @@ export class Help {
   /** Style for command name in usage string.  */
   styleCommandText(str: string): string;
 
-  styleItemDescription(str: string): string;
   styleCommandDescription(str: string): string;
+  styleOptionDescription(str: string): string;
+  styleSubcommandDescription(str: string): string;
+  styleArgumentDescription(str: string): string;
   /** Base style used by descriptions. */
   styleDescriptionText(str: string): string;
 

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -605,8 +605,10 @@ expectType<string>(helper.styleTitle('Usage:'));
 expectType<string>(helper.styleUsage('foo [options] <file>'));
 expectType<string>(helper.styleCommandText('foo'));
 
-expectType<string>(helper.styleItemDescription('description'));
 expectType<string>(helper.styleCommandDescription('description'));
+expectType<string>(helper.styleOptionDescription('description'));
+expectType<string>(helper.styleSubcommandDescription('description'));
+expectType<string>(helper.styleArgumentDescription('description'));
 expectType<string>(helper.styleDescriptionText('description'));
 
 expectType<string>(helper.styleOptionTerm('-a, --all'));


### PR DESCRIPTION
## Problem

I noticed the inconsistency when documenting the routines in #2282.

Have option+subcommand+argument flavours for stringify but not for style. If someone wanted the description colours to match the term colours they would be out of luck. I don't think many people will want separate styles, but easy to make the separation right from the start.

|  | stringify(object) | style(string) | default style |
 | - | - | - | - |
| 4 | argumentTerm | styleArgumentTerm | styleArgumentText |
 | 5 | argumentDescription | **styleItemDescription** | styleDescriptionText |
 | 6 | optionTerm | styleOptionTerm | styleOptionText |
 | 7 | optionDescription | **styleItemDescription** | styleDescriptionText |
 | 8 | subcommandTerm | styleSubcommandTerm | b, c, d |
 | 9 | subcommandDescription | **styleItemDescription** |  styleDescriptionText|```

## Solution

Split style for item descriptions into fine-grained option+subcommand+argument. Consistent pattern.