### PR TITLE
feat: allow custom env bag in parse options

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -57,6 +57,8 @@ export class Command extends EventEmitter {
     this._showHelpAfterError = false;
     this._showSuggestionAfterError = true;
     this._savedState = null; // used in save/restoreStateBeforeParse
+    /** @type {NodeJS.ProcessEnv | Record<string, string | undefined>} */
+    this._env = process.env; // overridable via parse options
 
     // see configureOutput() for docs
     this._outputConfiguration = {
@@ -1075,11 +1077,13 @@ Expecting one of '${allowedValues.join("', '")}'`);
    * @param {string[]} [argv] - optional, defaults to process.argv
    * @param {object} [parseOptions] - optionally specify style of options with from: node/user/electron
    * @param {string} [parseOptions.from] - where the args are from: 'node', 'user', 'electron'
+   * @param {NodeJS.ProcessEnv|Record<string, string|undefined>} [parseOptions.env] - env bag for `.env()` options (default: process.env)
    * @return {Command} `this` command for chaining
    */
 
   parse(argv, parseOptions) {
     this._prepareForParse();
+    this._env = parseOptions?.env ?? process.env;
     const userArgs = this._prepareUserArgs(argv, parseOptions);
     this._parseCommand([], userArgs);
 
@@ -1109,6 +1113,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
   async parseAsync(argv, parseOptions) {
     this._prepareForParse();
+    this._env = parseOptions?.env ?? process.env;
     const userArgs = this._prepareUserArgs(argv, parseOptions);
     await this._parseCommand([], userArgs);
 
@@ -1976,8 +1981,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
    * @private
    */
   _parseOptionsEnv() {
+    const env = this._env || process.env;
     this.options.forEach((option) => {
-      if (option.envVar && option.envVar in process.env) {
+      if (option.envVar && option.envVar in env) {
         const optionKey = option.attributeName();
         // Priority check. Do not overwrite cli or options from unknown source (client-code).
         if (
@@ -1989,7 +1995,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
           if (option.required || option.optional) {
             // option can take a value
             // keep very simple, optional always takes value
-            this.emit(`optionEnv:${option.name()}`, process.env[option.envVar]);
+            this.emit(`optionEnv:${option.name()}`, env[option.envVar]);
           } else {
             // boolean
             // keep very simple, only care that envVar defined and not the value

--- a/tests/options.env.test.js
+++ b/tests/options.env.test.js
@@ -369,3 +369,37 @@ describe('Option.env()', () => {
     });
   });
 });
+
+describe('ParseOptions.env', () => {
+  test('when parse options include env then uses custom env instead of process.env', () => {
+    const program = new commander.Command();
+    program.addOption(
+      new commander.Option('-p, --port <number>', 'port number').env('PORT'),
+    );
+
+    const hold = process.env.PORT;
+    delete process.env.PORT;
+
+    program.parse([], { from: 'user', env: { PORT: '4000' } });
+    assert.equal(program.opts().port, '4000');
+
+    if (hold === undefined) delete process.env.PORT;
+    else process.env.PORT = hold;
+  });
+
+  test('when parse options omit env then still uses process.env', () => {
+    const program = new commander.Command();
+    program.addOption(
+      new commander.Option('-p, --port <number>', 'port number').env('PORT'),
+    );
+
+    const hold = process.env.PORT;
+    process.env.PORT = '5000';
+
+    program.parse([], { from: 'user' });
+    assert.equal(program.opts().port, '5000');
+
+    if (hold === undefined) delete process.env.PORT;
+    else process.env.PORT = hold;
+  });
+});

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -340,7 +340,12 @@ export class Help {
 export type HelpConfiguration = Partial<Help>;
 
 export interface ParseOptions {
-  from: 'node' | 'electron' | 'user';
+  from?: 'node' | 'electron' | 'user';
+  /**
+   * Optional environment bag used for `.env()` option values instead of `process.env`.
+   * Useful for tests without mutating the real process environment.
+   */
+  env?: NodeJS.ProcessEnv | Record<string, string | undefined>;
 }
 export interface HelpContext {
   // optional parameter for .help() and .outputHelp()


### PR DESCRIPTION
## Summary
- Add `parseOptions.env` so `.env()` option values can be resolved from a caller-provided object instead of `process.env`.
- Useful for tests without mutating the real process environment.
- Updates TypeScript typings and adds tests.

Fixes #2549

## Test plan
- [x] `node --test tests/options.env.test.js` (41 passing)