### PR TITLE
Fix leading space in option helptext

### DIFF
--- a/lib/help.js
+++ b/lib/help.js
@@ -352,7 +352,11 @@ class Help {
       extraInfo.push(`env: ${option.envVar}`);
     }
     if (extraInfo.length > 0) {
-      return `${option.description} (${extraInfo.join(', ')})`;
+      const extraDescription = `(${extraInfo.join(', ')})`;
+      if (option.description) {
+        return `${option.description} ${extraDescription}`;
+      }
+      return extraDescription;
     }
 
     return option.description;

--- a/tests/help.optionDescription.test.js
+++ b/tests/help.optionDescription.test.js
@@ -70,6 +70,18 @@ describe('optionDescription', () => {
     );
   });
 
+  test('when option has default value but not description then return custom default', () => {
+    const defaultValueDescription = 'custom';
+    const option = new commander.Option('-a <value>').default(
+      'default value',
+      defaultValueDescription,
+    );
+    const helper = new commander.Help();
+    expect(helper.optionDescription(option)).toEqual(
+      `(default: ${defaultValueDescription})`,
+    );
+  });
+
   test('when option has choices then return description and choices', () => {
     const description = 'description';
     const choices = ['one', 'two'];


### PR DESCRIPTION
<!--
The text in these markdown comments is instructions that will not appear in the displayed pull request,
and can be deleted.

Please submit pull requests against the develop branch.

Follow the existing code style. Check the tests succeed, including format and lint.
  npm run test
  npm run check

Don't update the CHANGELOG or package version number. That gets done by maintainers when preparing the release.

Commander currently has zero production dependencies. That isn't a hard requirement, but is a simple story. Requests which 
add a dependency are much less likely to be accepted, and we are likely to ask for alternative approaches to avoid the dependency.
-->

## Problem

There's a leading space when an option has no description but does have a default value (or other "extra info"):

<img width="432" alt="image" src="https://github.com/user-attachments/assets/4a73e4d7-b411-45f5-8b09-8737e49a98df" />


<!--
What problem are you solving?
What Issues does this relate to?
Show the broken output if appropriate.
-->

## Solution

Copy the existing logic for arguments to avoid a leading space:

<img width="390" alt="image" src="https://github.com/user-attachments/assets/0af647af-d0a1-4488-8676-77c8e41537bb" />

<!--
How did you solve the problem? 
Show the fixed output if appropriate.

There are a lot of forms of documentation which could need updating for a change in functionality. It
is ok if you want to show us the code to discuss before doing the extra work, and
you should say so in your comments so we focus on the concept first before talking about all the other pieces:

- TypeScript typings
- JSDoc documentation in code
- tests
- README
- examples/
-->

Added a test which failed before the change to `lib/help.js`

<img width="710" alt="image" src="https://github.com/user-attachments/assets/7db8dbae-90d5-465c-93c1-0cab8e242837" />

## ChangeLog

Fix leading space in option helptext
<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->
