### PR TITLE
Fix missing return after help() in _dispatchHelpCommand()

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -1380,10 +1380,12 @@ Expecting one of '${allowedValues.join("', '")}'`);
   _dispatchHelpCommand(subcommandName) {
     if (!subcommandName) {
       this.help();
+      return;
     }
     const subCommand = this._findCommand(subcommandName);
     if (subCommand && !subCommand._executableHandler) {
       subCommand.help();
+      return;
     }
 
     // Fallback to parsing the help flag to invoke the help.

--- a/tests/command.helpCommand.test.js
+++ b/tests/command.helpCommand.test.js
@@ -177,4 +177,21 @@ describe('help command processed on correct command', () => {
       program.parse(['help', 'sub'], { from: 'user' });
     }).toThrow('sub help');
   });
+
+  test('when "program help" with non-throwing exitOverride then should not fall through to dispatch', () => {
+    const program = new commander.Command();
+    program.command('sub1');
+    program.exitOverride(() => {
+      // Intentionally not throwing
+    });
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});
+    try {
+      const dispatchSpy = jest.spyOn(program, '_dispatchSubcommand');
+      program.parse(['help'], { from: 'user' });
+      expect(dispatchSpy).not.toHaveBeenCalled();
+      dispatchSpy.mockRestore();
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
 });


### PR DESCRIPTION
<!--
The text in these markdown comments is instructions that will not appear in the displayed pull request,
and can be deleted.

Please submit pull requests against the develop branch.

Follow the existing code style. Check the tests succeed, including format and lint.
  npm run test
  npm run check

Don't update the CHANGELOG or package version number. That gets done by maintainers when preparing the release.

Commander currently has zero production dependencies. That isn't a hard requirement, but is a simple story. Requests which 
add a dependency are much less likely to be accepted, and we are likely to ask for alternative approaches to avoid the dependency.
-->

## Problem

<!--
What problem are you solving?
What Issues does this relate to?
Show the broken output if appropriate.
-->

`_dispatchHelpCommand()` does not return after calling `this.help()` or `subCommand.help()`.
When `exitOverride` is set with a non-throwing callback and `process.exit` is overridden,
execution falls through and calls `_dispatchSubcommand(undefined, ...)`,
which results in a `TypeError: Cannot read properties of undefined (reading '_prepareForParse')`.

## Solution

<!--
How did you solve the problem? 
Show the fixed output if appropriate.

There are a lot of forms of documentation which could need updating for a change in functionality. It
is ok if you want to show us the code to discuss before doing the extra work, and
you should say so in your comments so we focus on the concept first before talking about all the other pieces:

- TypeScript typings
- JSDoc documentation in code
- tests
- README
- examples/
-->

Added `return` statements after `this.help()` calls in `_dispatchHelpCommand()` so that execution stops after displaying help, regardless of how `exitOverride` is configured.
Added a test to verify the fix.

## ChangeLog

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->
