### PR TITLE
Fix examples/using-esm-from-commonjs for prerelease

### DIFF
--- a/examples/using-esm-from-commonjs/jest-javascript/package.json
+++ b/examples/using-esm-from-commonjs/jest-javascript/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "type": "commonjs",
   "dependencies": {
-    "commander": "^15.0.0"
+    "commander": "^15.0.0-0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.28.6",

--- a/examples/using-esm-from-commonjs/jest-typescript/package.json
+++ b/examples/using-esm-from-commonjs/jest-typescript/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "type": "commonjs",
   "dependencies": {
-    "commander": "^15.0.0"
+    "commander": "^15.0.0-0"
   },
   "devDependencies": {
     "jest": "^30.2.0",


### PR DESCRIPTION
## Problem

I put in `^15.0.0` as a placeholder for the Commander version in the example packages, but that does not work with the prerelease.

## Solution

Now we have a prerelease, use that. (I could have done this in advance but didn't work it out at the time!)