### PR TITLE
fix: preserve -- for executable and in-process subcommands

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -1361,7 +1361,12 @@ Expecting one of '${allowedValues.join("', '")}'`);
    * @private
    */
 
-  _dispatchSubcommand(commandName, operands, unknown) {
+  _dispatchSubcommand(
+    commandName,
+    operands,
+    unknown,
+    optionTerminatorIndex,
+  ) {
     const subCommand = this._findCommand(commandName);
     if (!subCommand) this.help({ error: true });
 
@@ -1374,8 +1379,20 @@ Expecting one of '${allowedValues.join("', '")}'`);
     );
     promiseChain = this._chainOrCall(promiseChain, () => {
       if (subCommand._executableHandler) {
-        this._executeSubCommand(subCommand, operands.concat(unknown));
+        const args = operands.concat(unknown);
+        if (optionTerminatorIndex !== undefined) {
+          args.splice(optionTerminatorIndex, 0, '--');
+        }
+        this._executeSubCommand(subCommand, args);
       } else {
+        if (optionTerminatorIndex !== undefined) {
+          const args = [
+            ...operands.slice(0, optionTerminatorIndex),
+            '--',
+            ...operands.slice(optionTerminatorIndex),
+          ];
+          return subCommand._parseCommand([], args.concat(unknown));
+        }
         return subCommand._parseCommand(operands, unknown);
       }
     });
@@ -1565,10 +1582,27 @@ Expecting one of '${allowedValues.join("', '")}'`);
     this._parseOptionsImplied();
     operands = operands.concat(parsed.operands);
     unknown = parsed.unknown;
+
+    // Calculate where '--' should be restored in the combined operands
+    const optionTerminatorIndex =
+      parsed.optionTerminatorIndex !== undefined
+        ? parsed.optionTerminatorIndex +
+            (operands.length - parsed.operands.length)
+        : undefined;
+
     this.args = operands.concat(unknown);
 
     if (operands && this._findCommand(operands[0])) {
-      return this._dispatchSubcommand(operands[0], operands.slice(1), unknown);
+      const subcommandTerminatorIndex =
+        optionTerminatorIndex !== undefined
+          ? optionTerminatorIndex - 1
+          : undefined;
+      return this._dispatchSubcommand(
+        operands[0],
+        operands.slice(1),
+        unknown,
+        subcommandTerminatorIndex,
+      );
     }
     if (
       this._getHelpCommand() &&
@@ -1582,6 +1616,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
         this._defaultCommandName,
         operands,
         unknown,
+        optionTerminatorIndex,
       );
     }
     if (
@@ -1754,13 +1789,14 @@ Expecting one of '${allowedValues.join("', '")}'`);
    *     sub -- --unknown uuu op => [sub --unknown uuu op], []
    *
    * @param {string[]} args
