### PR TITLE
Unskip .ts subcommand lookup test now that node 20 is EOL

### DIFF
--- a/tests/command.executableSubcommand.lookup.test.js
+++ b/tests/command.executableSubcommand.lookup.test.js
@@ -90,8 +90,7 @@ describe('executable subcommand lookup ', () => {
     },
   );
 
-  // This test currently fails on Node 20 when run as ESM because Node does not execute .ts files as JavaScript by default.
-  test.skip('when subcommand suffix is .ts then lookup succeeds', async () => {
+  test('when subcommand suffix is .ts then lookup succeeds', async () => {
     // We support looking for ts files for ts-node in particular, but don't need to test ts-node itself.
     // The subcommand is both plain JavaScript code for this test.
     const binLinkTs = path.join(


### PR DESCRIPTION
## Problem

The `.ts` executable-subcommand lookup test was skipped in the ESM-only migration (#2464) because it failed on Node 20, which does not run `.ts` files.

## Solution

Node 20 is now EOL and was dropped from the test matrix in #2520, and all current matrix versions (22.x, 24.x, 26.x) run the plain-JS `.ts` fixture via default type stripping. This un-skips the test and removes the stale comment; it passes locally on Node 22.22.2, 24.15.0, and 26.3.0.

## ChangeLog

Test-only change, no CHANGELOG entry needed.
