### PR TITLE
Allow negative numbers as optional optional arguments and command arguments when unambiguous

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -333,9 +333,9 @@ $ pizza-options --cheese mozzarella
 add cheese type mozzarella
 ```
 
-Options with an optional option-argument are not greedy and will ignore arguments starting with a dash,
-except negative numbers which are accepted.
+Options with an optional option-argument are not greedy and will ignore arguments starting with a dash.
 So `id` behaves as a boolean option for `--id -ABCD`, but you can use a combined form if needed like `--id=-ABCD`.
+Negative numbers are special and are accepted as an option-argument.
 
 For information about possible ambiguous cases, see [options taking varying arguments](./docs/options-in-depth.md).
 

--- a/Readme.md
+++ b/Readme.md
@@ -333,8 +333,9 @@ $ pizza-options --cheese mozzarella
 add cheese type mozzarella
 ```
 
-Options with an optional option-argument are not greedy and will ignore arguments starting with a dash.
-So `id` behaves as a boolean option for `--id -5`, but you can use a combined form if needed like `--id=-5`.
+Options with an optional option-argument are not greedy and will ignore arguments starting with a dash,
+except negative numbers which are accepted.
+So `id` behaves as a boolean option for `--id -ABCD`, but you can use a combined form if needed like `--id=-ABCD`.
 
 For information about possible ambiguous cases, see [options taking varying arguments](./docs/options-in-depth.md).
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -1740,10 +1740,12 @@ Expecting one of '${allowedValues.join("', '")}'`);
     const negativeNumberArg = (arg) => {
       // return false if not a negative number
       if (!/^-\d*\.?\d+(e[+-]?\d+)?$/.test(arg)) return false;
-      // return false if any short option flags use digits, since ambiguous overlap of options and negative numbers
-      return !this.options
-        .map((opt) => opt.short)
-        .some((short) => /^-\d$/.test(short));
+      // negative number is ok unless digit used as an option in command hierarchy
+      return !this._getCommandAndAncestors().some((cmd) =>
+        cmd.options
+          .map((opt) => opt.short)
+          .some((short) => /^-\d$/.test(short)),
+      );
     };
 
     // parse options

--- a/lib/command.js
+++ b/lib/command.js
@@ -1737,6 +1737,15 @@ Expecting one of '${allowedValues.join("', '")}'`);
       return arg.length > 1 && arg[0] === '-';
     }
 
