### PR TITLE
fix: detect a negated option's positive pair by attribute, not flag string

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -1128,14 +1128,18 @@ Expecting one of '${allowedValues.join("', '")}'`);
             this.getOptionValue(option.attributeName()) === undefined,
         )
         .forEach((option) => {
-          // check for lone negated option: --no-foo without a --foo option
-          const positiveLongFlag = option.long.replace(/^--no-/, '--');
-          if (!this._findOption(positiveLongFlag)) {
-            this.setOptionValueWithSource(
-              option.attributeName(),
-              true,
-              'default',
-            );
+          // Check for lone negated option: a --no-foo without any positive
+          // option sharing its attribute. Matching by attribute (like
+          // DualOptions) rather than by reconstructing the --foo flag string
+          // also recognises a differently-spelled positive such as -f or
+          // --fooBar as the pair, so it is not wrongly treated as lone.
+          const attributeName = option.attributeName();
+          const hasPositiveOption = this.options.some(
+            (candidate) =>
+              !candidate.negate && candidate.attributeName() === attributeName,
+          );
+          if (!hasPositiveOption) {
+            this.setOptionValueWithSource(attributeName, true, 'default');
           }
         });
 

--- a/tests/options.bool.test.js
+++ b/tests/options.bool.test.js
@@ -120,6 +120,29 @@ describe('boolean option with non-boolean default', () => {
   });
 });
 
+describe('negated option paired with a differently-spelled positive', () => {
+  test('when short-only positive and negated then no implicit default', () => {
+    const program = new commander.Command();
+    program.option('-c', 'add cheese').option('--no-c', 'remove cheese');
+    program.parse([], { from: 'user' });
+    assert.equal(program.opts().c, undefined);
+  });
+
+  test('when camelCase positive and kebab-case negated then no implicit default', () => {
+    const program = new commander.Command();
+    program.option('--fooBar').option('--no-foo-bar');
+    program.parse([], { from: 'user' });
+    assert.equal(program.opts().fooBar, undefined);
+  });
+
+  test('when only negated (lone) then implicit default is still true', () => {
+    const program = new commander.Command();
+    program.option('--no-sauce');
+    program.parse([], { from: 'user' });
+    assert.equal(program.opts().sauce, true);
+  });
+});
+
 // Regression test for #1301 with `-no-` in middle of option
 describe('regression test for -no- in middle of option name', () => {
   test('when option not specified then value is undefined', () => {


### PR DESCRIPTION
### Problem

When only a negated option is defined, Commander gives it an implicit `true`
default; when a positive counterpart is *also* defined, it must not, because
the pair shares a single value (per the v15 behavior from #2405).

The "is there a positive counterpart?" check reconstructs the `--foo` long flag
from `--no-foo` and looks it up by **flag string**:

```js
const positiveLongFlag = option.long.replace(/^--no-/, '--');
if (!this._findOption(positiveLongFlag)) { /* treat as lone → default true */ }
```

So it misses a positive option that shares the same **attribute** but is spelled
differently — a short-only `-c`, or a camelCase `--fooBar` paired with a
kebab-case `--no-foo-bar`. Those `--no-*` options are then wrongly defaulted to
`true` when unused, instead of left `undefined`, silently flipping program logic:

```js
const p = new Command();
p.option('-c', 'add cheese').option('--no-c', 'remove cheese');
p.parse([], { from: 'user' });        // neither supplied
p.opts();  // { c: true }   ← expected {} (undefined)
```

The equivalent all-long dual (`--cheese` + `--no-cheese`) already behaves
correctly (`{}`), so the two spellings of the same construct diverge.

### Fix

Detect the positive counterpart by `attributeName()` — the same way the internal
`DualOptions` helper already pairs positive/negative options — instead of
reconstructing and matching the flag string. Any spelling of the positive option
is then recognised as the pair. A genuinely lone `--no-*` option is unaffected
and still defaults to `true`.

### Test

Added cases in `tests/options.bool.test.js` for a short-only positive (`-c` +
`--no-c`) and a camelCase/kebab mismatch (`--fooBar` + `--no-foo-bar`), asserting
the value stays `undefined` when unused, plus a lone `--no-sauce` asserting the
`true` default is preserved. The two mismatch cases fail on `main`; all pass with
the fix, and the full suite is green (1375 pass, 0 fail).