-   * @return {{operands: string[], unknown: string[]}}
+   * @return {{operands: string[], unknown: string[], optionTerminatorIndex: number | undefined}}
    */
 
   parseOptions(args) {
     const operands = []; // operands, not options or values
     const unknown = []; // first unknown option and remaining unknown args
     let dest = operands;
+    let optionTerminatorIndex = undefined;
 
     function maybeOption(arg) {
       return arg.length > 1 && arg[0] === '-';
@@ -1787,7 +1823,11 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
       // literal
       if (arg === '--') {
-        if (dest === unknown) dest.push(arg);
+        if (dest === unknown) {
+          dest.push(arg);
+        } else {
+          optionTerminatorIndex = dest.length;
+        }
         dest.push(...args.slice(i));
         break;
       }
@@ -1903,7 +1943,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
       dest.push(arg);
     }
 
-    return { operands, unknown };
+    return { operands, unknown, optionTerminatorIndex };
   }
 
   /**

--- a/tests/args.literal.test.js
+++ b/tests/args.literal.test.js
@@ -31,4 +31,39 @@ describe('end of options delimiter "--"', () => {
     program.parse(['node', 'test', '--', 'cmd', '--', '--arg']);
     assert.deepEqual(program.args, ['cmd', '--', '--arg']);
   });
+
+  test('when in-process subcommand has -- then option-like operand is treated as argument', () => {
+    const program = new commander.Command();
+    const sub = program.command('sub');
+    sub.argument('[input]').action((input) => {
+      assert.equal(input, '--not-an-option');
+    });
+    program.parse(['node', 'test', 'sub', '--', '--not-an-option']);
+  });
+
+  test('when nested in-process subcommand has -- then option-like operand is treated as argument', () => {
+    const program = new commander.Command();
+    const sub = program.command('sub');
+    const nested = sub.command('nested');
+    nested.argument('[input]').action((input) => {
+      assert.equal(input, '--not-an-option');
+    });
+    program.parse([
+      'node',
+      'test',
+      'sub',
+      'nested',
+      '--',
+      '--not-an-option',
+    ]);
+  });
+
+  test('when in-process subcommand has args before and after -- then all args passed correctly', () => {
+    const program = new commander.Command();
+    const sub = program.command('sub');
+    sub.argument('[args...]').action((args) => {
+      assert.deepEqual(args, ['before', '--after']);
+    });
+    program.parse(['node', 'test', 'sub', 'before', '--', '--after']);
+  });
 });

--- a/tests/command.executableSubcommand.lookup.test.js
+++ b/tests/command.executableSubcommand.lookup.test.js
@@ -128,4 +128,30 @@ describe('executable subcommand lookup ', () => {
     const { stdout } = await execFileAsync('node', [pm, 'cache', 'clear']);
     assert.equal(stdout, 'cache-clear\n');
   });
+
+  test('when executable subcommand with -- then -- passed to subcommand', async () => {
+    const { stdout } = await execFileAsync('node', [
+      pm,
+      'echo',
+      '--',
+      '--not-an-option',
+    ]);
+    assert.equal(stdout, '["--","--not-an-option"]\n');
+  });
+
+  test('when executable subcommand with args before and after -- then -- passed to subcommand', async () => {
+    const { stdout } = await execFileAsync('node', [
+      pm,
+      'echo',
+      'before',
+      '--',
+      '--after',
+    ]);
+    assert.equal(stdout, '["before","--","--after"]\n');
+  });
+
+  test('when executable subcommand with bare -- then -- passed to subcommand', async () => {
+    const { stdout } = await execFileAsync('node', [pm, 'echo', '--']);
+    assert.equal(stdout, '["--"]\n');
+  });
 });

--- a/tests/command.parseOptions.test.js
+++ b/tests/command.parseOptions.test.js
@@ -71,7 +71,11 @@ describe('Command.parseOptions()', () => {
   test('when empty args then empty results', () => {
     const program = createProgram();
     const result = program.parseOptions([]);
-    assert.deepEqual(result, { operands: [], unknown: [] });
+    assert.deepEqual(result, {
+      operands: [],
+      unknown: [],
+      optionTerminatorIndex: undefined,
+    });
   });
 
   test('when only operands then results has all operands', () => {
@@ -80,85 +84,138 @@ describe('Command.parseOptions()', () => {
     assert.deepEqual(result, {
       operands: ['one', 'two', 'three'],
       unknown: [],
+      optionTerminatorIndex: undefined,
     });
   });
 
   test('when subcommand and operand then results has subcommand and operand', () => {
     const program = createProgram();
     const result = program.parseOptions('sub one'.split(' '));
-    assert.deepEqual(result, { operands: ['sub', 'one'], unknown: [] });
+    assert.deepEqual(result, {
+      operands: ['sub', 'one'],
+      unknown: [],
+      optionTerminatorIndex: undefined,
+    });
   });
 
   test('when program has flag then option removed', () => {
     const program = createProgram();
     const result = program.parseOptions('--global-flag'.split(' '));
-    assert.deepEqual(result, { operands: [], unknown: [] });
+    assert.deepEqual(result, {
+      operands: [],
+      unknown: [],
+      optionTerminatorIndex: undefined,
+    });
   });
 
   test('when program has option with value then option removed', () => {
     const program = createProgram();
     const result = program.parseOptions('--global-value foo'.split(' '));
-    assert.deepEqual(result, { operands: [], unknown: [] });
+    assert.deepEqual(result, {
+      operands: [],
+      unknown: [],
+      optionTerminatorIndex: undefined,
+    });
   });
 
   test('when program has flag before operand then option removed', () => {
     const program = createProgram();
     const result = program.parseOptions('--global-flag arg'.split(' '));
-    assert.deepEqual(result, { operands: ['arg'], unknown: [] });
+    assert.deepEqual(result, {
+      operands: ['arg'],
+      unknown: [],
+      optionTerminatorIndex: undefined,
+    });
   });
 
   test('when program has flag after operand then option removed', () => {
     const program = createProgram();
     const result = program.parseOptions('arg --global-flag'.split(' '));
-    assert.deepEqual(result, { operands: ['arg'], unknown: [] });
+    assert.deepEqual(result, {
+      operands: ['arg'],
+      unknown: [],
+      optionTerminatorIndex: undefined,
+    });
   });
 
   test('when program has flag after subcommand then option removed', () => {
     const program = createProgram();
     const result = program.parseOptions('sub --global-flag'.split(' '));
-    assert.deepEqual(result, { operands: ['sub'], unknown: [] });
+    assert.deepEqual(result, {
+      operands: ['sub'],
+      unknown: [],
+      optionTerminatorIndex: undefined,
+    });
   });
 
   test('when program has unknown option then option returned in unknown', () => {
     const program = createProgram();
     const result = program.parseOptions('--unknown'.split(' '));
-    assert.deepEqual(result, { operands: [], unknown: ['--unknown'] });
+    assert.deepEqual(result, {
+      operands: [],
+      unknown: ['--unknown'],
+      optionTerminatorIndex: undefined,
+    });
   });
 
   test('when program has unknown option before operands then all unknown in same order', () => {
     const program = createProgram();
     const result = program.parseOptions('--unknown arg'.split(' '));
-    assert.deepEqual(result, { operands: [], unknown: ['--unknown', 'arg'] });
+    assert.deepEqual(result, {
+      operands: [],
+      unknown: ['--unknown', 'arg'],
+      optionTerminatorIndex: undefined,
+    });
   });
 
   test('when program has unknown option after operand then option returned in unknown', () => {
     const program = createProgram();
     const result = program.parseOptions('arg --unknown'.split(' '));
-    assert.deepEqual(result, { operands: ['arg'], unknown: ['--unknown'] });
+    assert.deepEqual(result, {
+      operands: ['arg'],
+      unknown: ['--unknown'],
+      optionTerminatorIndex: undefined,
+    });
   });
 
   test('when program has flag after unknown option then flag removed', () => {
     const program = createProgram();
     const result = program.parseOptions('--unknown --global-flag'.split(' '));
-    assert.deepEqual(result, { operands: [], unknown: ['--unknown'] });
+    assert.deepEqual(result, {
+      operands: [],
+      unknown: ['--unknown'],
+      optionTerminatorIndex: undefined,
+    });
   });
 
   test('when subcommand has flag then flag returned as unknown', () => {
     const program = createProgram();
     const result = program.parseOptions('sub --sub-flag'.split(' '));
-    assert.deepEqual(result, { operands: ['sub'], unknown: ['--sub-flag'] });
+    assert.deepEqual(result, {
+      operands: ['sub'],
+      unknown: ['--sub-flag'],
+      optionTerminatorIndex: undefined,
+    });
   });
 
   test('when program has literal before known flag then option returned as operand', () => {
     const program = createProgram();
     const result = program.parseOptions('-- --global-flag'.split(' '));
-    assert.deepEqual(result, { operands: ['--global-flag'], unknown: [] });
+    assert.deepEqual(result, {
+      operands: ['--global-flag'],
+      unknown: [],
+      optionTerminatorIndex: 0,
+    });
   });
 
   test('when program has literal before unknown option then option returned as operand', () => {
     const program = createProgram();
     const result = program.parseOptions('-- --unknown uuu'.split(' '));
-    assert.deepEqual(result, { operands: ['--unknown', 'uuu'], unknown: [] });
+    assert.deepEqual(result, {
+      operands: ['--unknown', 'uuu'],
+      unknown: [],
+      optionTerminatorIndex: 0,
+    });
   });
 
   test('when program has literal after unknown option then literal preserved too', () => {
@@ -167,6 +224,7 @@ describe('Command.parseOptions()', () => {
     assert.deepEqual(result, {
       operands: [],
       unknown: ['--unknown1', '--', '--unknown2'],
+      optionTerminatorIndex: undefined,
     });
   });
 });
@@ -259,56 +317,88 @@ describe('Posix Utility Conventions', () => {
   test('when program has combo known boolean short flags then arg removed', () => {
     const program = createProgram();
     const result = program.parseOptions(['-ab']);
-    assert.deepEqual(result, { operands: [], unknown: [] });
+    assert.deepEqual(result, {
+      operands: [],
+      unknown: [],
+      optionTerminatorIndex: undefined,
+    });
     assert.deepEqual(program.opts(), { aaa: true, bbb: true });
   });
 
   test('when program has combo unknown short flags then arg preserved', () => {
     const program = createProgram();
     const result = program.parseOptions(['-pq']);
-    assert.deepEqual(result, { operands: [], unknown: ['-pq'] });
+    assert.deepEqual(result, {
+      operands: [],
+      unknown: ['-pq'],
+      optionTerminatorIndex: undefined,
+    });
     assert.deepEqual(program.opts(), {});
   });
 
   test('when program has combo known short option and required value then arg removed', () => {
     const program = createProgram();
     const result = program.parseOptions(['-cvalue']);
-    assert.deepEqual(result, { operands: [], unknown: [] });
+    assert.deepEqual(result, {
+      operands: [],
+      unknown: [],
+      optionTerminatorIndex: undefined,
+    });
     assert.deepEqual(program.opts(), { ccc: 'value' });
   });
 
   test('when program has combo known short option and optional value then arg removed', () => {
     const program = createProgram();
     const result = program.parseOptions(['-dvalue']);
-    assert.deepEqual(result, { operands: [], unknown: [] });
+    assert.deepEqual(result, {
+      operands: [],
+      unknown: [],
+      optionTerminatorIndex: undefined,
+    });
     assert.deepEqual(program.opts(), { ddd: 'value' });
   });
 
   test('when program has known combo short boolean flags and required value then arg removed', () => {
     const program = createProgram();
     const result = program.parseOptions(['-abcvalue']);
-    assert.deepEqual(result, { operands: [], unknown: [] });
+    assert.deepEqual(result, {
+      operands: [],
+      unknown: [],
+      optionTerminatorIndex: undefined,
+    });
     assert.deepEqual(program.opts(), { aaa: true, bbb: true, ccc: 'value' });
   });
 
   test('when program has known combo short boolean flags and optional value then arg removed', () => {
     const program = createProgram();
     const result = program.parseOptions(['-abdvalue']);
-    assert.deepEqual(result, { operands: [], unknown: [] });
+    assert.deepEqual(result, {
+      operands: [],
+      unknown: [],
+      optionTerminatorIndex: undefined,
+    });
     assert.deepEqual(program.opts(), { aaa: true, bbb: true, ddd: 'value' });
   });
 
   test('when program has known long flag=value then arg removed', () => {
     const program = createProgram();
     const result = program.parseOptions(['--ccc=value']);
-    assert.deepEqual(result, { operands: [], unknown: [] });
+    assert.deepEqual(result, {
+      operands: [],
+      unknown: [],
+      optionTerminatorIndex: undefined,
+    });
     assert.deepEqual(program.opts(), { ccc: 'value' });
   });
 
   test('when program has unknown long flag=value then arg preserved', () => {
     const program = createProgram();
     const result = program.parseOptions(['--rrr=value']);
-    assert.deepEqual(result, { operands: [], unknown: ['--rrr=value'] });
+    assert.deepEqual(result, {
+      operands: [],
+      unknown: ['--rrr=value'],
+      optionTerminatorIndex: undefined,
+    });
     assert.deepEqual(program.opts(), {});
   });
 


### PR DESCRIPTION
## Problem

When using executable subcommands (or nested in-process subcommands), the `--` option terminator is consumed by the parent command's option parsing and never reaches the child subcommand.

This breaks POSIX-compliant argument handling where option-like operands after `--` should be treated as arguments.

### Reproduction

```js
// parent.js
const { Command } = require('commander');
new Command()
  .name('parent')
  .command('child', 'run child', { executableFile: 'child.js' })
  .parse();

// child.js
const { Command } = require('commander');
new Command()
  .name('parent child')
  .argument('[input]')
  .action((input) => console.log({ input }))
  .parse();
```

```bash
$ node parent.js child -- --not-an-option
# Expected: { input: '--not-an-option' }
# Actual: error: unknown option '--not-an-option'
```

## Solution

Track the position of `--` in `parseOptions()` via a new `optionTerminatorIndex` field in the return value. When dispatching to a subcommand, restore `--` at the correct position in the arguments:

- **Executable subcommands**: splice `--` back into the args passed to the child process
- **In-process subcommands**: pass `--` as part of the `unknown` args so the subcommand re-parses it correctly

This approach is lighter-weight than the Symbol-based fix proposed in #2531 and preserves backward compatibility for leaf commands.

## Changes

- `lib/command.js`: track `optionTerminatorIndex` in `parseOptions`, restore `--` in `_dispatchSubcommand`
- `tests/args.literal.test.js`: add tests for in-process and nested subcommands with `--`
- `tests/command.executableSubcommand.lookup.test.js`: add end-to-end tests for executable subcommands with `--`
- `tests/command.parseOptions.test.js`: update assertions to include `optionTerminatorIndex`

Fixes #2530
