### PR TITLE
fix: throw clear error for long option names with trailing or consecutive dashes

### DIFF
--- a/lib/option.js
+++ b/lib/option.js
@@ -373,5 +373,17 @@ function splitOptionFlags(flags) {
       `option creation failed due to no flags found in '${flags}'.`,
     );
 
+  // Long flag name (the part after '--') must not have trailing or consecutive dashes,
+  // as those produce empty segments in camelcase conversion and cause a TypeError.
+  if (longFlag) {
+    const longFlagName = longFlag.slice(2); // strip '--'
+    if (longFlagName.endsWith('-') || longFlagName.includes('--')) {
+      const baseError = `option creation failed due to '${longFlag}' in option flags '${flags}'`;
+      throw new Error(
+        `${baseError}\n- long option name must not end with a dash or have consecutive dashes`,
+      );
+    }
+  }
+
   return { shortFlag, longFlag };
 }

--- a/tests/option.bad-flags.test.js
+++ b/tests/option.bad-flags.test.js
@@ -15,6 +15,8 @@ describe('when construct Option with unsupported flags then throw', () => {
     { flags: '-a,-b' }, // try all the separators
     { flags: '-a|-b' },
     { flags: '-a -b' },
+    { flags: '--trailing-dash-' }, // long option name with trailing dash
+    { flags: '--consecutive--dashes' }, // long option name with consecutive dashes
   ];
   for (const { flags } of flagsList) {
     test(`when construct Option with flags ${flags} then throw`, () => {


### PR DESCRIPTION
## Problem

A long option name with a trailing dash (e.g. `--foo-`) or consecutive inner dashes (e.g. `--foo--bar`) is silently accepted by the `longFlagExp` regex (`/^--[^-]/`) because that pattern only validates the third character. The bug is later when `attributeName()` is called — which happens inside `Command.option()`/`Command.addOption()` — the private `camelcase()` helper crashes:

```
program.option('--trailing-dash-', 'desc');
// TypeError: Cannot read properties of undefined (reading 'toUpperCase')
```

Root cause: `camelcase` splits on `'-'`, producing an empty string segment from the trailing or consecutive dashes. Accessing `''[0]` is `undefined`, so `undefined.toUpperCase()` throws.

## Solution

Add a post-resolution validation in `splitOptionFlags()` that checks the name portion of `longFlag` (everything after stripping `'--'`). If the name ends with `'-'` or contains `'--'`, throw the standard `option creation failed` error with a clear explanation. This is consistent with the existing checks for unsupported flag patterns (too many flags, unrecognised formats, etc.).

```
new Option('--foo-');
// Error: option creation failed due to '--foo-' in option flags '--foo-'
// - long option name must not end with a dash or have consecutive dashes
```

## ChangeLog

- Fix: `Option` constructor now throws a clear error for long option names ending with a dash or containing consecutive dashes, instead of crashing with a TypeError in `attributeName()`.