### PR TITLE
Update details for 15.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 <!-- markdownlint-disable MD024 -->
 <!-- markdownlint-disable MD004 -->
 
-## [15.0.0-0] (2025-02-22)
+## [15.0.0] (2025-05-29)
 
 Commander 15 is ESM only. This is expected to be seamless for ESM consumers, but some CommonJS consumers may hit issues with tooling requiring configuration for ESM-only dependencies. See Migration Tips below.
 
-The release of Commander 15 in May 2026 will move Commander 14 into maintenance. Commander 14 will get security updates for 
+The release of Commander 15 moves Commander 14 into maintenance. Commander 14 will get security updates for
 12 months (to May 2027). For more info see [Release Policy](./docs/release-policy.md).
 
 ### Added
@@ -43,6 +43,10 @@ or bundler.
 
 If you have problems using Commander 15 in your environment, one option is stay on Commander 14 for now. Commander 14 will
 get security updates until May 2027 and things will hopefully improve for your setup in the meantime.
+
+## [15.0.0-0] (2025-02-22)
+
+(Released as 15.0.0)
 
 ## [14.0.3] (2026-01-31)
 
@@ -1575,6 +1579,7 @@ program
 [#1028]: https://github.com/tj/commander.js/pull/1028
 
 [Unreleased]: https://github.com/tj/commander.js/compare/master...develop
+[15.0.0]: https://github.com/tj/commander.js/compare/v15.0.0...v14.0.3
 [15.0.0-0]: https://github.com/tj/commander.js/compare/v14.0.3...v15.0.0-0
 [14.0.3]: https://github.com/tj/commander.js/compare/v14.0.2...v14.0.3
 [14.0.2]: https://github.com/tj/commander.js/compare/v14.0.1...v14.0.2

--- a/Readme_zh-CN.md
+++ b/Readme_zh-CN.md
@@ -1060,7 +1060,7 @@ program
 
 ## 支持
 
-当前版本的 Commander 在 LTS 版本的 Node.js 上完全支持。并且至少需要 v18。
+当前版本的 Commander 在 LTS 版本的 Node.js 上完全支持。并且至少需要 v22.12。
 （使用更低版本 Node.js 的用户建议安装更低版本的 Commander）
 
 社区支持请访问项目的 [Issues](https://github.com/tj/commander.js/issues)。

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -11,6 +11,6 @@ The current release line gets all updates: features, bug fixes, and security upd
 
 | Version | First Release | Release Note |  Status | End of Life |
 | ------- | ------------- | - | ------- | ----------- |
-| 14.x | 2025-05-18 | [14.0.0](https://github.com/tj/commander.js/releases/tag/v14.0.0) | current | - |
-| 13.x | 2024-12-30 | [13.0.0](https://github.com/tj/commander.js/releases/tag/v13.0.0) | maintenance | 2026-05-18 |
-| <13 | | | end of life | |
+| 15.x | 2026-05-29 | [15.0.0](https://github.com/tj/commander.js/releases/tag/v15.0.0) | current | - |
+| 14.x | 2025-05-18 | [14.0.0](https://github.com/tj/commander.js/releases/tag/v14.0.0) | maintenance | 2027-05-29 |
+| <14 | | | end of life | |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commander",
-  "version": "15.0.0-0",
+  "version": "15.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commander",
-      "version": "15.0.0-0",
+      "version": "15.0.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "commander",
-  "version": "15.0.0-0",
+  "version": "15.0.0",
   "description": "the complete solution for node.js command-line programs",
   "keywords": [
     "commander",


### PR DESCRIPTION
Preparing for 15.0.0 release. I put in a date of next weekend, but we could do it this weekend if you like @abetomo ?  Just when suits you, no rush.

For interest:
- the `15.0.0-0` version has had 4162 downloads from [npmjs](https://www.npmjs.com/package/commander?activeTab=versions), which is our most ever for a prerelease. 
- v13 of Commander went EOL 4 days ago.