### PR TITLE
Implement useName() method for setting a custom attribute name

### DIFF
--- a/lib/option.js
+++ b/lib/option.js
@@ -34,7 +34,7 @@ class Option {
     this.conflictsWith = [];
     this.implied = undefined;
     this.helpGroupHeading = undefined; // soft initialised when option added to command
-    this.attrName = undefined;
+    this.attributeName = undefined;
   }
 
   /**
@@ -198,13 +198,13 @@ class Option {
     /**
    * Allow to change the attribute name of this option.
    *
-   * @param {string} the used attribute name
+   * @param {string} attributeName is used for a alternated attribute name
    * @return {Option}
    */
 
-  useName(artName) {
-    if (typeof artName === 'string') {
-      this.attrName = artName;
+  setAttributeName(attributeName) {
+    if (typeof attributeName === 'string') {
+      this.attributeName = attributeName;
     }
     return this;
   }
@@ -224,15 +224,15 @@ class Option {
   /**
    * Return option name, in a camelcase format that can be used
    * as an object attribute key. 
-   * This method now uses the attrName when it is set otherwise 
+   * This method now uses alternativly the this.attributeName when it is set otherwise 
    * it will still use the option name as before
    *
    * @return {string}
    */
 
   attributeName() {
-    if (typeof this.attrName === 'string') {
-      return attrName;
+    if (typeof this.attributeName === 'string') {
+      return this.attributeName;
     } 
     if (this.negate) {
       return camelcase(this.name().replace(/^no-/, ''));

--- a/lib/option.js
+++ b/lib/option.js
@@ -34,6 +34,7 @@ class Option {
     this.conflictsWith = [];
     this.implied = undefined;
     this.helpGroupHeading = undefined; // soft initialised when option added to command
+    this.attrName = undefined;
   }
 
   /**
@@ -194,6 +195,19 @@ class Option {
     return this;
   }
 
+    /**
+   * Allow to change the attribute name of this option.
+   *
+   * @param {string} the used attribute name
+   * @return {Option}
+   */
+
+  useName(artName) {
+    if (typeof artName === 'string') {
+      this.attrName = artName;
+    }
+    return this;
+  }
   /**
    * Return option name.
    *
@@ -209,12 +223,17 @@ class Option {
 
   /**
    * Return option name, in a camelcase format that can be used
-   * as an object attribute key.
+   * as an object attribute key. 
+   * This method now uses the attrName when it is set otherwise 
+   * it will still use the option name as before
    *
    * @return {string}
    */
 
   attributeName() {
+    if (typeof this.attrName === 'string') {
+      return attrName;
+    } 
     if (this.negate) {
       return camelcase(this.name().replace(/^no-/, ''));
     }

--- a/lib/option.js
+++ b/lib/option.js
@@ -34,7 +34,7 @@ class Option {
     this.conflictsWith = [];
     this.implied = undefined;
     this.helpGroupHeading = undefined; // soft initialised when option added to command
-    this.attributeName = undefined;
+    this.attribName = undefined;
   }
 
   /**
@@ -204,7 +204,7 @@ class Option {
 
   setAttributeName(attributeName) {
     if (typeof attributeName === 'string') {
-      this.attributeName = attributeName;
+      this.attribName = attributeName;
     }
     return this;
   }
@@ -231,8 +231,8 @@ class Option {
    */
 
   attributeName() {
-    if (typeof this.attributeName === 'string') {
-      return this.attributeName;
+    if (typeof this.attribName === 'string') {
+      return this.attribName;
     } 
     if (this.negate) {
       return camelcase(this.name().replace(/^no-/, ''));


### PR DESCRIPTION

<!--
The text in these markdown comments is instructions that will not appear in the displayed pull request,
and can be deleted.

Please submit pull requests against the develop branch.

Follow the existing code style. Check the tests succeed, including format and lint.
  npm run test
  npm run check

Don't update the CHANGELOG or package version number. That gets done by maintainers when preparing the release.

Commander currently has zero production dependencies. That isn't a hard requirement, but is a simple story. Requests which 
add a dependency are much less likely to be accepted, and we are likely to ask for alternative approaches to avoid the dependency.
-->

## Problem

In my setup i use a fixed configuration file that is loaded from an INI file. To make thinks easier for me i like the result of the arg parser have the same key names as this configuration class members so i could easily set the values without first modify the result.

## Solution

With this PR we can now set an alternative attribute but name.

This small PR adds a method `useName()` to have a different attribute name then the current option name and the `attributeName()` checks first if the `useName()` is used will then us the given attrName or use the old method to determine the attributes name.


<!--
How did you solve the problem? 
Show the fixed output if appropriate.

There are a lot of forms of documentation which could need updating for a change in functionality. It
is ok if you want to show us the code to discuss before doing the extra work, and
you should say so in your comments so we focus on the concept first before talking about all the other pieces:

- TypeScript typings
- JSDoc documentation in code
- tests
- README
- examples/
-->

## ChangeLog

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->
