### PR TITLE
fix: preserve -- for executable subcommands

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -11,6 +11,8 @@ import { Help } from './help.js';
 import { Option, DualOptions } from './option.js';
 import { suggestSimilar } from './suggestSimilar.js';
 
+const OptionTerminatorSymbol = Symbol('optionTerminator');
+
 export class Command extends EventEmitter {
   /**
    * Initialize a new `Command`.
@@ -1361,7 +1363,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    * @private
    */
 
-  _dispatchSubcommand(commandName, operands, unknown) {
+  _dispatchSubcommand(commandName, operands, unknown, optionTerminatorIndex) {
     const subCommand = this._findCommand(commandName);
     if (!subCommand) this.help({ error: true });
 
@@ -1374,9 +1376,17 @@ Expecting one of '${allowedValues.join("', '")}'`);
     );
     promiseChain = this._chainOrCall(promiseChain, () => {
       if (subCommand._executableHandler) {
-        this._executeSubCommand(subCommand, operands.concat(unknown));
+        const args = operands.concat(unknown);
+        if (optionTerminatorIndex !== undefined) {
+          args.splice(optionTerminatorIndex, 0, '--');
+        }
+        this._executeSubCommand(subCommand, args);
       } else {
-        return subCommand._parseCommand(operands, unknown);
+        return subCommand._parseCommand(
+          operands,
+          unknown,
+          optionTerminatorIndex,
+        );
       }
     });
     return promiseChain;
@@ -1559,16 +1569,32 @@ Expecting one of '${allowedValues.join("', '")}'`);
    * @private
    */
 
-  _parseCommand(operands, unknown) {
+  _parseCommand(operands, unknown, optionTerminatorIndex) {
     const parsed = this.parseOptions(unknown);
     this._parseOptionsEnv(); // after cli, so parseArg not called on both cli and env
     this._parseOptionsImplied();
+    const parsedOptionTerminatorIndex = parsed[OptionTerminatorSymbol];
+    if (
+      optionTerminatorIndex === undefined &&
+      parsedOptionTerminatorIndex !== undefined
+    ) {
+      optionTerminatorIndex = operands.length + parsedOptionTerminatorIndex;
+    }
     operands = operands.concat(parsed.operands);
     unknown = parsed.unknown;
     this.args = operands.concat(unknown);
 
     if (operands && this._findCommand(operands[0])) {
-      return this._dispatchSubcommand(operands[0], operands.slice(1), unknown);
+      const subCommandTerminatorIndex =
+        optionTerminatorIndex === undefined
+          ? undefined
+          : Math.max(0, optionTerminatorIndex - 1);
+      return this._dispatchSubcommand(
+        operands[0],
+        operands.slice(1),
+        unknown,
+        subCommandTerminatorIndex,
+      );
     }
     if (
       this._getHelpCommand() &&
@@ -1582,6 +1608,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
         this._defaultCommandName,
         operands,
         unknown,
+        optionTerminatorIndex,
       );
     }
     if (
@@ -1630,7 +1657,12 @@ Expecting one of '${allowedValues.join("', '")}'`);
     } else if (operands.length) {
       if (this._findCommand('*')) {
         // legacy default command
-        return this._dispatchSubcommand('*', operands, unknown);
+        return this._dispatchSubcommand(
+          '*',
+          operands,
+          unknown,
+          optionTerminatorIndex,
+        );
       }
       if (this.listenerCount('command:*')) {
         // skip option check, emit event for possible misspelling suggestion
@@ -1761,6 +1793,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     const operands = []; // operands, not options or values
     const unknown = []; // first unknown option and remaining unknown args
     let dest = operands;
+    let optionTerminatorIndex;
 
     function maybeOption(arg) {
       return arg.length > 1 && arg[0] === '-';
@@ -1787,7 +1820,11 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
       // literal
       if (arg === '--') {
-        if (dest === unknown) dest.push(arg);
+        if (dest === unknown) {
+          dest.push(arg);
+        } else {
+          optionTerminatorIndex = dest.length;
+        }
         dest.push(...args.slice(i));
         break;
       }
@@ -1903,7 +1940,13 @@ Expecting one of '${allowedValues.join("', '")}'`);
       dest.push(arg);
     }
 
-    return { operands, unknown };
+    const result = { operands, unknown };
+    if (optionTerminatorIndex !== undefined) {
+      Object.defineProperty(result, OptionTerminatorSymbol, {
+        value: optionTerminatorIndex,
+      });
+    }
+    return result;
   }
 
   /**

--- a/tests/command.executableSubcommand.lookup.test.js
+++ b/tests/command.executableSubcommand.lookup.test.js
@@ -57,6 +57,38 @@ describe('executable subcommand lookup ', () => {
     assert.equal(stdout, 'publish\n');
   });
 
+  test('when subcommand has literal delimiter then preserve in arguments', async () => {
+    const { stdout } = await execFileAsync('node', [
+      pm,
+      'echo',
+      '--',
+      '--not-an-option',
+    ]);
+    assert.equal(stdout, '["--","--not-an-option"]\n');
+  });
+
+  test('when subcommand has operands around literal delimiter then preserve order', async () => {
+    const { stdout } = await execFileAsync('node', [
+      pm,
+      'echo',
+      'before',
+      '--',
+      '--after',
+    ]);
+    assert.equal(stdout, '["before","--","--after"]\n');
+  });
+
+  test('when subcommand has repeated literal delimiter then preserve second as operand', async () => {
+    const { stdout } = await execFileAsync('node', [
+      pm,
+      'echo',
+      '--',
+      '--',
+      '--not-an-option',
+    ]);
+    assert.equal(stdout, '["--","--","--not-an-option"]\n');
+  });
+
   test('when alias subcommand file suffix .js then lookup succeeds', async () => {
     const { stdout } = await execFileAsync('node', [pm, 'p']);
     assert.equal(stdout, 'publish\n');


### PR DESCRIPTION
## Summary
- Fixes #2530 by keeping the first end-of-options delimiter when spawning executable subcommands
- Records where `--` appeared during option parsing and splices it back into argv before `child_process.spawn()`
- Adds regression tests for delimiter preservation with option-like operands

## Test plan
- [x] `node --test tests/command.executableSubcommand.lookup.test.js`
- [x] Verified `pm echo -- --not-an-option` passes `--` through to the child process