+    const negativeNumberArg = (arg) => {
+      // return false if not a negative number
+      if (!/^-\d*\.?\d+(e[+-]?\d+)?$/.test(arg)) return false;
+      // return false if any short option flags use digits, since ambiguous overlap of options and negative numbers
+      return !this.options
+        .map((opt) => opt.short)
+        .some((short) => /^-\d$/.test(short));
+    };
+
     // parse options
     let activeVariadicOption = null;
     while (args.length) {
@@ -1749,7 +1758,10 @@ Expecting one of '${allowedValues.join("', '")}'`);
         break;
       }
 
-      if (activeVariadicOption && !maybeOption(arg)) {
+      if (
+        activeVariadicOption &&
+        (!maybeOption(arg) || negativeNumberArg(arg))
+      ) {
         this.emit(`option:${activeVariadicOption.name()}`, arg);
         continue;
       }
@@ -1766,7 +1778,10 @@ Expecting one of '${allowedValues.join("', '")}'`);
           } else if (option.optional) {
             let value = null;
             // historical behaviour is optional value is following arg unless an option
-            if (args.length > 0 && !maybeOption(args[0])) {
+            if (
+              args.length > 0 &&
+              (!maybeOption(args[0]) || negativeNumberArg(args[0]))
+            ) {
               value = args.shift();
             }
             this.emit(`option:${option.name()}`, value);
@@ -1812,7 +1827,12 @@ Expecting one of '${allowedValues.join("', '")}'`);
       // Might be a command-argument, or subcommand option, or unknown option, or help command or option.
 
       // An unknown option means further arguments also classified as unknown so can be reprocessed by subcommands.
-      if (maybeOption(arg)) {
+      // A negative number in a leaf command is not an unknown option.
+      if (
+        dest === operands &&
+        maybeOption(arg) &&
+        !(this.commands.length === 0 && negativeNumberArg(arg))
+      ) {
         dest = unknown;
       }
 

--- a/tests/negatives.test.js
+++ b/tests/negatives.test.js
@@ -254,7 +254,8 @@ test('when default command with digit option then negative throws', () => {
 });
 
 test('when program has subcommand and action handler then negative command-argument unsupported', () => {
-  // Known limitation in parsing. Only allowing negative command-arguments in leaf commands.
+  // Known limitation in parsing. Only allowed negative command-arguments in leaf commands
+  // to minimise changes to parsing when added support for negative numbers.
   const program = new Command();
   program
     .exitOverride()

--- a/tests/negatives.test.js
+++ b/tests/negatives.test.js
@@ -25,8 +25,7 @@ test.each(negativeNumbers)(
   `when option-argument for short optional is %s then consumed=%s`,
   (value, consume) => {
     const program = new Command();
-    program.exitOverride();
-    program.configureOutput({ writeErr: () => {} });
+    program.exitOverride().configureOutput({ writeErr: () => {} });
     program.option('-o, --optional [value]', 'optional option');
     const args = ['-o', value];
     let thrown = '';
@@ -46,8 +45,7 @@ test.each(negativeNumbers)(
   `when option-argument for long optional is %s then consumed=%s`,
   (value, consume) => {
     const program = new Command();
-    program.exitOverride();
-    program.configureOutput({ writeErr: () => {} });
+    program.exitOverride().configureOutput({ writeErr: () => {} });
     program.option('-o, --optional [value]', 'optional option');
     const args = ['--optional', value];
     let thrown = '';
@@ -67,9 +65,10 @@ test.each(negativeNumbers)(
   `when option-argument for short optional... is %s then consumed=%s`,
   (value, consume) => {
     const program = new Command();
-    program.exitOverride();
-    program.configureOutput({ writeErr: () => {} });
-    program.option('-o, --optional [value...]', 'optional option');
+    program
+      .exitOverride()
+      .configureOutput({ writeErr: () => {} })
+      .option('-o, --optional [value...]', 'optional option');
     const args = ['-o', 'first', value];
     let thrown = '';
     try {
@@ -90,9 +89,10 @@ test.each(negativeNumbers)(
   `when option-argument for long optional... is %s then consumed=%s`,
   (value, consume) => {
     const program = new Command();
-    program.exitOverride();
-    program.configureOutput({ writeErr: () => {} });
-    program.option('-o, --optional [value...]', 'optional option');
+    program
+      .exitOverride()
+      .configureOutput({ writeErr: () => {} })
+      .option('-o, --optional [value...]', 'optional option');
     const args = ['--optional', 'first', value];
     let thrown = '';
     try {
@@ -113,9 +113,10 @@ test.each(negativeNumbers)(
   `when command-argument is %s then consumed=%s`,
   (value, consume) => {
     const program = new Command();
-    program.exitOverride();
-    program.configureOutput({ writeErr: () => {} });
-    program.argument('<value>', 'argument');
+    program
+      .exitOverride()
+      .configureOutput({ writeErr: () => {} })
+      .argument('<value>', 'argument');
     const args = [value];
     let thrown = '';
     try {
@@ -135,9 +136,9 @@ test.each(negativeNumbers)(
   `when digit option defined and option-argument is %s then negative not consumed`,
   (value, _ignore) => {
     const program = new Command();
-    program.exitOverride();
-    program.configureOutput({ writeErr: () => {} });
     program
+      .exitOverride()
+      .configureOutput({ writeErr: () => {} })
       .option('-o, --optional [value]', 'optional option')
       .option('-9', 'register option using digit');
     const args = ['-o', value];
@@ -158,9 +159,11 @@ test.each(negativeNumbers)(
   `when digit option defined and command-argument is %s then negative not consumed`,
   (value, _ignore) => {
     const program = new Command();
-    program.exitOverride();
-    program.configureOutput({ writeErr: () => {} });
-    program.argument('[value]').option('-9', 'register option using digit');
+    program
+      .exitOverride()
+      .configureOutput({ writeErr: () => {} })
+      .argument('[value]')
+      .option('-9', 'register option using digit');
     const args = [value];
     let thrown = '';
     try {
@@ -211,9 +214,10 @@ test('when complex example with negative numbers then all consumed', () => {
 
 test('when program has digit option then negatives not allowed in leaf command', () => {
   const program = new Command();
-  program.exitOverride();
-  program.configureOutput({ writeErr: () => {} });
-  program.option('-2', 'double option');
+  program
+    .exitOverride()
+    .configureOutput({ writeErr: () => {} })
+    .option('-2', 'double option');
   let leafArgs;
   program
     .command('leaf')
@@ -240,12 +244,23 @@ test('when default command without digit option then negatives accepted', () => 
 
 test('when default command with digit option then negative throws', () => {
   const program = new Command();
-  program.exitOverride();
-  program.configureOutput({ writeErr: () => {} });
+  program.exitOverride().configureOutput({ writeErr: () => {} });
   program
     .command('leaf', { isDefault: true })
     .option('-2')
     .argument('[value...]')
     .action(() => {});
+  expect(() => program.parse(['-1'], { from: 'user' })).toThrow();
+});
+
+test('when program has subcommand and action handler then negative command-argument unsupported', () => {
+  // Known limitation in parsing. Only allowing negative command-arguments in leaf commands.
+  const program = new Command();
+  program
+    .exitOverride()
+    .configureOutput({ writeErr: () => {} })
+    .argument('[value...]')
+    .action(() => {});
+  program.command('leaf').action(() => {});
   expect(() => program.parse(['-1'], { from: 'user' })).toThrow();
 });

--- a/tests/negatives.test.js
+++ b/tests/negatives.test.js
@@ -22,7 +22,7 @@ const negativeNumbers = [
 ];
 
 test.each(negativeNumbers)(
-  `when option argument for short optional is %s then consumed=%s`,
+  `when option-argument for short optional is %s then consumed=%s`,
   (value, consume) => {
     const program = new Command();
     program.exitOverride();
@@ -42,7 +42,7 @@ test.each(negativeNumbers)(
 );
 
 test.each(negativeNumbers)(
-  `when option argument for long optional is %s then consumed=%s`,
+  `when option-argument for long optional is %s then consumed=%s`,
   (value, consume) => {
     const program = new Command();
     program.exitOverride();
@@ -62,7 +62,7 @@ test.each(negativeNumbers)(
 );
 
 test.each(negativeNumbers)(
-  `when option argument for short optional... is %s then consumed=%s`,
+  `when option-argument for short optional... is %s then consumed=%s`,
   (value, consume) => {
     const program = new Command();
     program.exitOverride();
@@ -84,7 +84,7 @@ test.each(negativeNumbers)(
 );
 
 test.each(negativeNumbers)(
-  `when option argument for long optional... is %s then consumed=%s`,
+  `when option-argument for long optional... is %s then consumed=%s`,
   (value, consume) => {
     const program = new Command();
     program.exitOverride();
@@ -106,7 +106,7 @@ test.each(negativeNumbers)(
 );
 
 test.each(negativeNumbers)(
-  `when command argument is %s then consumed=%s`,
+  `when command-argument is %s then consumed=%s`,
   (value, consume) => {
     const program = new Command();
     program.exitOverride();
@@ -127,7 +127,7 @@ test.each(negativeNumbers)(
 );
 
 test.each(negativeNumbers)(
-  `when digit option defined and option argument is %s then negative not consumed`,
+  `when digit option defined and option-argument is %s then negative not consumed`,
   (value, _ignore) => {
     const program = new Command();
     program.exitOverride();
@@ -149,7 +149,7 @@ test.each(negativeNumbers)(
 );
 
 test.each(negativeNumbers)(
-  `when digit option defined and command argument is %s then negative not consumed`,
+  `when digit option defined and command-argument is %s then negative not consumed`,
   (value, _ignore) => {
     const program = new Command();
     program.exitOverride();

--- a/tests/negatives.test.js
+++ b/tests/negatives.test.js
@@ -1,0 +1,207 @@
+const { Command } = require('../');
+
+// boolean is whether is a consumable argument when negative numbers allowed
+const negativeNumbers = [
+  ['-.1', true],
+  ['-123', true],
+  ['-123.45', true],
+  ['-1e3', true],
+  ['-1e+3', true],
+  ['-1e-3', true],
+  ['-1.2e3', true],
+  ['-1.2e+3', true],
+  ['-1.2e-3', true],
+  ['-1e-3.0', false], // invalid number format
+  ['--1 ', false], // invalid number format
+  ['-0', true],
+  ['1', true],
+  ['-1x', false], // whole string is not a number
+  ['-x-1 ', false], // whole string is not a number
+  ['', true],
+  ['-0x1234', false], // not a plain number
+];
+
+test.each(negativeNumbers)(
+  `when option argument for short optional is %s then consumed=%s`,
+  (value, consume) => {
+    const program = new Command();
+    program.exitOverride();
+    program.option('-o, --optional [value]', 'optional option');
+    const args = ['-o', value];
+    let thrown = '';
+    try {
+      program.parse(args, { from: 'user' });
+    } catch (err) {
+      thrown = err.code;
+    }
+
+    expect(thrown).toEqual(consume ? '' : 'commander.unknownOption');
+    // throws after setting optional to true
+    expect(program.opts()['optional']).toBe(consume ? value : true);
+  },
+);
+
+test.each(negativeNumbers)(
+  `when option argument for long optional is %s then consumed=%s`,
+  (value, consume) => {
+    const program = new Command();
+    program.exitOverride();
+    program.option('-o, --optional [value]', 'optional option');
+    const args = ['--optional', value];
+    let thrown = '';
+    try {
+      program.parse(args, { from: 'user' });
+    } catch (err) {
+      thrown = err.code;
+    }
+
+    expect(thrown).toEqual(consume ? '' : 'commander.unknownOption');
+    // throws after setting optional to true
+    expect(program.opts()['optional']).toBe(consume ? value : true);
+  },
+);
+
+test.each(negativeNumbers)(
+  `when option argument for short optional... is %s then consumed=%s`,
+  (value, consume) => {
+    const program = new Command();
+    program.exitOverride();
+    program.option('-o, --optional [value...]', 'optional option');
+    const args = ['-o', 'first', value];
+    let thrown = '';
+    try {
+      program.parse(args, { from: 'user' });
+    } catch (err) {
+      thrown = err.code;
+    }
+
+    expect(thrown).toEqual(consume ? '' : 'commander.unknownOption');
+    // throws after consuming 'first'
+    expect(program.opts()['optional']).toEqual(
+      consume ? ['first', value] : ['first'],
+    );
+  },
+);
+
+test.each(negativeNumbers)(
+  `when option argument for long optional... is %s then consumed=%s`,
+  (value, consume) => {
+    const program = new Command();
+    program.exitOverride();
+    program.option('-o, --optional [value...]', 'optional option');
+    const args = ['--optional', 'first', value];
+    let thrown = '';
+    try {
+      program.parse(args, { from: 'user' });
+    } catch (err) {
+      thrown = err.code;
+    }
+
+    expect(thrown).toEqual(consume ? '' : 'commander.unknownOption');
+    // throws after consuming 'first'
+    expect(program.opts()['optional']).toEqual(
+      consume ? ['first', value] : ['first'],
+    );
+  },
+);
+
+test.each(negativeNumbers)(
+  `when command argument is %s then consumed=%s`,
+  (value, consume) => {
+    const program = new Command();
+    program.exitOverride();
+    program.argument('<value>', 'argument');
+    const args = [value];
+    let thrown = '';
+    try {
+      program.parse(args, { from: 'user' });
+    } catch (err) {
+      thrown = err.code;
+    }
+
+    expect(thrown).toEqual(consume ? '' : 'commander.unknownOption');
+    expect(consume ? program.args : undefined).toEqual(
+      consume ? [value] : undefined,
+    );
+  },
+);
+
+test.each(negativeNumbers)(
+  `when digit option defined and option argument is %s then negative not consumed`,
+  (value, _ignore) => {
+    const program = new Command();
+    program.exitOverride();
+    program
+      .option('-o, --optional [value]', 'optional option')
+      .option('-9', 'register option using digit');
+    const args = ['-o', value];
+    let thrown = '';
+    try {
+      program.parse(args, { from: 'user' });
+    } catch (err) {
+      thrown = err.code;
+    }
+
+    let consume = value[0] !== '-';
+    expect(thrown).toEqual(consume ? '' : 'commander.unknownOption');
+    expect(program.opts()['optional']).toBe(consume ? value : true);
+  },
+);
+
+test.each(negativeNumbers)(
+  `when digit option defined and command argument is %s then negative not consumed`,
+  (value, _ignore) => {
+    const program = new Command();
+    program.exitOverride();
+    program.argument('[value]').option('-9', 'register option using digit');
+    const args = [value];
+    let thrown = '';
+    try {
+      program.parse(args, { from: 'user' });
+    } catch (err) {
+      thrown = err.code;
+    }
+
+    let consume = value[0] !== '-';
+    expect(thrown).toEqual(consume ? '' : 'commander.unknownOption');
+    expect(consume ? program.args : undefined).toEqual(
+      consume ? [value] : undefined,
+    );
+  },
+);
+
+test('when complex example with negative numbers then all consumed', () => {
+  const program = new Command();
+  program
+    .option('-o [value]', 'optional')
+    .option('-m <value>', 'required option-argument')
+    .option('-O [value...]', 'optional')
+    .option('-M <value...>', 'required option-argument')
+    .argument('[value...]', 'argument');
+  const args = [
+    '-10',
+    '-O',
+    '-40',
+    '-41',
+    '-M',
+    '-50',
+    '-51',
+    '-o',
+    '-20',
+    '-m',
+    '-30',
+    '-11',
+  ];
+  program.parse(args, { from: 'user' });
+  expect(program.opts()).toEqual({
+    o: '-20',
+    m: '-30',
+    O: ['-40', '-41'],
+    M: ['-50', '-51'],
+  });
+  expect(program.args).toEqual(['-10', '-11']);
+});
+
+// ToDo: test when program has digital option and leaf command does not
+// ToDo: test when leaf command has digital option and option does not
+// ToDo: test negatives work with default command

--- a/tests/negatives.test.js
+++ b/tests/negatives.test.js
@@ -26,6 +26,7 @@ test.each(negativeNumbers)(
   (value, consume) => {
     const program = new Command();
     program.exitOverride();
+    program.configureOutput({ writeErr: () => {} });
     program.option('-o, --optional [value]', 'optional option');
     const args = ['-o', value];
     let thrown = '';
@@ -46,6 +47,7 @@ test.each(negativeNumbers)(
   (value, consume) => {
     const program = new Command();
     program.exitOverride();
+    program.configureOutput({ writeErr: () => {} });
     program.option('-o, --optional [value]', 'optional option');
     const args = ['--optional', value];
     let thrown = '';
@@ -66,6 +68,7 @@ test.each(negativeNumbers)(
   (value, consume) => {
     const program = new Command();
     program.exitOverride();
+    program.configureOutput({ writeErr: () => {} });
     program.option('-o, --optional [value...]', 'optional option');
     const args = ['-o', 'first', value];
     let thrown = '';
@@ -88,6 +91,7 @@ test.each(negativeNumbers)(
   (value, consume) => {
     const program = new Command();
     program.exitOverride();
+    program.configureOutput({ writeErr: () => {} });
     program.option('-o, --optional [value...]', 'optional option');
     const args = ['--optional', 'first', value];
     let thrown = '';
@@ -110,6 +114,7 @@ test.each(negativeNumbers)(
   (value, consume) => {
     const program = new Command();
     program.exitOverride();
+    program.configureOutput({ writeErr: () => {} });
     program.argument('<value>', 'argument');
     const args = [value];
     let thrown = '';
@@ -131,6 +136,7 @@ test.each(negativeNumbers)(
   (value, _ignore) => {
     const program = new Command();
     program.exitOverride();
+    program.configureOutput({ writeErr: () => {} });
     program
       .option('-o, --optional [value]', 'optional option')
       .option('-9', 'register option using digit');
@@ -153,6 +159,7 @@ test.each(negativeNumbers)(
   (value, _ignore) => {
     const program = new Command();
     program.exitOverride();
+    program.configureOutput({ writeErr: () => {} });
     program.argument('[value]').option('-9', 'register option using digit');
     const args = [value];
     let thrown = '';
@@ -202,6 +209,43 @@ test('when complex example with negative numbers then all consumed', () => {
   expect(program.args).toEqual(['-10', '-11']);
 });
 
-// ToDo: test when program has digital option and leaf command does not
-// ToDo: test when leaf command has digital option and option does not
-// ToDo: test negatives work with default command
+test('when program has digit option then negatives not allowed in leaf command', () => {
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({ writeErr: () => {} });
+  program.option('-2', 'double option');
+  let leafArgs;
+  program
+    .command('leaf')
+    .argument('[value...]')
+    .action((args) => {
+      leafArgs = args;
+    });
+  const args = ['leaf', '-1'];
+  expect(() => program.parse(args, { from: 'user' })).toThrow();
+});
+
+test('when default command without digit option then negatives accepted', () => {
+  const program = new Command();
+  let leafArgs;
+  program
+    .command('leaf', { isDefault: true })
+    .argument('[value...]')
+    .action((args) => {
+      leafArgs = args;
+    });
+  program.parse(['-1'], { from: 'user' });
+  expect(leafArgs).toEqual(['-1']);
+});
+
+test('when default command with digit option then negative throws', () => {
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({ writeErr: () => {} });
+  program
+    .command('leaf', { isDefault: true })
+    .option('-2')
+    .argument('[value...]')
+    .action(() => {});
+  expect(() => program.parse(['-1'], { from: 'user' })).toThrow();
+});


### PR DESCRIPTION
## Problem

It is unexpected when negative numbers don't work as option-arguments or command arguments and require special treatment.

e.g.

`test --optional -3` => `test --optional=-3`
`test -12.4` => `test -- -12.4`

See: #61 #413 #2338 

## Solution

Allow negative numbers for optional option-arguments and for command arguments.

Like Python, if there are options with digit short flag then don't treat negative numbers as special since they overlap with some options. Keep the behaviour simple and conservative.

Description of what some other libraries do: https://github.com/pkgjs/parseargs/issues/77#issue-1164568986
- yargs has support for negative numbers
- Python allows negative numbers for positionals if there are not options that look like negative numbers (Python [Arguments containing -](https://docs.python.org/3/library/argparse.html#arguments-containing))

## ChangeLog

- add: support for negative numbers as option-arguments and command-arguments