### PR TITLE
Refactor parseOptions to process args in-place

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -1741,15 +1741,14 @@ Expecting one of '${allowedValues.join("', '")}'`);
    *     sub --unknown uuu op => [sub], [--unknown uuu op]
    *     sub -- --unknown uuu op => [sub --unknown uuu op], []
    *
-   * @param {string[]} argv
+   * @param {string[]} args
    * @return {{operands: string[], unknown: string[]}}
    */
 
-  parseOptions(argv) {
+  parseOptions(args) {
     const operands = []; // operands, not options or values
     const unknown = []; // first unknown option and remaining unknown args
     let dest = operands;
-    const args = argv.slice();
 
     function maybeOption(arg) {
       return arg.length > 1 && arg[0] === '-';
@@ -1768,13 +1767,16 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
     // parse options
     let activeVariadicOption = null;
-    while (args.length) {
-      const arg = args.shift();
+    let activeGroup = null; // working through group of short options, like -abc
+    let i = 0;
+    while (i < args.length || activeGroup) {
+      const arg = activeGroup ?? args[i++];
+      activeGroup = null;
 
       // literal
       if (arg === '--') {
         if (dest === unknown) dest.push(arg);
-        dest.push(...args);
+        dest.push(...args.slice(i));
         break;
       }
 
@@ -1792,17 +1794,17 @@ Expecting one of '${allowedValues.join("', '")}'`);
         // recognised option, call listener to assign value with possible custom processing
         if (option) {
           if (option.required) {
-            const value = args.shift();
+            const value = args[i++];
             if (value === undefined) this.optionMissingArgument(option);
             this.emit(`option:${option.name()}`, value);
           } else if (option.optional) {
             let value = null;
             // historical behaviour is optional value is following arg unless an option
             if (
-              args.length > 0 &&
-              (!maybeOption(args[0]) || negativeNumberArg(args[0]))
+              i < args.length &&
+              (!maybeOption(args[i]) || negativeNumberArg(args[i]))
             ) {
-              value = args.shift();
+              value = args[i++];
             }
             this.emit(`option:${option.name()}`, value);
           } else {
@@ -1825,9 +1827,10 @@ Expecting one of '${allowedValues.join("', '")}'`);
             // option with value following in same argument
             this.emit(`option:${option.name()}`, arg.slice(2));
           } else {
-            // boolean option, emit and put back remainder of arg for further processing
+            // boolean option
             this.emit(`option:${option.name()}`);
-            args.unshift(`-${arg.slice(2)}`);
+            // remove the processed option and keep processing group
+            activeGroup = `-${arg.slice(2)}`;
           }
           continue;
         }
@@ -1864,26 +1867,23 @@ Expecting one of '${allowedValues.join("', '")}'`);
       ) {
         if (this._findCommand(arg)) {
           operands.push(arg);
-          if (args.length > 0) unknown.push(...args);
+          unknown.push(...args.slice(i));
           break;
         } else if (
           this._getHelpCommand() &&
           arg === this._getHelpCommand().name()
         ) {
-          operands.push(arg);
-          if (args.length > 0) operands.push(...args);
+          operands.push(arg, ...args.slice(i));
           break;
         } else if (this._defaultCommandName) {
-          unknown.push(arg);
-          if (args.length > 0) unknown.push(...args);
+          unknown.push(arg, ...args.slice(i));
           break;
         }
       }
 
       // If using passThroughOptions, stop processing options at first command-argument.
       if (this._passThroughOptions) {
-        dest.push(arg);
-        if (args.length > 0) dest.push(...args);
+        dest.push(arg, ...args.slice(i));
         break;
       }
 


### PR DESCRIPTION
When I refactored the parsing back in #1145 I thought the in-place processing of the args was a little messy to follow, and I refactored to work with a copy. The code has changed since then and this refactor processes the args in-place again with very much the same logic and flow. Testing and using the next argument for using as a value is still clear.

(For amusement, ended up with exactly the same number of lines of code.)