### PR TITLE
feat: add plugin support using `register`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1151,6 +1151,22 @@ program
   });
 ```
 
+### Composable Plugins using `register`
+
+Use `program.register(plugin)` (from `Command` class) to make it easier to change the behavior. `plugin` is a function that receives the `Command` object.
+
+Example:
+
+```js
+program
+  .register(prettyErrors)
+  .parse();
+
+function prettyErrors(command) {
+  command.configureOutput({/* snip */});
+}
+```
+
 ### Additional documentation
 
 There is more information available about:

--- a/examples/plugins.js
+++ b/examples/plugins.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+const { Command } = require('commander');
+
+new Command()
+  .option('-c, --compress')
+  .command('sub-command')
+  .register(prettyErrors)
+  .register(setMeta)
+  .register(logger)
+  .action(() => {
+    // noop
+  })
+  .parse();
+
+function prettyErrors(command) {
+  function errorColor(str) {
+    // Add ANSI escape codes to display text in red.
+    return `\x1b[31m${str}\x1b[0m`;
+  }
+
+  command.configureOutput({
+    // Visibly override write routines as example!
+    writeOut: (str) => process.stdout.write(`[OUT] ${str}`),
+    writeErr: (str) => process.stdout.write(`[ERR] ${str}`),
+    // Highlight errors in color.
+    outputError: (str, write) => write(errorColor(str)),
+  });
+}
+
+function setMeta(command) {
+  command.version('1.2.3');
+}
+
+function logger(command) {
+  command.option('--trace');
+  command.hook('preAction', (thisCommand, actionCommand) => {
+    if (thisCommand.opts().trace) {
+      console.log(
+        `About to call action handler for subcommand: ${actionCommand.name()}`,
+      );
+      console.log('arguments: %O', actionCommand.args);
+      console.log('options: %o', actionCommand.opts());
+    }
+  });
+}
+
+// Try the following:
+//    node plugins.js --version
+//    node plugins.js --unknown
+//    node plugins.js --help
+//    node plugins.js --trace
+//    node plugins.js

--- a/lib/command.js
+++ b/lib/command.js
@@ -2692,6 +2692,14 @@ Expecting one of '${allowedValues.join("', '")}'`);
       this._exit(0, 'commander.helpDisplayed', '(outputHelp)');
     }
   }
+
+  register(plugin) {
+    const result = plugin(this);
+    if (result != null) {
+      return result;
+    }
+    return this;
+  }
 }
 
 /**

--- a/tests/command.register.test.ts
+++ b/tests/command.register.test.ts
@@ -1,0 +1,46 @@
+import { expectType } from 'tsd';
+import commander from '../';
+
+describe('program with plugins', () => {
+  test('plugin that extends command, no return', () => {
+    function pluginExtendCommand(command: commander.Command) {
+      Object.assign(command, {
+        foo: () => 'Hello World',
+      });
+    }
+
+    const program = new commander.Command();
+
+    const result = program.register(pluginExtendCommand);
+
+    expectType<typeof program>(result);
+
+    expect(result).toEqual(result); // should be the same instance
+
+    expect(result).toHaveProperty('foo'); // should have new properties
+    expect(result).toHaveProperty('name'); // should have existing properties
+    expect((result as commander.Command & { foo(): string }).foo()).toEqual(
+      'Hello World',
+    );
+  });
+
+  test('plugin that extends command, return, same instance', () => {
+    function pluginExtendCommand(command: commander.Command) {
+      return Object.assign(command, {
+        foo: () => 'Hello World',
+      });
+    }
+
+    const program = new commander.Command();
+
+    const result = program.register(pluginExtendCommand);
+
+    expectType<typeof program & { foo(): string }>(result);
+
+    expect(result).toEqual(result); // should be the same instance
+
+    expect(result).toHaveProperty('foo'); // should have new properties
+    expect(result).toHaveProperty('name'); // should have existing properties
+    expect(result.foo()).toEqual('Hello World');
+  });
+});

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1089,6 +1089,11 @@ export class Command {
    * Add a listener (callback) for when events occur. (Implemented using EventEmitter.)
    */
   on(event: string | symbol, listener: (...args: any[]) => void): this;
+
+  /** Register a plugin. */
+  register<T>(
+    plugin: (command: this) => T,
+  ): NonNullable<T> extends void ? this : NonNullable<T>;
 }
 
 export interface CommandOptions {


### PR DESCRIPTION
<!--
The text in these markdown comments is instructions that will not appear in the displayed pull request,
and can be deleted.

Please submit pull requests against the develop branch.

Follow the existing code style. Check the tests succeed, including format and lint.
  npm run test
  npm run check

Don't update the CHANGELOG or package version number. That gets done by maintainers when preparing the release.

Commander currently has zero production dependencies. That isn't a hard requirement, but is a simple story. Requests which 
add a dependency are much less likely to be accepted, and we are likely to ask for alternative approaches to avoid the dependency.
-->

## Problem


<!--
What problem are you solving?
What Issues does this relate to?
Show the broken output if appropriate.
-->


Add a composable plugin interface using the `Command.register(plugin)` api.

The `register` method is similar to how [fastify does plugins](https://fastify.dev/docs/latest/Reference/Plugins/): `fastify.register(plugin)`

This makes it easier to reuse code when creating multiple commands using method chaining.

```js
new Command()
  .option('-c, --compress')
  .command('sub-command')
  .register(prettyErrors)
  .register(setMeta)
  .register(logger)
  .action(() => {
    // noop
  })
  .parse();

// vs

const command = new Command() // forces binding the new command to a variable
  .option('-c, --compress')
  .command('sub-command')
  .action(() => {
    // noop
  })
  .parse();

prettyErrors(command);
setMeta(command);
logger(command);

// or worse
logger(
  setMeta(
    prettyErrors(
      new Command()
        .option('-c, --compress')
        .command('sub-command')
        .action(() => {
          // noop
        })
        .parse(),
    ),
  ),
);
```

## Solution

<!--
How did you solve the problem? 
Show the fixed output if appropriate.

There are a lot of forms of documentation which could need updating for a change in functionality. It
is ok if you want to show us the code to discuss before doing the extra work, and
you should say so in your comments so we focus on the concept first before talking about all the other pieces:

- TypeScript typings
- JSDoc documentation in code
- tests
- README
- examples/
-->

See the full example in https://github.com/danielpza/commander.js/blob/517749ff6094df484c701aaa3d5513e4e2eb1014/examples/plugins.js

## ChangeLog

<!--
Optional. Suggest a line for adding to the CHANGELOG to summarise your change.
-->

Add plugin support using `register` api similar to fastify
