### PR TITLE
fix: avoid TypeError in camelcase for empty word segments

### DIFF
--- a/lib/option.js
+++ b/lib/option.js
@@ -315,7 +315,7 @@ export class DualOptions {
 
 function camelcase(str) {
   return str.split('-').reduce((str, word) => {
-    return str + word[0].toUpperCase() + word.slice(1);
+    return str + (word ? word[0].toUpperCase() + word.slice(1) : '');
   });
 }
 

--- a/tests/options.camelcase.test.js
+++ b/tests/options.camelcase.test.js
@@ -46,4 +46,18 @@ describe('option property is camelCase of option name', () => {
     program.parse(['node', 'test', '--Myoption']);
     assert.equal(program.opts().Myoption, true);
   });
+
+  test('when option name ends with a dash then trailing dash is ignored', () => {
+    const program = new commander.Command();
+    program.option('--my-option-', 'description');
+    program.parse(['node', 'test', '--my-option-']);
+    assert.equal(program.opts().myOption, true);
+  });
+
+  test('when option name has consecutive dashes then empty word is ignored', () => {
+    const program = new commander.Command();
+    program.option('--my--option', 'description');
+    program.parse(['node', 'test', '--my--option']);
+    assert.equal(program.opts().myOption, true);
+  });
 });


### PR DESCRIPTION
## Problem

A long option name with a trailing dash (e.g. `--foo-`) or consecutive inner dashes (e.g. `--foo--bar`) crashes when Commander builds the option's attribute name:

```js
const { Option } = require('commander');
new Option('--foo-').attributeName();
// TypeError: Cannot read properties of undefined (reading 'toUpperCase')

program.option('--my--option', 'desc');
// TypeError: Cannot read properties of undefined (reading 'toUpperCase')
```

The internal `camelcase()` helper splits the name on `'-'`, which yields empty-string segments for these inputs. `word[0]` is then `undefined`, so `undefined.toUpperCase()` throws.

The README documents that multi-word options are normalized to camelCase (e.g. `--template-engine` → `templateEngine`), so an option with extra/trailing dashes hitting an opaque internal `TypeError` is a rough edge rather than the intended behavior.

## Solution

Make the helper robust by skipping empty word segments, instead of crashing:

```js
function camelcase(str) {
  return str.split('-').reduce((str, word) => {
    return str + (word ? word[0].toUpperCase() + word.slice(1) : '');
  });
}
```

This is the minimal "tidy the helper" approach rather than adding new detection/error logic. Behavior for every previously-valid option name is unchanged — the reduce stays unseeded so the first word keeps its case (`--my-option` → `myOption`, `--my-OPTION` → `myOPTION`). Only the previously-crashing inputs change, and now produce a sensible name:

- `--my-option-` → `myOption` (trailing dash ignored)
- `--my--option` → `myOption` (empty segment ignored)

This follows up #2532, where the suggestion was:

> However, if fixing the camelcase helper was tidy, I would consider that.

## ChangeLog

- Fixed: long option names with a trailing dash or consecutive dashes no longer throw a `TypeError` when building the camelCase attribute name.

## Tests

Added two cases to `tests/options.camelcase.test.js` that fail without the change (with the `TypeError`) and pass with it. Full suite, lint, format, and type checks pass:

- `npm run test`
- `npm run check`
