### PR TITLE
Use simple match in test (to avoid warning about expensive regex)

### DIFF
--- a/tests/command.help.test.js
+++ b/tests/command.help.test.js
@@ -118,7 +118,10 @@ Commands:
 
   test('when help short flag masked then not displayed in helpInformation', () => {
     const program = new commander.Command();
-    program.option('-o, --ordinary', 'select host');
+    program.option(
+      '-o, --ordinary',
+      'example option for checking expected help format',
+    );
     program.option('-h, --host', 'select host');
     const helpInformation = program.helpInformation();
     // sanity check how option is normally displayed

--- a/tests/command.help.test.js
+++ b/tests/command.help.test.js
@@ -118,9 +118,14 @@ Commands:
 
   test('when help short flag masked then not displayed in helpInformation', () => {
     const program = new commander.Command();
+    program.option('-o, --ordinary', 'select host');
     program.option('-h, --host', 'select host');
     const helpInformation = program.helpInformation();
-    assert(!/\W-h\W.*display help/.test(helpInformation));
+    // sanity check how option is normally displayed
+    assert(helpInformation.includes('-o, --ordinary'));
+    // check help listed as --help not -h, --help
+    assert(helpInformation.includes('--help'));
+    assert(!helpInformation.includes('-h, --help'));
   });
 
   test('when both help flags masked then not displayed in helpInformation', () => {

--- a/tests/command.help.test.js
+++ b/tests/command.help.test.js
@@ -118,17 +118,11 @@ Commands:
 
   test('when help short flag masked then not displayed in helpInformation', () => {
     const program = new commander.Command();
-    program.option(
-      '-o, --ordinary',
-      'example option for checking expected help format',
-    );
     program.option('-h, --host', 'select host');
     const helpInformation = program.helpInformation();
-    // sanity check how option is normally displayed
-    assert(helpInformation.includes('-o, --ordinary'));
-    // check help listed as --help not -h, --help
-    assert(helpInformation.includes('--help'));
-    assert(!helpInformation.includes('-h, --help'));
+    assert(helpInformation.includes(' -h, --host'));
+    assert(!helpInformation.includes(' -h, --help'));
+    assert(helpInformation.includes(' --help'));
   });
 
   test('when both help flags masked then not displayed in helpInformation', () => {


### PR DESCRIPTION
## Problem

CodeQL reports:

> Polynomial regular expression used on uncontrolled data

for regex `assert(!/\W-h\W.*display help/.test(helpInformation));`

## Solution

This isn't a vulnerability since only used within test with controlled data, but want to fix warning/error anyway.

Just replace regex with some simple string matches.
