### PR TITLE
Reorder funding with active maintainers first

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
-github: [tj, shadowspawn, abetomo]
+github: [shadowspawn, abetomo, tj]
 tidelift: npm/commander


### PR DESCRIPTION
## Problem

I saw a new funding program is starting up, funding key projects in various ecosystems:
- https://blog.ecosyste.ms/2024/12/09/ecosystem-funds-curated-support-for-your-critical-software-dependencies.html

Commander.js features in the JavaScript fund! (Woop!)
- https://funds.ecosyste.ms/funds/javascript

Most of the other supported packages have Open Collective collectives and can distribute the funds after allocation. We don't, and I noticed only @tj was listed on the fund page. I checked, and currently these payments are just allocated to first listed GitHub sponsor.
- https://github.com/ecosyste-ms/funds/issues/188

I am not expecting TJ to be active and redistribute the funding.

## Solution

Shift TJ to last, and the first listed person can redistribute these allocations. I have listed me first but don't mind if you would like to handle it @abetomo.

Alternatively, we could open a collective, but that is a bigger step and I have not looked into that.
