### PR TITLE
List excess arguments in error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ Now shows an error:
 
 ```console
 $ node example.js a b c
-error: too many arguments. Expected 0 arguments but got 3.
+error: too many arguments. Expected 0 arguments but got 3: a, b, c.
 ```
 
 You can declare the expected arguments. The help will then be more accurate too. Note that declaring
@@ -455,7 +455,7 @@ program.parse();
 ```
 
 ```sh
-$ node trivial.js 
+$ node trivial.js
 error: missing required argument 'file'
 ```
 
@@ -557,7 +557,7 @@ program.showHelpAfterError();
   - pad width calculation was not including help option and help command
   - pad width calculation was including hidden options and commands
 - improve backwards compatibility for custom command event listeners ([#1403])
-  
+
 ### Deleted
 
 - *Breaking:* `.passCommandToAction()` ([#1409])
@@ -658,7 +658,7 @@ program
 - documented second parameter to `.description()` to describe command arguments ([#1353])
 - documentation of special cases with options taking varying numbers of option-arguments ([#1332])
 - documentation for terminology ([#1361])
-  
+
 ### Fixed
 
 - add missing TypeScript definition for `.addHelpCommand()' ([#1375])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -455,7 +455,7 @@ program.parse();
 ```
 
 ```sh
-$ node trivial.js
+$ node trivial.js 
 error: missing required argument 'file'
 ```
 
@@ -557,7 +557,7 @@ program.showHelpAfterError();
   - pad width calculation was not including help option and help command
   - pad width calculation was including hidden options and commands
 - improve backwards compatibility for custom command event listeners ([#1403])
-
+  
 ### Deleted
 
 - *Breaking:* `.passCommandToAction()` ([#1409])
@@ -658,7 +658,7 @@ program
 - documented second parameter to `.description()` to describe command arguments ([#1353])
 - documentation of special cases with options taking varying numbers of option-arguments ([#1332])
 - documentation for terminology ([#1361])
-
+  
 ### Fixed
 
 - add missing TypeScript definition for `.addHelpCommand()' ([#1375])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ Now shows an error:
 
 ```console
 $ node example.js a b c
-error: too many arguments. Expected 0 arguments but got 3: a, b, c.
+error: too many arguments. Expected 0 arguments but got 3.
 ```
 
 You can declare the expected arguments. The help will then be more accurate too. Note that declaring

--- a/lib/command.js
+++ b/lib/command.js
@@ -2149,9 +2149,10 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
     const expected = this.registeredArguments.length;
     const s = expected === 1 ? '' : 's';
+    const received = receivedArgs.length;
     const forSubcommand = this.parent ? ` for '${this.name()}'` : '';
-    const excess = receivedArgs.slice(expected).join(', ');
-    const message = `error: too many arguments${forSubcommand}. Expected ${expected} argument${s} but got ${receivedArgs.length}: ${excess}.`;
+    const details = receivedArgs.join(', ');
+    const message = `error: too many arguments${forSubcommand}. Expected ${expected} argument${s} but got ${received}: ${details}.`;
     this.error(message, { code: 'commander.excessArguments' });
   }
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -2150,7 +2150,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
     const expected = this.registeredArguments.length;
     const s = expected === 1 ? '' : 's';
     const forSubcommand = this.parent ? ` for '${this.name()}'` : '';
-    const message = `error: too many arguments${forSubcommand}. Expected ${expected} argument${s} but got ${receivedArgs.length}.`;
+    const knownNames = new Set(this.registeredArguments.map((arg) => arg.name()));
+    const excess = receivedArgs.filter((arg) => !knownNames.has(arg)).join(', ');
+    const message = `error: too many arguments${forSubcommand}. Expected ${expected} argument${s} but got ${receivedArgs.length}: ${excess}.`;
     this.error(message, { code: 'commander.excessArguments' });
   }
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -2150,8 +2150,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     const expected = this.registeredArguments.length;
     const s = expected === 1 ? '' : 's';
     const forSubcommand = this.parent ? ` for '${this.name()}'` : '';
-    const knownNames = new Set(this.registeredArguments.map((arg) => arg.name()));
-    const excess = receivedArgs.filter((arg) => !knownNames.has(arg)).join(', ');
+    const excess = receivedArgs.slice(expected).join(', ');
     const message = `error: too many arguments${forSubcommand}. Expected ${expected} argument${s} but got ${receivedArgs.length}: ${excess}.`;
     this.error(message, { code: 'commander.excessArguments' });
   }

--- a/tests/command.exitOverride.test.js
+++ b/tests/command.exitOverride.test.js
@@ -183,7 +183,7 @@ describe('.exitOverride and error details', () => {
       caughtErr,
       1,
       'commander.excessArguments',
-      'error: too many arguments. Expected 0 arguments but got 1.',
+      'error: too many arguments. Expected 0 arguments but got 1: excess.',
     );
   });
 
@@ -207,7 +207,7 @@ describe('.exitOverride and error details', () => {
       caughtErr,
       1,
       'commander.excessArguments',
-      "error: too many arguments for 'speak'. Expected 0 arguments but got 1.",
+      "error: too many arguments for 'speak'. Expected 0 arguments but got 1: excess.",
     );
   });
 


### PR DESCRIPTION
Sometimes a typo in arguments list can be parsed as an excess argument rather than option. When the options list is long, finding it can be tricky, so it would be helpful to see exactly what arguments are treated as excess.

## Solution

Real life example by mistakenly adding spaces before # in systemd service file:

```
error: too many arguments. Expected 0 arguments but got 2: #, #--address=0x72.
```

## ChangeLog

List excess arguments in error message