### PR TITLE
add parseArg to Argument class

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -320,16 +320,16 @@ class Command extends EventEmitter {
    *
    * @param {string} name
    * @param {string} [description]
-   * @param {(Function|*)} [fn] - custom argument processing function
+   * @param {(Function|*)} [parseArg] - custom argument processing function or default value
    * @param {*} [defaultValue]
    * @return {Command} `this` command for chaining
    */
-  argument(name, description, fn, defaultValue) {
+  argument(name, description, parseArg, defaultValue) {
     const argument = this.createArgument(name, description);
-    if (typeof fn === 'function') {
-      argument.default(defaultValue).argParser(fn);
+    if (typeof parseArg === 'function') {
+      argument.default(defaultValue).argParser(parseArg);
     } else {
-      argument.default(fn);
+      argument.default(parseArg);
     }
     this.addArgument(argument);
     return this;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -467,7 +467,7 @@ export class Command {
   argument<T>(
     flags: string,
     description: string,
-    fn: (value: string, previous: T) => T,
+    parseArg: (value: string, previous: T) => T,
     defaultValue?: T,
   ): this;
   argument(name: string, description?: string, defaultValue?: unknown): this;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -51,6 +51,7 @@ export class Argument {
   variadic: boolean;
   defaultValue?: any;
   defaultValueDescription?: string;
+  parseArg?: <T>(value: string, previous: T) => T;
   argChoices?: string[];
 
   /**


### PR DESCRIPTION
## Problem
Missing `parseArg` property on `Arguments` class

## Solution
Adding the missing property to the class

## ChangeLog
Add `parseArg` to property to `Arguments` class
Rename `fn` parameter in `argument` method to `parseArg` to be inline with the `option` method