### PR TITLE
Fix support backing details

### DIFF
--- a/package-support.json
+++ b/package-support.json
@@ -9,7 +9,10 @@
         "type": "time-permitting"
       },
       "backing": {
-        "npm-funding": true
+        "donations": [
+          "https://github.com/sponsors/abetomo",
+          "https://github.com/sponsors/shadowspawn"
+        ]
       }
     }
   ]


### PR DESCRIPTION
The `npm_funding` support field refers to the funding property in `package.json`, and does not cover the funding file in the root level of the repo that GitHub uses. 

Specification: https://github.com/nodejs/package-maintenance/blob/main/docs/PACKAGE-SUPPORT.md#support-backing

I actually had explicit fields when first adding this file but thought the `npm_funding` covered it: https://github.com/tj/commander.js/pull/1477/commits/cf2ae74fffc3af7c4d9023fabc5453088183b334

I don't think `package-support.json` is much used, but fixing up the details after I noticed the issue.