### PR TITLE
fix: use Infinity instead of 80 for helpWidth when columns is undefined (#2508)

### DIFF
--- a/lib/help.js
+++ b/lib/help.js
@@ -28,7 +28,7 @@ export class Help {
    * @param {{ error?: boolean, helpWidth?: number, outputHasColors?: boolean }} contextOptions
    */
   prepareContext(contextOptions) {
-    this.helpWidth = this.helpWidth ?? contextOptions.helpWidth ?? 80;
+    this.helpWidth = this.helpWidth ?? contextOptions.helpWidth ?? Infinity;
   }
 
   /**
@@ -443,7 +443,7 @@ export class Help {
 
   formatHelp(cmd, helper) {
     const termWidth = helper.padWidth(cmd, helper);
-    const helpWidth = helper.helpWidth ?? 80; // in case prepareContext() was not called
+    const helpWidth = helper.helpWidth ?? Infinity; // in case prepareContext() was not called
 
     function callFormatItem(term, description) {
       return helper.formatItem(term, termWidth, description, helper);
@@ -660,7 +660,7 @@ export class Help {
 
     // Format the description.
     const spacerWidth = 2; // between term and description
-    const helpWidth = this.helpWidth ?? 80; // in case prepareContext() was not called
+    const helpWidth = this.helpWidth ?? Infinity; // in case prepareContext() was not called
     const remainingWidth = helpWidth - termWidth - spacerWidth - itemIndent;
     let formattedDescription;
     if (

--- a/tests/command.infinite-width-piping.test.js
+++ b/tests/command.infinite-width-piping.test.js
@@ -1,0 +1,70 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import * as commander from '../index.js';
+
+describe('Infinite width when piping (#2508)', () => {
+  test('when process.stdout.columns is undefined then helpWidth is Infinity (not 80)', () => {
+    const program = new commander.Command();
+    program
+      .option('-d, --debug', 'enable debug mode with detailed logging output for troubleshooting purposes')
+      .option('-v, --verbose', 'enable verbose output showing detailed information during execution');
+
+    // Mock getOutHelpWidth to return undefined (simulating pipe scenario)
+    const customProgram = program.configureOutput({
+      getOutHelpWidth: () => undefined,
+    });
+
+    // Get the help output
+    const helpOutput = customProgram.helpInformation();
+
+    // When helpWidth is Infinity, descriptions should NOT be wrapped
+    // The debug option description should remain on a single line after the option
+    // If wrapped to 80, there would be line breaks in the description
+    assert.match(helpOutput, /-d, --debug\s+enable debug mode with detailed logging output for troubleshooting purposes/);
+    assert.match(helpOutput, /-v, --verbose\s+enable verbose output showing detailed information during execution/);
+  });
+
+  test('when process.stderr.columns is undefined then error helpWidth is Infinity', () => {
+    const program = new commander.Command();
+    program.option('-d, --debug', 'enable debug mode with detailed logging output for troubleshooting purposes');
+
+    // Mock getErrHelpWidth to return undefined (simulating pipe scenario)
+    const customProgram = program.configureOutput({
+      getErrHelpWidth: () => undefined,
+    });
+
+    // Get the error help output
+    const helpOutput = customProgram.helpInformation({ error: true });
+
+    // Should not be wrapped
+    assert.match(helpOutput, /-d, --debug\s+enable debug mode with detailed logging output for troubleshooting purposes/);
+  });
+
+  test('when helpWidth is Infinity then boxWrap returns string unchanged', () => {
+    const program = new commander.Command();
+    const helper = new commander.Help();
+
+    helper.prepareContext({ helpWidth: Infinity });
+
+    const longText = 'enable debug mode with detailed logging output for troubleshooting purposes that goes on and on without any line breaks at all in this description text';
+    const wrapped = helper.boxWrap(longText, Infinity);
+
+    // With Infinity width, boxWrap should not wrap
+    assert.equal(wrapped, longText);
+  });
+
+  test('when helpWidth is explicitly set to a number then wrapping works', () => {
+    const program = new commander.Command();
+    program.configureOutput({
+      getOutHelpWidth: () => 60,
+    });
+    program.option('-d, --debug', 'enable debug mode with detailed logging output for troubleshooting purposes');
+
+    const helpOutput = program.helpInformation();
+
+    // With explicit width, wrapping should occur
+    // The description should be wrapped to fit within the width
+    assert.ok(helpOutput.includes('enable debug mode'));
+    assert.ok(helpOutput.includes('detailed logging'));
+  });
+});


### PR DESCRIPTION
Fixes #2508

When piping command output, `process.stdout.columns` is undefined, causing help text to be wrapped to 80 chars. Using Infinity prevents unwanted wrapping in pipe scenarios.

**Changes:**
- `prepareContext()`: 80 → Infinity
- `formatHelp()`: 80 → Infinity  
- `formatItem()`: 80 → Infinity
- Tests added in `command.infinite-width-piping.test.js`