### PR TITLE
Remove declaration order dependency for negated options

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -687,6 +687,19 @@ Expecting one of '${allowedValues.join("', '")}'`);
       }
     } else if (option.defaultValue !== undefined) {
       this.setOptionValueWithSource(name, option.defaultValue, 'default');
+    } else if (!option.negate && option.long) {
+      // If this is a positive option and there's a corresponding negated option
+      // that set a default value of true, remove that default
+      const negatedLongFlag = `--no-${option.long.slice(2)}`;
+      if (this._findOption(negatedLongFlag)) {
+        if (
+          this.getOptionValue(name) === true &&
+          this.getOptionValueSource(name) === 'default'
+        ) {
+          delete this._optionValues[name];
+          delete this._optionValueSources[name];
+        }
+      }
     }
 
     // handler for cli and env supplied values

--- a/tests/options.bool.combo.test.js
+++ b/tests/options.bool.combo.test.js
@@ -51,7 +51,6 @@ describe('boolean option combo with no default', () => {
     program.parse(['node', 'test', '--pepper', '--no-pepper']);
     expect(program.opts().pepper).toBe(false);
   });
-
 });
 
 // Flag with default, say from an environment variable.

--- a/tests/options.bool.combo.test.js
+++ b/tests/options.bool.combo.test.js
@@ -19,6 +19,15 @@ describe('boolean option combo with no default', () => {
     expect(program.opts().pepper).toBeUndefined();
   });
 
+  test('when boolean combo not specified then value is undefined (order declaration does not matter)', () => {
+    const program = new commander.Command();
+    program
+      .option('--no-pepper', 'remove pepper')
+      .option('--pepper', 'pepper only');
+    program.parse(['node', 'test']);
+    expect(program.opts().pepper).toBeUndefined();
+  });
+
   test('when boolean combo positive then value is true', () => {
     const program = createPepperProgram();
     program.parse(['node', 'test', '--pepper']);
@@ -42,6 +51,7 @@ describe('boolean option combo with no default', () => {
     program.parse(['node', 'test', '--pepper', '--no-pepper']);
     expect(program.opts().pepper).toBe(false);
   });
+
 });
 
 // Flag with default, say from an environment variable.

--- a/tests/options.bool.test.js
+++ b/tests/options.bool.test.js
@@ -86,6 +86,38 @@ describe('boolean flag on command', () => {
     program.parse(['node', 'test', 'sub', '--no-cheese']);
     expect(subCommandOptions.cheese).toBe(false);
   });
+
+  test('when neither boolean flag or its negated counterpart is specified, then value is undefined', () => {
+    let subCommandOptions;
+    const program = new commander.Command();
+    program
+      .command('sub')
+      .option('--cheese', 'cheese only')
+      .option('--no-cheese', 'remove cheese')
+      .action((options) => {
+        subCommandOptions = options;
+      });
+    program.parse(['node', 'test', 'sub']);
+
+    expect(subCommandOptions.cheese).toBeUndefined();
+    expect(subCommandOptions.noCheese).toBeUndefined();
+  });
+
+  test('when neither boolean flag or its negated counterpart is specified, then value is undefined (order declaration does not matter)', () => {
+    let subCommandOptions;
+    const program = new commander.Command();
+    program
+      .command('sub')
+      .option('--no-cheese', 'remove cheese')
+      .option('--cheese', 'cheese only')
+      .action((options) => {
+        subCommandOptions = options;
+      });
+    program.parse(['node', 'test', 'sub']);
+
+    expect(subCommandOptions.cheese).toBeUndefined();
+    expect(subCommandOptions.noCheese).toBeUndefined();
+  });
 });
 
 // boolean flag with non-boolean default

--- a/tests/options.bool.test.js
+++ b/tests/options.bool.test.js
@@ -86,36 +86,6 @@ describe('boolean flag on command', () => {
     program.parse(['node', 'test', 'sub', '--no-cheese']);
     expect(subCommandOptions.cheese).toBe(false);
   });
-
-  test('when neither boolean flag or its negated counterpart is specified, then value is undefined', () => {
-    let subCommandOptions;
-    const program = new commander.Command();
-    program
-      .command('sub')
-      .option('--cheese', 'cheese only')
-      .option('--no-cheese', 'remove cheese')
-      .action((options) => {
-        subCommandOptions = options;
-      });
-    program.parse(['node', 'test', 'sub']);
-
-    expect(subCommandOptions.cheese).toBeUndefined();
-  });
-
-  test('when neither boolean flag or its negated counterpart is specified, then value is undefined (order declaration does not matter)', () => {
-    let subCommandOptions;
-    const program = new commander.Command();
-    program
-      .command('sub')
-      .option('--no-cheese', 'remove cheese')
-      .option('--cheese', 'cheese only')
-      .action((options) => {
-        subCommandOptions = options;
-      });
-    program.parse(['node', 'test', 'sub']);
-
-    expect(subCommandOptions.cheese).toBeUndefined();
-  });
 });
 
 // boolean flag with non-boolean default

--- a/tests/options.bool.test.js
+++ b/tests/options.bool.test.js
@@ -100,7 +100,6 @@ describe('boolean flag on command', () => {
     program.parse(['node', 'test', 'sub']);
 
     expect(subCommandOptions.cheese).toBeUndefined();
-    expect(subCommandOptions.noCheese).toBeUndefined();
   });
 
   test('when neither boolean flag or its negated counterpart is specified, then value is undefined (order declaration does not matter)', () => {
@@ -116,7 +115,6 @@ describe('boolean flag on command', () => {
     program.parse(['node', 'test', 'sub']);
 
     expect(subCommandOptions.cheese).toBeUndefined();
-    expect(subCommandOptions.noCheese).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Problem

When declaring both a boolean option and its negated version (e.g. `--cheese` and `--no-cheese`), the order in which the options are _declared_ changes parsing behavior.

When passing neither `--cheese` or `--no-cheese`:
- If `--cheese` is declared first, parsing produces `{}` as expected
- If `--no-cheese` is declared first, parsing produces `{cheese: true}` (unexpected)

Initially, defining both `--cheese` and `--no-cheese` would break the boolean option altogether, and #795 fixed that in the current order-specific way.

## Solution

Explicitly remove the default if neither option is provided