### PR TITLE
docs: fix two syntax errors in JSDoc @example blocks

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -2366,7 +2366,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    * (This does not override a group set directly on the subcommand using .helpGroup().)
    *
    * @example
-   * program.commandsGroup('Development Commands:);
+   * program.commandsGroup('Development Commands:');
    * program.command('watch')...
    * program.command('lint')...
    * ...
@@ -2562,7 +2562,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    * Pass in false to disable the built-in help option.
    *
    * @example
-   * program.helpOption('-?, --help' 'show help'); // customise
+   * program.helpOption('-?, --help', 'show help'); // customise
    * program.helpOption(false); // disable
    *
    * @param {(string | boolean)} flags


### PR DESCRIPTION
## Problem

Two of the JSDoc `@example` snippets in `lib/command.js` are not valid JavaScript, so anyone copying them to try out the API hits a syntax error.

`commandsGroup()` example (was missing the closing quote, unterminated string):

```js
program.commandsGroup('Development Commands:);
```

`helpOption()` example (was missing the comma between the two arguments):

```js
program.helpOption('-?, --help' 'show help'); // customise
```

Both throw when run as-is. Checking each snippet with `node --check`:

```
SyntaxError: Invalid or unexpected token        // commandsGroup example
SyntaxError: missing ) after argument list      // helpOption example
```

## Solution

Add the missing closing quote and the missing comma so both examples match the documented signatures and parse cleanly:

```js
program.commandsGroup('Development Commands:');
program.helpOption('-?, --help', 'show help'); // customise
```

After the change, each snippet passes `node --check`, and `npm test` (lint, unit tests, and type checks) is green.

## ChangeLog

Fixed two invalid JavaScript snippets in the JSDoc examples for `.commandsGroup()` and `.helpOption()`.
