### PR TITLE
Group codeql updates as inter-dependent

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      codeql-actions:
+        patterns:
+          - "github/codeql-action/*"


### PR DESCRIPTION
## Problem

`github/codeql-action/init` and `github/codeql-action/analyze` need to be in sync, and dependabot PRs fail their checks when updated spearately:

- https://github.com/tj/commander.js/pull/2563
- https://github.com/tj/commander.js/pull/2564

## Solution

Add configuration to group the codeql updates together in a single PR.