### PR TITLE
Improve negative test

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -1756,7 +1756,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
     const negativeNumberArg = (arg) => {
       // return false if not a negative number
-      if (!/^-\d*\.?\d+(e[+-]?\d+)?$/.test(arg)) return false;
+      if (!/^-(\d+|\d*\.\d+)(e[+-]?\d+)?$/.test(arg)) return false;
       // negative number is ok unless digit used as an option in command hierarchy
       return !this._getCommandAndAncestors().some((cmd) =>
         cmd.options


### PR DESCRIPTION
I had a loose expression to accept all of`123` and `4.5` and `.678`. More explicit and tidier using the OR operator to test for a number with OR without a decimal point.

The OR operator is lowest precedence, so `\d+|\d*\.\d+` is same as `(\d+)|(\d*\.\d+)`