### PR TITLE
fix: skip help text wrapping when output is not a TTY

### DIFF
--- a/lib/help.js
+++ b/lib/help.js
@@ -27,7 +27,7 @@ class Help {
    * @param {{ error?: boolean, helpWidth?: number, outputHasColors?: boolean }} contextOptions
    */
   prepareContext(contextOptions) {
-    this.helpWidth = this.helpWidth ?? contextOptions.helpWidth ?? 80;
+    this.helpWidth = this.helpWidth ?? contextOptions.helpWidth;
   }
 
   /**
@@ -659,15 +659,16 @@ class Help {
 
     // Format the description.
     const spacerWidth = 2; // between term and description
-    const helpWidth = this.helpWidth ?? 80; // in case prepareContext() was not called
-    const remainingWidth = helpWidth - termWidth - spacerWidth - itemIndent;
+    const helpWidth = this.helpWidth; // undefined means no wrapping (e.g. piped output)
     let formattedDescription;
     if (
-      remainingWidth < this.minWidthToWrap ||
+      helpWidth === undefined ||
+      helpWidth - termWidth - spacerWidth - itemIndent < this.minWidthToWrap ||
       helper.preformatted(description)
     ) {
       formattedDescription = description;
     } else {
+      const remainingWidth = helpWidth - termWidth - spacerWidth - itemIndent;
       const wrappedDescription = helper.boxWrap(description, remainingWidth);
       formattedDescription = wrappedDescription.replace(
         /\n/g,

--- a/tests/command.configureOutput.test.js
+++ b/tests/command.configureOutput.test.js
@@ -264,22 +264,19 @@ test('when no custom setup and call formatHelp direct then effective helpWidth i
   expect(wrapWidth).toBe(80);
 });
 
-test('when no custom setup and call formatItem direct then effective helpWidth is fallback 80', () => {
-  // Not an important case, but filling out testing coverage.
+test('when no custom setup and call formatItem direct then no wrapping (helpWidth undefined)', () => {
+  // When helpWidth is undefined (e.g. piped output, no TTY), descriptions should not be wrapped.
   const helper = new commander.Help();
-  let wrapWidth;
-  helper.boxWrap = (str, width) => {
-    wrapWidth = wrapWidth ?? width;
+  let wrapCalled = false;
+  helper.boxWrap = () => {
+    wrapCalled = true;
     return '';
   };
 
   const termWidth = 8;
   helper.formatItem('term', termWidth, 'description', helper);
-  const itemIndent = 2;
-  const spacerWidth = 2; // between term and description
-  const remainingWidth = 80 - termWidth - spacerWidth - itemIndent;
 
-  expect(wrapWidth).toBe(remainingWidth);
+  expect(wrapCalled).toBe(false);
 });
 
 test('when set configureOutput then get configureOutput', () => {


### PR DESCRIPTION
Fixes #2508

## Problem

When command output is piped (not a TTY), `process.stdout.columns` is `undefined`. Commander was defaulting to 80 columns for wrapping help text, causing option descriptions to be unnecessarily broken across lines.

## Fix

- In `prepareContext()`: remove the `?? 80` fallback so `helpWidth` stays `undefined` when no TTY width is available
- In `formatItem()`: when `helpWidth` is `undefined`, skip wrapping entirely (no line breaks in descriptions)
- Updated test to verify `boxWrap` is not called when `helpWidth` is `undefined`

## Behavior change

- **TTY (terminal)**: wrapping still works as before using actual terminal width
- **Piped output**: descriptions no longer wrapped — full text on each line
- **Custom `helpWidth`**: still respected as before

All 1367 tests pass.