### PR TITLE
fix: accept uppercase E exponent in negative number args

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -1768,7 +1768,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
     const negativeNumberArg = (arg) => {
       // return false if not a negative number
-      if (!/^-(\d+|\d*\.\d+)(e[+-]?\d+)?$/.test(arg)) return false;
+      if (!/^-(\d+|\d*\.\d+)([eE][+-]?\d+)?$/.test(arg)) return false;
       // negative number is ok unless digit used as an option in command hierarchy
       return !this._getCommandAndAncestors().some((cmd) =>
         cmd.options

--- a/tests/negatives.test.js
+++ b/tests/negatives.test.js
@@ -16,6 +16,10 @@ describe('negative numbers', () => {
       ['-1.2e3', true],
       ['-1.2e+3', true],
       ['-1.2e-3', true],
+      ['-1E3', true],
+      ['-1E+3', true],
+      ['-1E-3', true],
+      ['-1.2E3', true],
       ['-1e-3.0', false], // invalid number format
       ['--1 ', false], // invalid number format
       ['-0', true],


### PR DESCRIPTION
Commander accepts unescaped negative numbers as command-arguments and as optional/variadic option-arguments (README: "Negative numbers are special and are accepted as an option-argument"). The negative-number detector matches only a lowercase `e` exponent, so a negative number written with an uppercase `E` (`-1E3`, `-1.2E-3`) is not recognised and is rejected as an unknown option, even though JavaScript parses `-1E3` and `-1e3` identically (`Number('-1E3') === -1000`).

```js
program.argument('<temp>');
program.parse(['-1e3'], { from: 'user' }); // ok
program.parse(['-1E3'], { from: 'user' }); // error: unknown option '-1E3'
```

## Cause

In `lib/command.js`, `negativeNumberArg` tests the arg against `/^-(\d+|\d*\.\d+)(e[+-]?\d+)?$/`. The exponent group matches only lowercase `e`, so an uppercase-`E` negative fails the test, is then classified as an option, lands in the unknown list, and is reported by `unknownOption()`.

## Fix

Add the `i` flag to the pattern. The only letter in it is `e`, so the flag makes `E` and `e` both match and changes nothing else. Invalid inputs such as `-1X3`, `-0xFF` and `-1e3.0` stay rejected.

## Testing

Extended the existing parametrized `negativeNumbers` cases in `tests/negatives.test.js` with the uppercase-`E` forms. They fail on the current code (rejected as unknown option) and pass with the fix. The full suite stays green.
