### PR TITLE
Modernise tsconfig targets, and add .cjs

### DIFF
--- a/tsconfig.js.json
+++ b/tsconfig.js.json
@@ -9,6 +9,7 @@
     /* All JavaScript targets from tsconfig.json include. */
     "*.js",
     ".prettierrc.js" /* missed by above pattern */,
+    "*.cjs",
     "*.mjs",
     "lib/**/*.js",
   ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,9 +10,9 @@
   */
   /* Visit https://aka.ms/tsconfig to read more about tsconfig configuration. */
   "compilerOptions": {
-    "lib": ["es2021"],
-    "module": "node16",
-    "target": "es2021",
+    "lib": ["es2024"],
+    "module": "nodenext",
+    "target": "es2024",
 
     "allowJs": true,
     "checkJs": true,
@@ -28,12 +28,12 @@
     "skipLibCheck": false /* we want to check our hand crafted definitions */,
     "forceConsistentCasingInFileNames": true,
     "esModuleInterop": true /* common TypeScript config */,
-    "resolveJsonModule": true /* needed for globals in node_modules?! */,
   },
   "include": [
     /* JavaScript. Should match includes in tsconfig.js.json. */
     "*.js",
     ".prettierrc.js" /* missed by above pattern */,
+    "*.cjs",
     "*.mjs",
     "lib/**/*.js",
     /* TypeScript. Should match includes in tsconfig.ts.json. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,9 +10,9 @@
   */
   /* Visit https://aka.ms/tsconfig to read more about tsconfig configuration. */
   "compilerOptions": {
-    "lib": ["es2024"],
+    "lib": ["ESNext"],
     "module": "nodenext",
-    "target": "es2024",
+    "target": "esnext",
 
     "allowJs": true,
     "checkJs": true,


### PR DESCRIPTION
## Problem

- somewhat old settings for tsconfig lib/module/target
- `resolveJsonModule` was work-around and not sure why needed
- now have some `.cjs` files

## Solution

The tsconfig targets are not critical as only type checking and not generating code. Use `nodenext` and `esnext` for simple modern targets that do not need mainteance.

Add `*.cjs` to javascript file patterns.