### PR TITLE
Separate out a more detailed release policy document

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1148,7 +1148,8 @@ There is more information available about:
 ## Support
 
 The current version of Commander is fully supported on Long Term Support versions of Node.js, and requires at least v20.
-(For older versions of Node.js, use an older version of Commander.)
+
+Older version lines of Commander receive security updates for 12 months. For more see: [Release Policy](./docs/release-policy.md).
 
 The main forum for free and community support is the project [Issues](https://github.com/tj/commander.js/issues) on GitHub.
 

--- a/Readme.md
+++ b/Readme.md
@@ -1149,7 +1149,7 @@ There is more information available about:
 
 The current version of Commander is fully supported on Long Term Support versions of Node.js, and requires at least v20.
 
-Older version lines of Commander receive security updates for 12 months. For more see: [Release Policy](./docs/release-policy.md).
+Older major versions of Commander receive security updates for 12 months. For more see: [Release Policy](./docs/release-policy.md).
 
 The main forum for free and community support is the project [Issues](https://github.com/tj/commander.js/issues) on GitHub.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,13 +1,7 @@
 # Security Policy
 
-## Supported Versions
-
-Security updates are supported for the current version and the previous major version.
-
-Pull Requests for security issues will be considered for older versions back to 2.x.
-
-## Reporting a Vulnerability
-
 To report a security vulnerability, please use the
 [Tidelift security contact](https://tidelift.com/security).
 Tidelift will coordinate the fix and disclosure.
+
+Please do not report security vulnerabilities through public GitHub issues or pull requests.

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -9,7 +9,7 @@ The [Changelog](../CHANGELOG.md) lists release notes for all versions.
 
 The current release line gets all updates: features, bug fixes, and security updates. Older maintenance versions get just security updates for 12 months.
 
-| Version | First Release | Release Note |  Status | End of life |
+| Version | First Release | Release Note |  Status | End of Life |
 | ------- | ------------- | - | ------- | ----------- |
 | 14.x | 2025-05-18 | [14.0.0](https://github.com/tj/commander.js/releases/tag/v14.0.0) | current | |
 | 13.x | 2024-12-30 | [13.0.0](https://github.com/tj/commander.js/releases/tag/v13.0.0) | maintenance | 2026-05-18 |

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -1,0 +1,18 @@
+# Release Policy
+
+We follow [Semantic Versioning](http://semver.org/spec/v2.0.0.html), and limit breaking changes to major versions.
+
+There are major releases about every six months. We do a major release and bump the minimum required node version when LTS Node.js versions reach end-of-life.
+
+The release notes for major versions highlight breaking changes, and include a section of migration tips for common changes required.
+The [Changelog](../CHANGELOG.md) lists release notes for all versions.
+
+The current release line gets all updates: features, bug fixes, and security updates. Older maintenance versions get just security updates for 12 months.
+
+| Version | First Release | Release Note |  Status | End of life |
+| ------- | ------------- | - | ------- | ----------- |
+| 14.x | 2025-05-18 | [14.0.0](https://github.com/tj/commander.js/releases/tag/v14.0.0) | current | |
+| 13.x | 2024-12-30 | [13.0.0](https://github.com/tj/commander.js/releases/tag/v13.0.0) | maintenance | 2026-05-18 |
+| 12.x | 2024-02-03 | [12.0.0](https://github.com/tj/commander.js/releases/tag/v12.0.0) | maintenance | 2025-12-30 |
+
+Older versions do not automatically get security updates.


### PR DESCRIPTION
## Problem

In particular:
- mixing security policy and releases policy
- no explicit EOL date for old versions

See #2455 for detailed background.

## Solution

Create a new Release Policy document with detail about release versioning, cadence, version status, and EOL dates.

## ChangeLog

- add new Release Policy documentation