### PR TITLE
minor change in index.d.ts

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1044,7 +1044,7 @@ export class Command {
    */
   outputHelp(context?: HelpContext): void;
   /** @deprecated since v7 */
-  outputHelp(cb?: (str: string) => string): void;
+  outputHelp(cb: (str: string) => string): void;
 
   /**
    * Return command help documentation.
@@ -1071,7 +1071,7 @@ export class Command {
    */
   help(context?: HelpContext): never;
   /** @deprecated since v7 */
-  help(cb?: (str: string) => string): never;
+  help(cb: (str: string) => string): never;
 
   /**
    * Add additional text to be displayed with the built-in help.


### PR DESCRIPTION
## Problem

No problem, just a subtlety in the typings. The deprecated versions of `help` and `outputHelp` should not include the parameter-less version to make it entirely clear that only the callback variant itself is deprecated.

## Solution

Remove optional marker from the deprecated signatures.

## ChangeLog

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->
