### PR TITLE
docs: add Deno to install instructions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -62,6 +62,7 @@ For information about terms used in this document see: [terminology](./docs/term
 
 ```sh
 npm install commander
+deno install commander
 ```
 
 ## Quick Start

--- a/Readme.md
+++ b/Readme.md
@@ -62,6 +62,11 @@ For information about terms used in this document see: [terminology](./docs/term
 
 ```sh
 npm install commander
+```
+
+Or using [Deno](https://deno.land):
+
+```sh
 deno install commander
 ```
 


### PR DESCRIPTION
👋 Bartek from the Deno team here.

The install instructions list npm, but not Deno. Since Deno is a drop-in replacement for npm these days, I'd like to add a Deno line so Deno users have a copy-pasteable command, in parity with the others:

```sh
deno install commander
```

(As of Deno 2.8 there's no `npm:` prefix needed, it's the same command shape as `npm install commander`.)

Totally fine to close this if you'd rather keep the list short, no hard feelings. Happy to adjust wording, placement, or move it to a docs site instead.

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._
