### PR TITLE
docs: avoid MINGW64/Git Bash slash interpretation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -91,10 +91,10 @@ console.log(program.args[0].split(options.separator, limit));
 ```
 
 ```console
-$ node split.js -s / --fits a/b/c
+$ node split.js -s - --fits a-b-c
 error: unknown option '--fits'
 (Did you mean --first?)
-$ node split.js -s / --first a/b/c
+$ node split.js -s - --first a-b-c
 [ 'a' ]
 ```
 
@@ -138,7 +138,7 @@ Options:
   -s, --separator <char>  separator character (default: ",")
   -h, --help              display help for command
 
-$ node string-util.js split --separator=/ a/b/c
+$ node string-util.js split --separator=- a-b-c
 [ 'a', 'b', 'c' ]
 ```
 

--- a/Readme_zh-CN.md
+++ b/Readme_zh-CN.md
@@ -88,10 +88,10 @@ console.log(program.args[0].split(options.separator, limit));
 ```
 
 ```console
-$ node split.js -s / --fits a/b/c
+$ node split.js -s - --fits a-b-c
 error: unknown option '--fits'
 (Did you mean --first?)
-$ node split.js -s / --first a/b/c
+$ node split.js -s - --first a-b-c
 [ 'a' ]
 ```
 
@@ -135,7 +135,7 @@ Options:
   -s, --separator <char>  separator character (default: ",")
   -h, --help              display help for command
 
-$ node string-util.js split --separator=/ a/b/c
+$ node string-util.js split --separator=- a-b-c
 [ 'a', 'b', 'c' ]
 ```
 

--- a/examples/split.js
+++ b/examples/split.js
@@ -11,6 +11,6 @@ const limit = options.first ? 1 : undefined;
 console.log(program.args[0].split(options.separator, limit));
 
 // Try the following:
-//    node split -s / --fits a/b/c
-//    node split -s / --first a/b/c
+//    node split -s - --fits a-b-c
+//    node split -s - --first a-b-c
 //    node split --separator=, a,b,c

--- a/examples/string-util.js
+++ b/examples/string-util.js
@@ -33,6 +33,6 @@ program.parse();
 // Try the following:
 //    node string-util
 //    node string-util help split
-//    node string-util split --separator=/ a/b/c
+//    node string-util split --separator=- a-b-c
 //    node string-util split --first a,b,c
 //    node string-util join a b c d


### PR DESCRIPTION
## Summary

Add documentation warning about forward slash (`/`) argument expansion in Git Bash (MINGW64) on Windows.

Closes #2380

## Changes

- Added new section "Windows MINGW64 / Git Bash" to both English and Chinese READMEs
- Documents the MSYS2 path conversion behavior that affects slash arguments
- Provides practical workarounds for users encountering this issue

## Workarounds Documented

1. Use a different character instead of `/`
2. Double the slash: `--separator //`
3. Set `MSYS_NO_PATHCONV` environment variable
4. Quote with leading slash: `--separator '///'`

## References

- [MSYS2 Filesystem Paths Documentation](https://www.msys2.org/docs/filesystem-paths/#automatic-unix-windows-path-conversion)