### PR TITLE
Make order not matter for adding combo positive/negative options

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -277,10 +277,7 @@ cheese: stilton
 ### Other option types, negatable boolean and boolean|value
 
 You can define a boolean option long name with a leading `no-` to set the option value to false when used.
-Defined alone this also makes the option true by default.
-
-If you define `--foo` first, adding `--no-foo` does not change the default value from what it would
-otherwise be.
+Defined alone without a matching positive option, this also makes the option true by default.
 
 Example file: [options-negatable.js](./examples/options-negatable.js)
 

--- a/examples/options-negatable.js
+++ b/examples/options-negatable.js
@@ -22,6 +22,6 @@ console.log(`You ordered a pizza with ${sauceStr} and ${cheeseStr}`);
 
 // Try the following:
 //    node options-negatable.js
-//    node options-negatable.js --sauce
+//    node options-negatable.js --no-sauce
 //    node options-negatable.js --cheese=blue
 //    node options-negatable.js --no-sauce --no-cheese

--- a/lib/command.js
+++ b/lib/command.js
@@ -675,17 +675,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     const name = option.attributeName();
 
     // store default value
-    if (option.negate) {
-      // --no-foo is special and defaults foo to true, unless a --foo option is already defined
-      const positiveLongFlag = option.long.replace(/^--no-/, '--');
-      if (!this._findOption(positiveLongFlag)) {
-        this.setOptionValueWithSource(
-          name,
-          option.defaultValue === undefined ? true : option.defaultValue,
-          'default',
-        );
-      }
-    } else if (option.defaultValue !== undefined) {
+    if (option.defaultValue !== undefined) {
       this.setOptionValueWithSource(name, option.defaultValue, 'default');
     }
 
@@ -1126,6 +1116,30 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   _prepareForParse() {
+    // Before parsing and before saving the state, do the special default of lone negated option to true.
+    // Some paranoia about not overwriting a value since doing this lazily instead of when option added.
+    if (this._savedState === null) {
+      this.options
+        .filter(
+          (option) =>
+            option.negate &&
+            option.defaultValue === undefined &&
+            this.getOptionValue(option.attributeName()) === undefined,
+        )
+        .forEach((option) => {
+          // lone --no-foo is special and defaults foo to true, unless a --foo option is already defined
+          const positiveLongFlag = option.long.replace(/^--no-/, '--');
+          if (!this._findOption(positiveLongFlag)) {
+            this.setOptionValueWithSource(
+              option.attributeName(),
+              true,
+              'default',
+            );
+          }
+        });
+    }
+
+    // Save the state the first time, then restore the state before each subsequent parse.
     if (this._savedState === null) {
       this.saveStateBeforeParse();
     } else {

--- a/lib/command.js
+++ b/lib/command.js
@@ -1116,9 +1116,10 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   _prepareForParse() {
-    // Before parsing and before saving the state, do the special default of lone negated option to true.
-    // Some paranoia about not overwriting a value since doing this lazily instead of when option added.
+    // Save the state the first time, then restore the state before each subsequent parse.
     if (this._savedState === null) {
+      // Do the special default of lone negated option to true, now that we have all the options.
+      // Filter for negated options that have not been processed already.
       this.options
         .filter(
           (option) =>
@@ -1127,7 +1128,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
             this.getOptionValue(option.attributeName()) === undefined,
         )
         .forEach((option) => {
-          // lone --no-foo is special and defaults foo to true, unless a --foo option is already defined
+          // check for lone negated option: --no-foo without a --foo option
           const positiveLongFlag = option.long.replace(/^--no-/, '--');
           if (!this._findOption(positiveLongFlag)) {
             this.setOptionValueWithSource(
@@ -1137,10 +1138,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
             );
           }
         });
-    }
 
-    // Save the state the first time, then restore the state before each subsequent parse.
-    if (this._savedState === null) {
       this.saveStateBeforeParse();
     } else {
       this.restoreStateBeforeParse();

--- a/tests/options.bool.combo.test.js
+++ b/tests/options.bool.combo.test.js
@@ -149,3 +149,43 @@ describe('boolean option combo with non-boolean default and preset', () => {
     expect(program.opts().pepper).toBe(false);
   });
 });
+
+describe('only lone negative causes implicit default of true', () => {
+  test('when lone negative then default value is true', () => {
+    const program = new commander.Command();
+    program.option('--no-pepper', 'remove pepper');
+    program.parse([], { from: 'user' });
+    expect(program.opts().pepper).toBe(true);
+  });
+
+  test('when boolean combo and negative first then no implicit default', () => {
+    // New behaviour in Commander 15, now only lone negative gets implicit default of true.
+    const program = new commander.Command();
+    program
+      .option('--no-pepper', 'remove pepper')
+      .option('--pepper', 'pepper only');
+    program.parse([], { from: 'user' });
+    expect(program.opts().pepper).toBeUndefined();
+  });
+
+  test('when boolean combo and negative second then no implicit default', () => {
+    const program = new commander.Command();
+    program
+      .option('--pepper', 'pepper only')
+      .option('--no-pepper', 'remove pepper');
+    program.parse([], { from: 'user' });
+    expect(program.opts().pepper).toBeUndefined();
+  });
+
+  test('when boolean combo and negative second with explicit default then get explicit default', () => {
+    // Prior to Commander 15, negative second would ignore implicit and explicit default value.
+    // Simpler rule now and the special default behaviour is for lone negative only. Add test since
+    // intentional change of behaviour for unlikely edge case.
+    const program = new commander.Command();
+    program
+      .option('--pepper', 'pepper only')
+      .option('--no-pepper', 'remove pepper', 'plain');
+    program.parse([], { from: 'user' });
+    expect(program.opts().pepper).toBe('plain');
+  });
+});


### PR DESCRIPTION
## Problem

Lone negated options default to true. (Historical.)
Positive then negative does not default to true. (By design.)
Negative then positive still defaults to true, for implementation reasons rather than by design.

See: #2397

## Solution

Move the setting of the default to when the options are known.

Alternative approach to #2398. That PR retroactively removes the "default true" when the positive option is added second.

## ChangeLog

Fix: only lone negated option defaults option value to true
