### PR TITLE
Use subtest not describe level loop

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -76,7 +76,7 @@ export default defineConfig(
       'node-test/prefer-test-context-assert': 'off', // we use callback parameter t to generate mocks, but do not want to use t.assertX (as t.assertX not automatically strict)
       'node-test/no-useless-assertion': 'off', // we use `assert.doesNotThrow()` as only assert in multiple tests (so removing that assert triggers a different lint error)
       'node-test/no-process-env-mutation': 'off', // we manage env in ways node-test does not recognise
-      'node-test/require-hook': 'error', // Temp, was using pattern for for-each on describe.
+      'node-test/require-hook': 'error', // Detect code, especially loops with embedded tests, at top level of describe as runs at file load time.
     },
   },
 );

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -77,6 +77,7 @@ export default defineConfig(
       'node-test/no-useless-assertion': 'off', // we use `assert.doesNotThrow()` as only assert in multiple tests (so removing that assert triggers a different lint error)
       'node-test/no-process-env-mutation': 'off', // we manage env in ways node-test does not recognise
       'node-test/require-top-level-describe': 'error', // Enforce top-level describe for providing context in test output. Disable by hand on single test files.
+      'node-test/require-hook': 'error', // Temp, was using pattern for for-each on describe.
     },
   },
 );

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -76,7 +76,6 @@ export default defineConfig(
       'node-test/prefer-test-context-assert': 'off', // we use callback parameter t to generate mocks, but do not want to use t.assertX (as t.assertX not automatically strict)
       'node-test/no-useless-assertion': 'off', // we use `assert.doesNotThrow()` as only assert in multiple tests (so removing that assert triggers a different lint error)
       'node-test/no-process-env-mutation': 'off', // we manage env in ways node-test does not recognise
-      'node-test/require-top-level-describe': 'error', // Enforce top-level describe for providing context in test output. Disable by hand on single test files.
       'node-test/require-hook': 'error', // Temp, was using pattern for for-each on describe.
     },
   },

--- a/tests/command.action.test.js
+++ b/tests/command.action.test.js
@@ -35,9 +35,9 @@ describe('Command.action()', () => {
     assert.deepEqual(program.args, ['info', 'my-file']);
   });
 
-  describe('when .action on program with required argument and argument supplied then action called', () => {
-    getTestCases('<file>').forEach(([methodName, program]) => {
-      test(`via ${methodName}`, (t) => {
+  test('when .action on program with required argument and argument supplied then action called', async (t) => {
+    for (const [methodName, program] of getTestCases('<file>')) {
+      await t.test(`via ${methodName}`, (t) => {
         const actionMock = t.mock.fn();
         program.action(actionMock);
         program.parse(['node', 'test', 'my-file']);
@@ -46,12 +46,12 @@ describe('Command.action()', () => {
         assert.equal(callArgs[1], program.opts());
         assert.equal(callArgs[2], program);
       });
-    });
+    }
   });
 
-  describe('when .action on program with required argument and argument not supplied then action not called', () => {
-    getTestCases('<file>').forEach(([methodName, program]) => {
-      test(`via ${methodName}`, (t) => {
+  test('when .action on program with required argument and argument not supplied then action not called', async (t) => {
+    for (const [methodName, program] of getTestCases('<file>')) {
+      await t.test(`via ${methodName}`, (t) => {
         const actionMock = t.mock.fn();
         program.action(actionMock);
         assert.throws(
@@ -62,7 +62,7 @@ describe('Command.action()', () => {
         );
         assert.equal(actionMock.mock.callCount(), 0);
       });
-    });
+    }
   });
 
   // Changes made in #729 to call program action handler
@@ -76,9 +76,9 @@ describe('Command.action()', () => {
     assert.equal(callArgs[1], program);
   });
 
-  describe('when .action on program with optional argument supplied then action called', () => {
-    getTestCases('[file]').forEach(([methodName, program]) => {
-      test(`via ${methodName}`, (t) => {
+  test('when .action on program with optional argument supplied then action called', async (t) => {
+    for (const [methodName, program] of getTestCases('[file]')) {
+      await t.test(`via ${methodName}`, (t) => {
         const actionMock = t.mock.fn();
         program.action(actionMock);
         program.parse(['node', 'test', 'my-file']);
@@ -87,12 +87,12 @@ describe('Command.action()', () => {
         assert.equal(callArgs[1], program.opts());
         assert.equal(callArgs[2], program);
       });
-    });
+    }
   });
 
-  describe('when .action on program without optional argument supplied then action called', () => {
-    getTestCases('[file]').forEach(([methodName, program]) => {
-      test(`via ${methodName}`, (t) => {
+  test('when .action on program without optional argument supplied then action called', async (t) => {
+    for (const [methodName, program] of getTestCases('[file]')) {
+      await t.test(`via ${methodName}`, (t) => {
         const actionMock = t.mock.fn();
         program.action(actionMock);
         program.parse(['node', 'test']);
@@ -101,12 +101,12 @@ describe('Command.action()', () => {
         assert.equal(callArgs[1], program.opts());
         assert.equal(callArgs[2], program);
       });
-    });
+    }
   });
 
-  describe('when .action on program with optional argument and subcommand and program argument then program action called', () => {
-    getTestCases('[file]').forEach(([methodName, program]) => {
-      test(`via ${methodName}`, (t) => {
+  test('when .action on program with optional argument and subcommand and program argument then program action called', async (t) => {
+    for (const [methodName, program] of getTestCases('[file]')) {
+      await t.test(`via ${methodName}`, (t) => {
         const actionMock = t.mock.fn();
         program.action(actionMock);
         program.command('subcommand');
@@ -118,13 +118,13 @@ describe('Command.action()', () => {
         assert.equal(callArgs[1], program.opts());
         assert.equal(callArgs[2], program);
       });
-    });
+    }
   });
 
   // Changes made in #1062 to allow this case
-  describe('when .action on program with optional argument and subcommand and no program argument then program action called', () => {
-    getTestCases('[file]').forEach(([methodName, program]) => {
-      test(`via ${methodName}`, (t) => {
+  test('when .action on program with optional argument and subcommand and no program argument then program action called', async (t) => {
+    for (const [methodName, program] of getTestCases('[file]')) {
+      await t.test(`via ${methodName}`, (t) => {
         const actionMock = t.mock.fn();
         program.action(actionMock);
         program.command('subcommand');
@@ -136,7 +136,7 @@ describe('Command.action()', () => {
         assert.equal(callArgs[1], program.opts());
         assert.equal(callArgs[2], program);
       });
-    });
+    }
   });
 
   test('when action is async then can await parseAsync', async () => {

--- a/tests/command.allowExcessArguments.test.js
+++ b/tests/command.allowExcessArguments.test.js
@@ -4,7 +4,6 @@ import assert from 'node:assert/strict';
 
 // Not testing output, just testing whether an error is detected.
 
-// eslint-disable-next-line node-test/require-top-level-describe
 test('Command.allowExcessArguments()', async (t) => {
   const cases = [true, false];
   for (const hasActionHandler of cases) {

--- a/tests/command.allowExcessArguments.test.js
+++ b/tests/command.allowExcessArguments.test.js
@@ -4,130 +4,164 @@ import assert from 'node:assert/strict';
 
 // Not testing output, just testing whether an error is detected.
 
-describe('Command.allowExcessArguments()', () => {
+// eslint-disable-next-line node-test/require-top-level-describe
+test('Command.allowExcessArguments()', async (t) => {
   const cases = [true, false];
-  cases.forEach((hasActionHandler) => {
-    describe(`when ${hasActionHandler ? 'has' : 'no'} action handler`, () => {
-      function configureCommand(cmd) {
-        if (hasActionHandler) cmd.action(() => {});
-      }
+  for (const hasActionHandler of cases) {
+    await t.test(
+      `when ${hasActionHandler ? 'has' : 'no'} action handler`,
+      async (t) => {
+        function configureCommand(cmd) {
+          if (hasActionHandler) cmd.action(() => {});
+        }
 
-      test('when specify excess program argument then error by default', () => {
-        const program = createTestCommand();
-        configureCommand(program);
-
-        assert.throws(
+        await t.test(
+          'when specify excess program argument then error by default',
           () => {
-            program.parse(['excess'], { from: 'user' });
+            const program = createTestCommand();
+            configureCommand(program);
+
+            assert.throws(
+              () => {
+                program.parse(['excess'], { from: 'user' });
+              },
+              { code: 'commander.excessArguments' },
+            );
           },
-          { code: 'commander.excessArguments' },
         );
-      });
 
-      test('when specify excess program argument and allowExcessArguments(false) then error', () => {
-        const program = createTestCommand();
-        configureCommand(program);
-        program.allowExcessArguments(false);
-
-        assert.throws(
+        await t.test(
+          'when specify excess program argument and allowExcessArguments(false) then error',
           () => {
-            program.parse(['excess'], { from: 'user' });
+            const program = createTestCommand();
+            configureCommand(program);
+            program.allowExcessArguments(false);
+
+            assert.throws(
+              () => {
+                program.parse(['excess'], { from: 'user' });
+              },
+              { code: 'commander.excessArguments' },
+            );
           },
-          { code: 'commander.excessArguments' },
         );
-      });
 
-      test('when specify excess program argument and allowExcessArguments() then no error', () => {
-        const program = createTestCommand();
-        configureCommand(program);
-        program.allowExcessArguments();
-
-        assert.doesNotThrow(() => {
-          program.parse(['excess'], { from: 'user' });
-        });
-      });
-
-      test('when specify excess program argument and allowExcessArguments(true) then no error', () => {
-        const program = createTestCommand();
-        configureCommand(program);
-        program.allowExcessArguments(true);
-
-        assert.doesNotThrow(() => {
-          program.parse(['excess'], { from: 'user' });
-        });
-      });
-
-      test('when specify excess command argument then error (by default)', () => {
-        const program = createTestCommand();
-        const sub = program.command('sub');
-        configureCommand(sub);
-
-        assert.throws(
+        await t.test(
+          'when specify excess program argument and allowExcessArguments() then no error',
           () => {
-            program.parse(['sub', 'excess'], { from: 'user' });
+            const program = createTestCommand();
+            configureCommand(program);
+            program.allowExcessArguments();
+
+            assert.doesNotThrow(() => {
+              program.parse(['excess'], { from: 'user' });
+            });
           },
-          { code: 'commander.excessArguments' },
         );
-      });
 
-      test('when specify excess command argument and allowExcessArguments(false) then error', () => {
-        const program = createTestCommand();
-        const sub = program.command('sub').allowExcessArguments(false);
-        configureCommand(sub);
-
-        assert.throws(
+        await t.test(
+          'when specify excess program argument and allowExcessArguments(true) then no error',
           () => {
-            program.parse(['sub', 'excess'], { from: 'user' });
+            const program = createTestCommand();
+            configureCommand(program);
+            program.allowExcessArguments(true);
+
+            assert.doesNotThrow(() => {
+              program.parse(['excess'], { from: 'user' });
+            });
           },
-          { code: 'commander.excessArguments' },
         );
-      });
 
-      test('when specify expected arg and allowExcessArguments(false) then no error', () => {
-        const program = createTestCommand();
-        configureCommand(program);
-        program.argument('<file>').allowExcessArguments(false);
-
-        assert.doesNotThrow(() => {
-          program.parse(['file'], { from: 'user' });
-        });
-      });
-
-      test('when specify excess after <arg> and allowExcessArguments(false) then error', () => {
-        const program = createTestCommand();
-        configureCommand(program);
-        program.argument('<file>').allowExcessArguments(false);
-
-        assert.throws(
+        await t.test(
+          'when specify excess command argument then error (by default)',
           () => {
-            program.parse(['file', 'excess'], { from: 'user' });
+            const program = createTestCommand();
+            const sub = program.command('sub');
+            configureCommand(sub);
+
+            assert.throws(
+              () => {
+                program.parse(['sub', 'excess'], { from: 'user' });
+              },
+              { code: 'commander.excessArguments' },
+            );
           },
-          { code: 'commander.excessArguments' },
         );
-      });
 
-      test('when specify excess after [arg] and allowExcessArguments(false) then error', () => {
-        const program = createTestCommand();
-        configureCommand(program);
-        program.argument('[file]').allowExcessArguments(false);
-
-        assert.throws(
+        await t.test(
+          'when specify excess command argument and allowExcessArguments(false) then error',
           () => {
-            program.parse(['file', 'excess'], { from: 'user' });
+            const program = createTestCommand();
+            const sub = program.command('sub').allowExcessArguments(false);
+            configureCommand(sub);
+
+            assert.throws(
+              () => {
+                program.parse(['sub', 'excess'], { from: 'user' });
+              },
+              { code: 'commander.excessArguments' },
+            );
           },
-          { code: 'commander.excessArguments' },
         );
-      });
 
-      test('when specify args for [args...] and allowExcessArguments(false) then no error', () => {
-        const program = createTestCommand();
-        configureCommand(program);
-        program.argument('[files...]').allowExcessArguments(false);
+        await t.test(
+          'when specify expected arg and allowExcessArguments(false) then no error',
+          () => {
+            const program = createTestCommand();
+            configureCommand(program);
+            program.argument('<file>').allowExcessArguments(false);
 
-        assert.doesNotThrow(() => {
-          program.parse(['file1', 'file2', 'file3'], { from: 'user' });
-        });
-      });
-    });
-  });
+            assert.doesNotThrow(() => {
+              program.parse(['file'], { from: 'user' });
+            });
+          },
+        );
+
+        await t.test(
+          'when specify excess after <arg> and allowExcessArguments(false) then error',
+          () => {
+            const program = createTestCommand();
+            configureCommand(program);
+            program.argument('<file>').allowExcessArguments(false);
+
+            assert.throws(
+              () => {
+                program.parse(['file', 'excess'], { from: 'user' });
+              },
+              { code: 'commander.excessArguments' },
+            );
+          },
+        );
+
+        await t.test(
+          'when specify excess after [arg] and allowExcessArguments(false) then error',
+          () => {
+            const program = createTestCommand();
+            configureCommand(program);
+            program.argument('[file]').allowExcessArguments(false);
+
+            assert.throws(
+              () => {
+                program.parse(['file', 'excess'], { from: 'user' });
+              },
+              { code: 'commander.excessArguments' },
+            );
+          },
+        );
+
+        await t.test(
+          'when specify args for [args...] and allowExcessArguments(false) then no error',
+          () => {
+            const program = createTestCommand();
+            configureCommand(program);
+            program.argument('[files...]').allowExcessArguments(false);
+
+            assert.doesNotThrow(() => {
+              program.parse(['file1', 'file2', 'file3'], { from: 'user' });
+            });
+          },
+        );
+      },
+    );
+  }
 });

--- a/tests/command.argumentVariations.test.js
+++ b/tests/command.argumentVariations.test.js
@@ -5,7 +5,6 @@ import assert from 'node:assert/strict';
 // Do some low-level checks that the multiple ways of specifying command arguments produce same internal result,
 // and not exhaustively testing all methods elsewhere.
 
-// eslint-disable-next-line node-test/require-top-level-describe
 test('Command arguments added using different methods', async (t) => {
   await t.test('when add "<arg>" then argument required', async (t) => {
     for (const [methodName, cmd] of getSingleArgCases('<explicit-required>')) {

--- a/tests/command.argumentVariations.test.js
+++ b/tests/command.argumentVariations.test.js
@@ -5,78 +5,92 @@ import assert from 'node:assert/strict';
 // Do some low-level checks that the multiple ways of specifying command arguments produce same internal result,
 // and not exhaustively testing all methods elsewhere.
 
-describe('Command arguments added using different methods', () => {
-  describe('when add "<arg>" then argument required', () => {
-    getSingleArgCases('<explicit-required>').forEach(([methodName, cmd]) => {
-      test(`using ${methodName}`, () => {
+// eslint-disable-next-line node-test/require-top-level-describe
+test('Command arguments added using different methods', async (t) => {
+  await t.test('when add "<arg>" then argument required', async (t) => {
+    for (const [methodName, cmd] of getSingleArgCases('<explicit-required>')) {
+      await t.test(`using ${methodName}`, () => {
         const argument = cmd.registeredArguments[0];
         assert.equal(argument._name, 'explicit-required');
         assert.equal(argument.required, true);
         assert.equal(argument.variadic, false);
         assert.equal(argument.description, '');
       });
-    });
+    }
   });
 
-  describe('when add "arg" then argument required', () => {
-    getSingleArgCases('implicit-required').forEach(([methodName, cmd]) => {
-      test(`using ${methodName}`, () => {
+  await t.test('when add "arg" then argument required', async (t) => {
+    for (const [methodName, cmd] of getSingleArgCases('implicit-required')) {
+      await t.test(`using ${methodName}`, () => {
         const argument = cmd.registeredArguments[0];
         assert.equal(argument._name, 'implicit-required');
         assert.equal(argument.required, true);
         assert.equal(argument.variadic, false);
         assert.equal(argument.description, '');
       });
-    });
+    }
   });
 
-  describe('when add "[arg]" then argument optional', () => {
-    getSingleArgCases('[optional]').forEach(([methodName, cmd]) => {
-      test(`using ${methodName}`, () => {
+  await t.test('when add "[arg]" then argument optional', async (t) => {
+    for (const [methodName, cmd] of getSingleArgCases('[optional]')) {
+      await t.test(`using ${methodName}`, () => {
         const argument = cmd.registeredArguments[0];
         assert.equal(argument._name, 'optional');
         assert.equal(argument.required, false);
         assert.equal(argument.variadic, false);
         assert.equal(argument.description, '');
       });
-    });
+    }
   });
 
-  describe('when add "<arg...>" then argument required and variadic', () => {
-    getSingleArgCases('<explicit-required...>').forEach(([methodName, cmd]) => {
-      test(`using ${methodName}`, () => {
-        const argument = cmd.registeredArguments[0];
-        assert.equal(argument._name, 'explicit-required');
-        assert.equal(argument.required, true);
-        assert.equal(argument.variadic, true);
-        assert.equal(argument.description, '');
-      });
-    });
-  });
+  await t.test(
+    'when add "<arg...>" then argument required and variadic',
+    async (t) => {
+      for (const [methodName, cmd] of getSingleArgCases(
+        '<explicit-required...>',
+      )) {
+        await t.test(`using ${methodName}`, () => {
+          const argument = cmd.registeredArguments[0];
+          assert.equal(argument._name, 'explicit-required');
+          assert.equal(argument.required, true);
+          assert.equal(argument.variadic, true);
+          assert.equal(argument.description, '');
+        });
+      }
+    },
+  );
 
-  describe('when add "arg..." then argument required and variadic', () => {
-    getSingleArgCases('implicit-required...').forEach(([methodName, cmd]) => {
-      test(`using ${methodName}`, () => {
-        const argument = cmd.registeredArguments[0];
-        assert.equal(argument._name, 'implicit-required');
-        assert.equal(argument.required, true);
-        assert.equal(argument.variadic, true);
-        assert.equal(argument.description, '');
-      });
-    });
-  });
+  await t.test(
+    'when add "arg..." then argument required and variadic',
+    async (t) => {
+      for (const [methodName, cmd] of getSingleArgCases(
+        'implicit-required...',
+      )) {
+        await t.test(`using ${methodName}`, () => {
+          const argument = cmd.registeredArguments[0];
+          assert.equal(argument._name, 'implicit-required');
+          assert.equal(argument.required, true);
+          assert.equal(argument.variadic, true);
+          assert.equal(argument.description, '');
+        });
+      }
+    },
+  );
 
-  describe('when add "[arg...]" then argument optional and variadic', () => {
-    getSingleArgCases('[optional...]').forEach(([methodName, cmd]) => {
-      test(`using ${methodName}`, () => {
-        const argument = cmd.registeredArguments[0];
-        assert.equal(argument._name, 'optional');
-        assert.equal(argument.required, false);
-        assert.equal(argument.variadic, true);
-        assert.equal(argument.description, '');
-      });
-    });
-  });
+  await t.test(
+    'when add "[arg...]" then argument optional and variadic',
+    async (t) => {
+      for (const [methodName, cmd] of getSingleArgCases('[optional...]')) {
+        await t.test(`using ${methodName}`, () => {
+          const argument = cmd.registeredArguments[0];
+          assert.equal(argument._name, 'optional');
+          assert.equal(argument.required, false);
+          assert.equal(argument.variadic, true);
+          assert.equal(argument.description, '');
+        });
+      }
+    },
+  );
 
   function getSingleArgCases(arg) {
     return [
@@ -92,13 +106,16 @@ describe('Command arguments added using different methods', () => {
     ];
   }
 
-  describe('when add two arguments then two arguments', () => {
-    getMultipleArgCases('<first>', '[second]').forEach(([methodName, cmd]) => {
-      test(`using ${methodName}`, () => {
+  await t.test('when add two arguments then two arguments', async (t) => {
+    for (const [methodName, cmd] of getMultipleArgCases(
+      '<first>',
+      '[second]',
+    )) {
+      await t.test(`using ${methodName}`, () => {
         assert.equal(cmd.registeredArguments[0].name(), 'first');
         assert.equal(cmd.registeredArguments[1].name(), 'second');
       });
-    });
+    }
   });
 
   function getMultipleArgCases(arg1, arg2) {
@@ -115,21 +132,24 @@ describe('Command arguments added using different methods', () => {
     ];
   }
 
-  test('when add arguments using multiple methods then all added', () => {
-    // This is not a key use case, but explicitly test that additive behaviour.
-    const program = new commander.Command();
-    const cmd = program.command('sub <arg1> <arg2>');
-    cmd.arguments('<arg3> <arg4>');
-    cmd.argument('<arg5>');
-    cmd.addArgument(new commander.Argument('arg6'));
-    const argNames = cmd.registeredArguments.map((arg) => arg.name());
-    assert.deepEqual(argNames, [
-      'arg1',
-      'arg2',
-      'arg3',
-      'arg4',
-      'arg5',
-      'arg6',
-    ]);
-  });
+  await t.test(
+    'when add arguments using multiple methods then all added',
+    () => {
+      // This is not a key use case, but explicitly test that additive behaviour.
+      const program = new commander.Command();
+      const cmd = program.command('sub <arg1> <arg2>');
+      cmd.arguments('<arg3> <arg4>');
+      cmd.argument('<arg5>');
+      cmd.addArgument(new commander.Argument('arg6'));
+      const argNames = cmd.registeredArguments.map((arg) => arg.name());
+      assert.deepEqual(argNames, [
+        'arg1',
+        'arg2',
+        'arg3',
+        'arg4',
+        'arg5',
+        'arg6',
+      ]);
+    },
+  );
 });

--- a/tests/command.argumentVariations.test.js
+++ b/tests/command.argumentVariations.test.js
@@ -5,8 +5,8 @@ import assert from 'node:assert/strict';
 // Do some low-level checks that the multiple ways of specifying command arguments produce same internal result,
 // and not exhaustively testing all methods elsewhere.
 
-test('Command arguments added using different methods', async (t) => {
-  await t.test('when add "<arg>" then argument required', async (t) => {
+describe('Command arguments added using different methods', () => {
+  test('when add "<arg>" then argument required', async (t) => {
     for (const [methodName, cmd] of getSingleArgCases('<explicit-required>')) {
       await t.test(`using ${methodName}`, () => {
         const argument = cmd.registeredArguments[0];
@@ -18,7 +18,7 @@ test('Command arguments added using different methods', async (t) => {
     }
   });
 
-  await t.test('when add "arg" then argument required', async (t) => {
+  test('when add "arg" then argument required', async (t) => {
     for (const [methodName, cmd] of getSingleArgCases('implicit-required')) {
       await t.test(`using ${methodName}`, () => {
         const argument = cmd.registeredArguments[0];
@@ -30,7 +30,7 @@ test('Command arguments added using different methods', async (t) => {
     }
   });
 
-  await t.test('when add "[arg]" then argument optional', async (t) => {
+  test('when add "[arg]" then argument optional', async (t) => {
     for (const [methodName, cmd] of getSingleArgCases('[optional]')) {
       await t.test(`using ${methodName}`, () => {
         const argument = cmd.registeredArguments[0];
@@ -42,54 +42,43 @@ test('Command arguments added using different methods', async (t) => {
     }
   });
 
-  await t.test(
-    'when add "<arg...>" then argument required and variadic',
-    async (t) => {
-      for (const [methodName, cmd] of getSingleArgCases(
-        '<explicit-required...>',
-      )) {
-        await t.test(`using ${methodName}`, () => {
-          const argument = cmd.registeredArguments[0];
-          assert.equal(argument._name, 'explicit-required');
-          assert.equal(argument.required, true);
-          assert.equal(argument.variadic, true);
-          assert.equal(argument.description, '');
-        });
-      }
-    },
-  );
+  test('when add "<arg...>" then argument required and variadic', async (t) => {
+    for (const [methodName, cmd] of getSingleArgCases(
+      '<explicit-required...>',
+    )) {
+      await t.test(`using ${methodName}`, () => {
+        const argument = cmd.registeredArguments[0];
+        assert.equal(argument._name, 'explicit-required');
+        assert.equal(argument.required, true);
+        assert.equal(argument.variadic, true);
+        assert.equal(argument.description, '');
+      });
+    }
+  });
 
-  await t.test(
-    'when add "arg..." then argument required and variadic',
-    async (t) => {
-      for (const [methodName, cmd] of getSingleArgCases(
-        'implicit-required...',
-      )) {
-        await t.test(`using ${methodName}`, () => {
-          const argument = cmd.registeredArguments[0];
-          assert.equal(argument._name, 'implicit-required');
-          assert.equal(argument.required, true);
-          assert.equal(argument.variadic, true);
-          assert.equal(argument.description, '');
-        });
-      }
-    },
-  );
+  test('when add "arg..." then argument required and variadic', async (t) => {
+    for (const [methodName, cmd] of getSingleArgCases('implicit-required...')) {
+      await t.test(`using ${methodName}`, () => {
+        const argument = cmd.registeredArguments[0];
+        assert.equal(argument._name, 'implicit-required');
+        assert.equal(argument.required, true);
+        assert.equal(argument.variadic, true);
+        assert.equal(argument.description, '');
+      });
+    }
+  });
 
-  await t.test(
-    'when add "[arg...]" then argument optional and variadic',
-    async (t) => {
-      for (const [methodName, cmd] of getSingleArgCases('[optional...]')) {
-        await t.test(`using ${methodName}`, () => {
-          const argument = cmd.registeredArguments[0];
-          assert.equal(argument._name, 'optional');
-          assert.equal(argument.required, false);
-          assert.equal(argument.variadic, true);
-          assert.equal(argument.description, '');
-        });
-      }
-    },
-  );
+  test('when add "[arg...]" then argument optional and variadic', async (t) => {
+    for (const [methodName, cmd] of getSingleArgCases('[optional...]')) {
+      await t.test(`using ${methodName}`, () => {
+        const argument = cmd.registeredArguments[0];
+        assert.equal(argument._name, 'optional');
+        assert.equal(argument.required, false);
+        assert.equal(argument.variadic, true);
+        assert.equal(argument.description, '');
+      });
+    }
+  });
 
   function getSingleArgCases(arg) {
     return [
@@ -105,7 +94,7 @@ test('Command arguments added using different methods', async (t) => {
     ];
   }
 
-  await t.test('when add two arguments then two arguments', async (t) => {
+  test('when add two arguments then two arguments', async (t) => {
     for (const [methodName, cmd] of getMultipleArgCases(
       '<first>',
       '[second]',
@@ -131,24 +120,21 @@ test('Command arguments added using different methods', async (t) => {
     ];
   }
 
-  await t.test(
-    'when add arguments using multiple methods then all added',
-    () => {
-      // This is not a key use case, but explicitly test that additive behaviour.
-      const program = new commander.Command();
-      const cmd = program.command('sub <arg1> <arg2>');
-      cmd.arguments('<arg3> <arg4>');
-      cmd.argument('<arg5>');
-      cmd.addArgument(new commander.Argument('arg6'));
-      const argNames = cmd.registeredArguments.map((arg) => arg.name());
-      assert.deepEqual(argNames, [
-        'arg1',
-        'arg2',
-        'arg3',
-        'arg4',
-        'arg5',
-        'arg6',
-      ]);
-    },
-  );
+  test('when add arguments using multiple methods then all added', () => {
+    // This is not a key use case, but explicitly test that additive behaviour.
+    const program = new commander.Command();
+    const cmd = program.command('sub <arg1> <arg2>');
+    cmd.arguments('<arg3> <arg4>');
+    cmd.argument('<arg5>');
+    cmd.addArgument(new commander.Argument('arg6'));
+    const argNames = cmd.registeredArguments.map((arg) => arg.name());
+    assert.deepEqual(argNames, [
+      'arg1',
+      'arg2',
+      'arg3',
+      'arg4',
+      'arg5',
+      'arg6',
+    ]);
+  });
 });

--- a/tests/command.configureOutput.test.js
+++ b/tests/command.configureOutput.test.js
@@ -3,8 +3,8 @@ import assert from 'node:assert/strict';
 import * as commander from '../index.js';
 import process from 'node:process';
 
-test('Command.configureOutput()', async (t) => {
-  await t.test('when default writeErr() then error on stderr', (t) => {
+describe('Command.configureOutput()', () => {
+  test('when default writeErr() then error on stderr', (t) => {
     const writeSpy = t.mock.method(process.stderr, 'write', () => {});
     const program = new commander.Command();
     program.exitOverride();
@@ -18,7 +18,7 @@ test('Command.configureOutput()', async (t) => {
     assert.equal(writeSpy.mock.callCount(), 1);
   });
 
-  await t.test('when custom writeErr() then error on custom output', (t) => {
+  test('when custom writeErr() then error on custom output', (t) => {
     const writeSpy = t.mock.method(process.stderr, 'write', () => {});
     const customWrite = t.mock.fn();
     const program = new commander.Command();
@@ -34,7 +34,7 @@ test('Command.configureOutput()', async (t) => {
     assert.equal(customWrite.mock.callCount(), 1);
   });
 
-  await t.test('when default write() then version on stdout', (t) => {
+  test('when default write() then version on stdout', (t) => {
     const writeSpy = t.mock.method(process.stdout, 'write', () => {});
     const program = new commander.Command();
     program.exitOverride().version('1.2.3');
@@ -49,7 +49,7 @@ test('Command.configureOutput()', async (t) => {
     assert.equal(writeSpy.mock.callCount(), 1);
   });
 
-  await t.test('when custom write() then version on custom output', (t) => {
+  test('when custom write() then version on custom output', (t) => {
     const writeSpy = t.mock.method(process.stdout, 'write', () => {});
     const customWrite = t.mock.fn();
     const program = new commander.Command();
@@ -69,7 +69,7 @@ test('Command.configureOutput()', async (t) => {
     assert.equal(customWrite.mock.callCount(), 1);
   });
 
-  await t.test('when default write() then help on stdout', (t) => {
+  test('when default write() then help on stdout', (t) => {
     const writeSpy = t.mock.method(process.stdout, 'write', () => {});
     const program = new commander.Command();
     program.outputHelp();
@@ -77,7 +77,7 @@ test('Command.configureOutput()', async (t) => {
     assert.equal(writeSpy.mock.callCount(), 1);
   });
 
-  await t.test('when custom write() then help error on custom output', (t) => {
+  test('when custom write() then help error on custom output', (t) => {
     const writeSpy = t.mock.method(process.stdout, 'write', () => {});
     const customWrite = t.mock.fn();
     const program = new commander.Command();
@@ -88,7 +88,7 @@ test('Command.configureOutput()', async (t) => {
     assert.equal(customWrite.mock.callCount(), 1);
   });
 
-  await t.test('when default writeErr then help error on stderr', (t) => {
+  test('when default writeErr then help error on stderr', (t) => {
     const writeSpy = t.mock.method(process.stderr, 'write', () => {});
     const program = new commander.Command();
     program.outputHelp({ error: true });
@@ -96,7 +96,7 @@ test('Command.configureOutput()', async (t) => {
     assert.equal(writeSpy.mock.callCount(), 1);
   });
 
-  await t.test('when custom writeErr then help error on custom output', (t) => {
+  test('when custom writeErr then help error on custom output', (t) => {
     const writeSpy = t.mock.method(process.stderr, 'write', () => {});
     const customWrite = t.mock.fn();
     const program = new commander.Command();
@@ -107,33 +107,30 @@ test('Command.configureOutput()', async (t) => {
     assert.equal(customWrite.mock.callCount(), 1);
   });
 
-  await t.test(
-    'when default getOutHelpWidth then help helpWidth from stdout',
-    () => {
-      const expectedColumns = 123;
-      const holdIsTTY = process.stdout.isTTY;
-      const holdColumns = process.stdout.columns;
-      let helpWidth;
+  test('when default getOutHelpWidth then help helpWidth from stdout', () => {
+    const expectedColumns = 123;
+    const holdIsTTY = process.stdout.isTTY;
+    const holdColumns = process.stdout.columns;
+    let helpWidth;
 
-      process.stderr.isTTY = true;
-      process.stdout.columns = expectedColumns;
-      process.stdout.isTTY = true;
-      const program = new commander.Command();
-      program.configureHelp({
-        formatHelp: (cmd, helper) => {
-          helpWidth = helper.helpWidth;
-          return '';
-        },
-      });
-      program.outputHelp();
+    process.stderr.isTTY = true;
+    process.stdout.columns = expectedColumns;
+    process.stdout.isTTY = true;
+    const program = new commander.Command();
+    program.configureHelp({
+      formatHelp: (cmd, helper) => {
+        helpWidth = helper.helpWidth;
+        return '';
+      },
+    });
+    program.outputHelp();
 
-      assert.equal(helpWidth, expectedColumns);
-      process.stdout.columns = holdColumns;
-      process.stdout.isTTY = holdIsTTY;
-    },
-  );
+    assert.equal(helpWidth, expectedColumns);
+    process.stdout.columns = holdColumns;
+    process.stdout.isTTY = holdIsTTY;
+  });
 
-  await t.test('when custom getOutHelpWidth then help helpWidth custom', () => {
+  test('when custom getOutHelpWidth then help helpWidth custom', () => {
     const expectedColumns = 123;
     let helpWidth;
 
@@ -153,142 +150,124 @@ test('Command.configureOutput()', async (t) => {
     assert.equal(helpWidth, expectedColumns);
   });
 
-  await t.test(
-    'when default getErrHelpWidth then help error helpWidth from stderr',
-    () => {
-      const expectedColumns = 123;
-      const holdIsTTY = process.stderr.isTTY;
-      const holdColumns = process.stderr.columns;
-      let helpWidth;
+  test('when default getErrHelpWidth then help error helpWidth from stderr', () => {
+    const expectedColumns = 123;
+    const holdIsTTY = process.stderr.isTTY;
+    const holdColumns = process.stderr.columns;
+    let helpWidth;
 
-      process.stderr.isTTY = true;
-      process.stderr.columns = expectedColumns;
-      const program = new commander.Command();
-      program.configureHelp({
+    process.stderr.isTTY = true;
+    process.stderr.columns = expectedColumns;
+    const program = new commander.Command();
+    program.configureHelp({
+      formatHelp: (cmd, helper) => {
+        helpWidth = helper.helpWidth;
+        return '';
+      },
+    });
+    program.outputHelp({ error: true });
+
+    assert.equal(helpWidth, expectedColumns);
+    process.stderr.isTTY = holdIsTTY;
+    process.stderr.columns = holdColumns;
+  });
+
+  test('when custom getErrHelpWidth then help error helpWidth custom', () => {
+    const expectedColumns = 123;
+    let helpWidth;
+
+    const program = new commander.Command();
+    program
+      .configureHelp({
         formatHelp: (cmd, helper) => {
           helpWidth = helper.helpWidth;
           return '';
         },
+      })
+      .configureOutput({
+        getErrHelpWidth: () => expectedColumns,
       });
-      program.outputHelp({ error: true });
+    program.outputHelp({ error: true });
 
-      assert.equal(helpWidth, expectedColumns);
-      process.stderr.isTTY = holdIsTTY;
-      process.stderr.columns = holdColumns;
-    },
-  );
+    assert.equal(helpWidth, expectedColumns);
+  });
 
-  await t.test(
-    'when custom getErrHelpWidth then help error helpWidth custom',
-    () => {
-      const expectedColumns = 123;
-      let helpWidth;
+  test('when custom getOutHelpWidth and configureHelp:helpWidth then help helpWidth from configureHelp', () => {
+    const expectedColumns = 123;
+    let helpWidth;
 
-      const program = new commander.Command();
-      program
-        .configureHelp({
-          formatHelp: (cmd, helper) => {
-            helpWidth = helper.helpWidth;
-            return '';
-          },
-        })
-        .configureOutput({
-          getErrHelpWidth: () => expectedColumns,
-        });
-      program.outputHelp({ error: true });
+    const program = new commander.Command();
+    program
+      .configureHelp({
+        formatHelp: (cmd, helper) => {
+          helpWidth = helper.helpWidth;
+          return '';
+        },
+        helpWidth: expectedColumns,
+      })
+      .configureOutput({
+        getOutHelpWidth: () => 999,
+      });
+    program.outputHelp();
 
-      assert.equal(helpWidth, expectedColumns);
-    },
-  );
+    assert.equal(helpWidth, expectedColumns);
+  });
 
-  await t.test(
-    'when custom getOutHelpWidth and configureHelp:helpWidth then help helpWidth from configureHelp',
-    () => {
-      const expectedColumns = 123;
-      let helpWidth;
+  test('when custom getErrHelpWidth and configureHelp:helpWidth then help error helpWidth from configureHelp', () => {
+    const expectedColumns = 123;
+    let helpWidth;
 
-      const program = new commander.Command();
-      program
-        .configureHelp({
-          formatHelp: (cmd, helper) => {
-            helpWidth = helper.helpWidth;
-            return '';
-          },
-          helpWidth: expectedColumns,
-        })
-        .configureOutput({
-          getOutHelpWidth: () => 999,
-        });
-      program.outputHelp();
+    const program = new commander.Command();
+    program
+      .configureHelp({
+        formatHelp: (cmd, helper) => {
+          helpWidth = helper.helpWidth;
+          return '';
+        },
+        helpWidth: expectedColumns,
+      })
+      .configureOutput({
+        getErrHelpWidth: () => 999,
+      });
+    program.outputHelp({ error: true });
 
-      assert.equal(helpWidth, expectedColumns);
-    },
-  );
+    assert.equal(helpWidth, expectedColumns);
+  });
 
-  await t.test(
-    'when custom getErrHelpWidth and configureHelp:helpWidth then help error helpWidth from configureHelp',
-    () => {
-      const expectedColumns = 123;
-      let helpWidth;
+  test('when no custom setup and call formatHelp direct then effective helpWidth is fallback 80', () => {
+    // Not an important case, but filling out testing coverage.
+    const helper = new commander.Help();
+    let wrapWidth;
+    helper.boxWrap = (str, width) => {
+      wrapWidth = wrapWidth ?? width;
+      return '';
+    };
+    const program = new commander.Command()
+      .description('description')
+      .helpOption(false);
+    helper.formatHelp(program, helper);
+    assert.equal(wrapWidth, 80);
+  });
 
-      const program = new commander.Command();
-      program
-        .configureHelp({
-          formatHelp: (cmd, helper) => {
-            helpWidth = helper.helpWidth;
-            return '';
-          },
-          helpWidth: expectedColumns,
-        })
-        .configureOutput({
-          getErrHelpWidth: () => 999,
-        });
-      program.outputHelp({ error: true });
+  test('when no custom setup and call formatItem direct then effective helpWidth is fallback 80', () => {
+    // Not an important case, but filling out testing coverage.
+    const helper = new commander.Help();
+    let wrapWidth;
+    helper.boxWrap = (str, width) => {
+      wrapWidth = wrapWidth ?? width;
+      return '';
+    };
 
-      assert.equal(helpWidth, expectedColumns);
-    },
-  );
+    const termWidth = 8;
+    helper.formatItem('term', termWidth, 'description', helper);
+    const itemIndent = 2;
+    const spacerWidth = 2; // between term and description
+    const remainingWidth = 80 - termWidth - spacerWidth - itemIndent;
 
-  await t.test(
-    'when no custom setup and call formatHelp direct then effective helpWidth is fallback 80',
-    () => {
-      // Not an important case, but filling out testing coverage.
-      const helper = new commander.Help();
-      let wrapWidth;
-      helper.boxWrap = (str, width) => {
-        wrapWidth = wrapWidth ?? width;
-        return '';
-      };
-      const program = new commander.Command()
-        .description('description')
-        .helpOption(false);
-      helper.formatHelp(program, helper);
-      assert.equal(wrapWidth, 80);
-    },
-  );
+    assert.equal(wrapWidth, remainingWidth);
+  });
 
-  await t.test(
-    'when no custom setup and call formatItem direct then effective helpWidth is fallback 80',
-    () => {
-      // Not an important case, but filling out testing coverage.
-      const helper = new commander.Help();
-      let wrapWidth;
-      helper.boxWrap = (str, width) => {
-        wrapWidth = wrapWidth ?? width;
-        return '';
-      };
-
-      const termWidth = 8;
-      helper.formatItem('term', termWidth, 'description', helper);
-      const itemIndent = 2;
-      const spacerWidth = 2; // between term and description
-      const remainingWidth = 80 - termWidth - spacerWidth - itemIndent;
-
-      assert.equal(wrapWidth, remainingWidth);
-    },
-  );
-
-  await t.test('when set configureOutput then get configureOutput', (t) => {
+  test('when set configureOutput then get configureOutput', (t) => {
     const outputOptions = {
       writeOut: t.mock.fn(),
       writeErr: t.mock.fn(),
@@ -304,7 +283,7 @@ test('Command.configureOutput()', async (t) => {
     assert.deepEqual(program.configureOutput(), outputOptions);
   });
 
-  await t.test('when custom outputErr and error then outputErr called', (t) => {
+  test('when custom outputErr and error then outputErr called', (t) => {
     const outputError = t.mock.fn();
     const program = new commander.Command();
     program.exitOverride().configureOutput({
@@ -327,43 +306,37 @@ test('Command.configureOutput()', async (t) => {
     );
   });
 
-  await t.test(
-    'when custom outputErr and writeErr and error then outputErr passed writeErr',
-    (t) => {
-      const writeErr = () => t.mock.fn();
-      const outputError = t.mock.fn();
-      const program = new commander.Command();
-      program.exitOverride().configureOutput({ writeErr, outputError });
+  test('when custom outputErr and writeErr and error then outputErr passed writeErr', (t) => {
+    const writeErr = () => t.mock.fn();
+    const outputError = t.mock.fn();
+    const program = new commander.Command();
+    program.exitOverride().configureOutput({ writeErr, outputError });
 
-      assert.throws(
-        () => {
-          program.parse(['--unknownOption'], { from: 'user' });
-        },
-        { code: 'commander.unknownOption' },
-      );
-      assert.equal(
-        outputError.mock.calls[0].arguments[0],
-        "error: unknown option '--unknownOption'\n",
-      );
-      assert.equal(outputError.mock.calls[0].arguments[1], writeErr);
-    },
-  );
+    assert.throws(
+      () => {
+        program.parse(['--unknownOption'], { from: 'user' });
+      },
+      { code: 'commander.unknownOption' },
+    );
+    assert.equal(
+      outputError.mock.calls[0].arguments[0],
+      "error: unknown option '--unknownOption'\n",
+    );
+    assert.equal(outputError.mock.calls[0].arguments[1], writeErr);
+  });
 
-  await t.test(
-    'when configureOutput after copyInheritedSettings then original unchanged',
-    () => {
-      const program = new commander.Command();
-      program.configureOutput({ getOutHelpWidth: () => 80 });
-      const copy = program.createCommand('copy');
-      copy.copyInheritedSettings(program);
-      assert.equal(copy.configureOutput().getOutHelpWidth(), 80);
-      copy.configureOutput({ getOutHelpWidth: () => 40 });
-      assert.equal(copy.configureOutput().getOutHelpWidth(), 40);
-      assert.equal(program.configureOutput().getOutHelpWidth(), 80);
-    },
-  );
+  test('when configureOutput after copyInheritedSettings then original unchanged', () => {
+    const program = new commander.Command();
+    program.configureOutput({ getOutHelpWidth: () => 80 });
+    const copy = program.createCommand('copy');
+    copy.copyInheritedSettings(program);
+    assert.equal(copy.configureOutput().getOutHelpWidth(), 80);
+    copy.configureOutput({ getOutHelpWidth: () => 40 });
+    assert.equal(copy.configureOutput().getOutHelpWidth(), 40);
+    assert.equal(program.configureOutput().getOutHelpWidth(), 80);
+  });
 
-  await t.test('environment variable tests', async (t) => {
+  test('environment variable tests', async (t) => {
     const testCases = [
       ['NO_COLOR', false],
       ['FORCE_COLOR', true],

--- a/tests/command.configureOutput.test.js
+++ b/tests/command.configureOutput.test.js
@@ -3,8 +3,8 @@ import assert from 'node:assert/strict';
 import * as commander from '../index.js';
 import process from 'node:process';
 
-describe('Command.configureOutput()', () => {
-  test('when default writeErr() then error on stderr', (t) => {
+test('Command.configureOutput()', async (t) => {
+  await t.test('when default writeErr() then error on stderr', (t) => {
     const writeSpy = t.mock.method(process.stderr, 'write', () => {});
     const program = new commander.Command();
     program.exitOverride();
@@ -18,7 +18,7 @@ describe('Command.configureOutput()', () => {
     assert.equal(writeSpy.mock.callCount(), 1);
   });
 
-  test('when custom writeErr() then error on custom output', (t) => {
+  await t.test('when custom writeErr() then error on custom output', (t) => {
     const writeSpy = t.mock.method(process.stderr, 'write', () => {});
     const customWrite = t.mock.fn();
     const program = new commander.Command();
@@ -34,7 +34,7 @@ describe('Command.configureOutput()', () => {
     assert.equal(customWrite.mock.callCount(), 1);
   });
 
-  test('when default write() then version on stdout', (t) => {
+  await t.test('when default write() then version on stdout', (t) => {
     const writeSpy = t.mock.method(process.stdout, 'write', () => {});
     const program = new commander.Command();
     program.exitOverride().version('1.2.3');
@@ -49,7 +49,7 @@ describe('Command.configureOutput()', () => {
     assert.equal(writeSpy.mock.callCount(), 1);
   });
 
-  test('when custom write() then version on custom output', (t) => {
+  await t.test('when custom write() then version on custom output', (t) => {
     const writeSpy = t.mock.method(process.stdout, 'write', () => {});
     const customWrite = t.mock.fn();
     const program = new commander.Command();
@@ -69,7 +69,7 @@ describe('Command.configureOutput()', () => {
     assert.equal(customWrite.mock.callCount(), 1);
   });
 
-  test('when default write() then help on stdout', (t) => {
+  await t.test('when default write() then help on stdout', (t) => {
     const writeSpy = t.mock.method(process.stdout, 'write', () => {});
     const program = new commander.Command();
     program.outputHelp();
@@ -77,7 +77,7 @@ describe('Command.configureOutput()', () => {
     assert.equal(writeSpy.mock.callCount(), 1);
   });
 
-  test('when custom write() then help error on custom output', (t) => {
+  await t.test('when custom write() then help error on custom output', (t) => {
     const writeSpy = t.mock.method(process.stdout, 'write', () => {});
     const customWrite = t.mock.fn();
     const program = new commander.Command();
@@ -88,7 +88,7 @@ describe('Command.configureOutput()', () => {
     assert.equal(customWrite.mock.callCount(), 1);
   });
 
-  test('when default writeErr then help error on stderr', (t) => {
+  await t.test('when default writeErr then help error on stderr', (t) => {
     const writeSpy = t.mock.method(process.stderr, 'write', () => {});
     const program = new commander.Command();
     program.outputHelp({ error: true });
@@ -96,7 +96,7 @@ describe('Command.configureOutput()', () => {
     assert.equal(writeSpy.mock.callCount(), 1);
   });
 
-  test('when custom writeErr then help error on custom output', (t) => {
+  await t.test('when custom writeErr then help error on custom output', (t) => {
     const writeSpy = t.mock.method(process.stderr, 'write', () => {});
     const customWrite = t.mock.fn();
     const program = new commander.Command();
@@ -107,30 +107,33 @@ describe('Command.configureOutput()', () => {
     assert.equal(customWrite.mock.callCount(), 1);
   });
 
-  test('when default getOutHelpWidth then help helpWidth from stdout', () => {
-    const expectedColumns = 123;
-    const holdIsTTY = process.stdout.isTTY;
-    const holdColumns = process.stdout.columns;
-    let helpWidth;
+  await t.test(
+    'when default getOutHelpWidth then help helpWidth from stdout',
+    () => {
+      const expectedColumns = 123;
+      const holdIsTTY = process.stdout.isTTY;
+      const holdColumns = process.stdout.columns;
+      let helpWidth;
 
-    process.stderr.isTTY = true;
-    process.stdout.columns = expectedColumns;
-    process.stdout.isTTY = true;
-    const program = new commander.Command();
-    program.configureHelp({
-      formatHelp: (cmd, helper) => {
-        helpWidth = helper.helpWidth;
-        return '';
-      },
-    });
-    program.outputHelp();
+      process.stderr.isTTY = true;
+      process.stdout.columns = expectedColumns;
+      process.stdout.isTTY = true;
+      const program = new commander.Command();
+      program.configureHelp({
+        formatHelp: (cmd, helper) => {
+          helpWidth = helper.helpWidth;
+          return '';
+        },
+      });
+      program.outputHelp();
 
-    assert.equal(helpWidth, expectedColumns);
-    process.stdout.columns = holdColumns;
-    process.stdout.isTTY = holdIsTTY;
-  });
+      assert.equal(helpWidth, expectedColumns);
+      process.stdout.columns = holdColumns;
+      process.stdout.isTTY = holdIsTTY;
+    },
+  );
 
-  test('when custom getOutHelpWidth then help helpWidth custom', () => {
+  await t.test('when custom getOutHelpWidth then help helpWidth custom', () => {
     const expectedColumns = 123;
     let helpWidth;
 
@@ -150,124 +153,142 @@ describe('Command.configureOutput()', () => {
     assert.equal(helpWidth, expectedColumns);
   });
 
-  test('when default getErrHelpWidth then help error helpWidth from stderr', () => {
-    const expectedColumns = 123;
-    const holdIsTTY = process.stderr.isTTY;
-    const holdColumns = process.stderr.columns;
-    let helpWidth;
+  await t.test(
+    'when default getErrHelpWidth then help error helpWidth from stderr',
+    () => {
+      const expectedColumns = 123;
+      const holdIsTTY = process.stderr.isTTY;
+      const holdColumns = process.stderr.columns;
+      let helpWidth;
 
-    process.stderr.isTTY = true;
-    process.stderr.columns = expectedColumns;
-    const program = new commander.Command();
-    program.configureHelp({
-      formatHelp: (cmd, helper) => {
-        helpWidth = helper.helpWidth;
+      process.stderr.isTTY = true;
+      process.stderr.columns = expectedColumns;
+      const program = new commander.Command();
+      program.configureHelp({
+        formatHelp: (cmd, helper) => {
+          helpWidth = helper.helpWidth;
+          return '';
+        },
+      });
+      program.outputHelp({ error: true });
+
+      assert.equal(helpWidth, expectedColumns);
+      process.stderr.isTTY = holdIsTTY;
+      process.stderr.columns = holdColumns;
+    },
+  );
+
+  await t.test(
+    'when custom getErrHelpWidth then help error helpWidth custom',
+    () => {
+      const expectedColumns = 123;
+      let helpWidth;
+
+      const program = new commander.Command();
+      program
+        .configureHelp({
+          formatHelp: (cmd, helper) => {
+            helpWidth = helper.helpWidth;
+            return '';
+          },
+        })
+        .configureOutput({
+          getErrHelpWidth: () => expectedColumns,
+        });
+      program.outputHelp({ error: true });
+
+      assert.equal(helpWidth, expectedColumns);
+    },
+  );
+
+  await t.test(
+    'when custom getOutHelpWidth and configureHelp:helpWidth then help helpWidth from configureHelp',
+    () => {
+      const expectedColumns = 123;
+      let helpWidth;
+
+      const program = new commander.Command();
+      program
+        .configureHelp({
+          formatHelp: (cmd, helper) => {
+            helpWidth = helper.helpWidth;
+            return '';
+          },
+          helpWidth: expectedColumns,
+        })
+        .configureOutput({
+          getOutHelpWidth: () => 999,
+        });
+      program.outputHelp();
+
+      assert.equal(helpWidth, expectedColumns);
+    },
+  );
+
+  await t.test(
+    'when custom getErrHelpWidth and configureHelp:helpWidth then help error helpWidth from configureHelp',
+    () => {
+      const expectedColumns = 123;
+      let helpWidth;
+
+      const program = new commander.Command();
+      program
+        .configureHelp({
+          formatHelp: (cmd, helper) => {
+            helpWidth = helper.helpWidth;
+            return '';
+          },
+          helpWidth: expectedColumns,
+        })
+        .configureOutput({
+          getErrHelpWidth: () => 999,
+        });
+      program.outputHelp({ error: true });
+
+      assert.equal(helpWidth, expectedColumns);
+    },
+  );
+
+  await t.test(
+    'when no custom setup and call formatHelp direct then effective helpWidth is fallback 80',
+    () => {
+      // Not an important case, but filling out testing coverage.
+      const helper = new commander.Help();
+      let wrapWidth;
+      helper.boxWrap = (str, width) => {
+        wrapWidth = wrapWidth ?? width;
         return '';
-      },
-    });
-    program.outputHelp({ error: true });
+      };
+      const program = new commander.Command()
+        .description('description')
+        .helpOption(false);
+      helper.formatHelp(program, helper);
+      assert.equal(wrapWidth, 80);
+    },
+  );
 
-    assert.equal(helpWidth, expectedColumns);
-    process.stderr.isTTY = holdIsTTY;
-    process.stderr.columns = holdColumns;
-  });
+  await t.test(
+    'when no custom setup and call formatItem direct then effective helpWidth is fallback 80',
+    () => {
+      // Not an important case, but filling out testing coverage.
+      const helper = new commander.Help();
+      let wrapWidth;
+      helper.boxWrap = (str, width) => {
+        wrapWidth = wrapWidth ?? width;
+        return '';
+      };
 
-  test('when custom getErrHelpWidth then help error helpWidth custom', () => {
-    const expectedColumns = 123;
-    let helpWidth;
+      const termWidth = 8;
+      helper.formatItem('term', termWidth, 'description', helper);
+      const itemIndent = 2;
+      const spacerWidth = 2; // between term and description
+      const remainingWidth = 80 - termWidth - spacerWidth - itemIndent;
 
-    const program = new commander.Command();
-    program
-      .configureHelp({
-        formatHelp: (cmd, helper) => {
-          helpWidth = helper.helpWidth;
-          return '';
-        },
-      })
-      .configureOutput({
-        getErrHelpWidth: () => expectedColumns,
-      });
-    program.outputHelp({ error: true });
+      assert.equal(wrapWidth, remainingWidth);
+    },
+  );
 
-    assert.equal(helpWidth, expectedColumns);
-  });
-
-  test('when custom getOutHelpWidth and configureHelp:helpWidth then help helpWidth from configureHelp', () => {
-    const expectedColumns = 123;
-    let helpWidth;
-
-    const program = new commander.Command();
-    program
-      .configureHelp({
-        formatHelp: (cmd, helper) => {
-          helpWidth = helper.helpWidth;
-          return '';
-        },
-        helpWidth: expectedColumns,
-      })
-      .configureOutput({
-        getOutHelpWidth: () => 999,
-      });
-    program.outputHelp();
-
-    assert.equal(helpWidth, expectedColumns);
-  });
-
-  test('when custom getErrHelpWidth and configureHelp:helpWidth then help error helpWidth from configureHelp', () => {
-    const expectedColumns = 123;
-    let helpWidth;
-
-    const program = new commander.Command();
-    program
-      .configureHelp({
-        formatHelp: (cmd, helper) => {
-          helpWidth = helper.helpWidth;
-          return '';
-        },
-        helpWidth: expectedColumns,
-      })
-      .configureOutput({
-        getErrHelpWidth: () => 999,
-      });
-    program.outputHelp({ error: true });
-
-    assert.equal(helpWidth, expectedColumns);
-  });
-
-  test('when no custom setup and call formatHelp direct then effective helpWidth is fallback 80', () => {
-    // Not an important case, but filling out testing coverage.
-    const helper = new commander.Help();
-    let wrapWidth;
-    helper.boxWrap = (str, width) => {
-      wrapWidth = wrapWidth ?? width;
-      return '';
-    };
-    const program = new commander.Command()
-      .description('description')
-      .helpOption(false);
-    helper.formatHelp(program, helper);
-    assert.equal(wrapWidth, 80);
-  });
-
-  test('when no custom setup and call formatItem direct then effective helpWidth is fallback 80', () => {
-    // Not an important case, but filling out testing coverage.
-    const helper = new commander.Help();
-    let wrapWidth;
-    helper.boxWrap = (str, width) => {
-      wrapWidth = wrapWidth ?? width;
-      return '';
-    };
-
-    const termWidth = 8;
-    helper.formatItem('term', termWidth, 'description', helper);
-    const itemIndent = 2;
-    const spacerWidth = 2; // between term and description
-    const remainingWidth = 80 - termWidth - spacerWidth - itemIndent;
-
-    assert.equal(wrapWidth, remainingWidth);
-  });
-
-  test('when set configureOutput then get configureOutput', (t) => {
+  await t.test('when set configureOutput then get configureOutput', (t) => {
     const outputOptions = {
       writeOut: t.mock.fn(),
       writeErr: t.mock.fn(),
@@ -283,7 +304,7 @@ describe('Command.configureOutput()', () => {
     assert.deepEqual(program.configureOutput(), outputOptions);
   });
 
-  test('when custom outputErr and error then outputErr called', (t) => {
+  await t.test('when custom outputErr and error then outputErr called', (t) => {
     const outputError = t.mock.fn();
     const program = new commander.Command();
     program.exitOverride().configureOutput({
@@ -306,52 +327,62 @@ describe('Command.configureOutput()', () => {
     );
   });
 
-  test('when custom outputErr and writeErr and error then outputErr passed writeErr', (t) => {
-    const writeErr = () => t.mock.fn();
-    const outputError = t.mock.fn();
-    const program = new commander.Command();
-    program.exitOverride().configureOutput({ writeErr, outputError });
+  await t.test(
+    'when custom outputErr and writeErr and error then outputErr passed writeErr',
+    (t) => {
+      const writeErr = () => t.mock.fn();
+      const outputError = t.mock.fn();
+      const program = new commander.Command();
+      program.exitOverride().configureOutput({ writeErr, outputError });
 
-    assert.throws(
-      () => {
-        program.parse(['--unknownOption'], { from: 'user' });
-      },
-      { code: 'commander.unknownOption' },
-    );
-    assert.equal(
-      outputError.mock.calls[0].arguments[0],
-      "error: unknown option '--unknownOption'\n",
-    );
-    assert.equal(outputError.mock.calls[0].arguments[1], writeErr);
-  });
+      assert.throws(
+        () => {
+          program.parse(['--unknownOption'], { from: 'user' });
+        },
+        { code: 'commander.unknownOption' },
+      );
+      assert.equal(
+        outputError.mock.calls[0].arguments[0],
+        "error: unknown option '--unknownOption'\n",
+      );
+      assert.equal(outputError.mock.calls[0].arguments[1], writeErr);
+    },
+  );
 
-  test('when configureOutput after copyInheritedSettings then original unchanged', () => {
-    const program = new commander.Command();
-    program.configureOutput({ getOutHelpWidth: () => 80 });
-    const copy = program.createCommand('copy');
-    copy.copyInheritedSettings(program);
-    assert.equal(copy.configureOutput().getOutHelpWidth(), 80);
-    copy.configureOutput({ getOutHelpWidth: () => 40 });
-    assert.equal(copy.configureOutput().getOutHelpWidth(), 40);
-    assert.equal(program.configureOutput().getOutHelpWidth(), 80);
-  });
+  await t.test(
+    'when configureOutput after copyInheritedSettings then original unchanged',
+    () => {
+      const program = new commander.Command();
+      program.configureOutput({ getOutHelpWidth: () => 80 });
+      const copy = program.createCommand('copy');
+      copy.copyInheritedSettings(program);
+      assert.equal(copy.configureOutput().getOutHelpWidth(), 80);
+      copy.configureOutput({ getOutHelpWidth: () => 40 });
+      assert.equal(copy.configureOutput().getOutHelpWidth(), 40);
+      assert.equal(program.configureOutput().getOutHelpWidth(), 80);
+    },
+  );
 
-  describe('environment variable tests', () => {
-    [
+  await t.test('environment variable tests', async (t) => {
+    const testCases = [
       ['NO_COLOR', false],
       ['FORCE_COLOR', true],
       ['CLICOLOR_FORCE', true],
-    ].forEach(([envvar, expected]) => {
-      test(`when ${envvar} then getFooHasColors returns ${expected}`, () => {
-        // Would like to vary process.istty too, but too hard, so tests here provide only partial cover.
-        const holdEnv = process.env[envvar];
-        process.env[envvar] = '1';
-        const config = new commander.Command().configureOutput();
-        assert.equal(config.getOutHasColors(), expected);
-        assert.equal(config.getErrHasColors(), expected);
-        if (holdEnv === undefined) delete process.env[envvar];
-        else process.env[envvar] = holdEnv;
-      });
-    });
+    ];
+    for (const [envvar, expected] of testCases) {
+      await t.test(
+        `when ${envvar} then getFooHasColors returns ${expected}`,
+        () => {
+          // Would like to vary process.istty too, but too hard, so tests here provide only partial cover.
+          const holdEnv = process.env[envvar];
+          process.env[envvar] = '1';
+          const config = new commander.Command().configureOutput();
+          assert.equal(config.getOutHasColors(), expected);
+          assert.equal(config.getErrHasColors(), expected);
+          if (holdEnv === undefined) delete process.env[envvar];
+          else process.env[envvar] = holdEnv;
+        },
+      );
+    }
   });
 });

--- a/tests/command.executableSubcommand.lookup.test.js
+++ b/tests/command.executableSubcommand.lookup.test.js
@@ -10,9 +10,7 @@ import assert from 'node:assert/strict';
 // This file does end-to-end tests actually spawning program.
 // See also command.executableSubcommand.search.test.js
 
-// Suppress false positive warnings due to use of testOrSkipOnWindows
-
-const testOrSkipOnWindows = process.platform === 'win32' ? test.skip : test;
+const isWindows = process.platform === 'win32';
 const pm = path.join(import.meta.dirname, './fixtures/pm');
 
 describe('executable subcommand lookup', () => {
@@ -68,8 +66,10 @@ describe('executable subcommand lookup', () => {
     assert.equal(stdout, 'publish\n');
   });
 
-  testOrSkipOnWindows(
+  test(
     'when subcommand file is symlink then lookup succeeds',
+    // eslint-disable-next-line node-test/no-skip-test
+    { skip: isWindows },
     async () => {
       const pmlink = path.join(import.meta.dirname, 'fixtures', 'pmlink');
       const { stdout } = await execFileAsync('node', [pmlink, 'install']);
@@ -77,8 +77,10 @@ describe('executable subcommand lookup', () => {
     },
   );
 
-  testOrSkipOnWindows(
+  test(
     'when subcommand file is double symlink then lookup succeeds',
+    // eslint-disable-next-line node-test/no-skip-test
+    { skip: isWindows },
     async () => {
       const pmlink = path.join(
         import.meta.dirname,

--- a/tests/command.executableSubcommand.mock.test.cjs
+++ b/tests/command.executableSubcommand.mock.test.cjs
@@ -16,13 +16,12 @@ function makeSystemError(code) {
   return err;
 }
 
-// Suppress false positive warnings due to use of testOrSkipOnWindows
-
-const testOrSkipOnWindows = process.platform === 'win32' ? test.skip : test;
+const isWindows = process.platform === 'win32';
 
 describe('executable subcommand missing file handling ', () => {
-  testOrSkipOnWindows(
+  test(
     'when subcommand executable missing (ENOENT) then throw custom message',
+    { skip: isWindows },
     (t) => {
       // If the command is not found, we show a custom error with an explanation and offer
       // some advice for possible fixes.
@@ -40,8 +39,9 @@ describe('executable subcommand missing file handling ', () => {
     },
   );
 
-  testOrSkipOnWindows(
+  test(
     'when subcommand executable not executable (EACCES) then throw custom message',
+    { skip: isWindows },
     (t) => {
       const mockProcess = new EventEmitter();
       t.mock.method(childProcess, 'spawn', () => {

--- a/tests/command.executableSubcommand.signals.test.js
+++ b/tests/command.executableSubcommand.signals.test.js
@@ -8,10 +8,10 @@ const pmPath = path.join(import.meta.dirname, 'fixtures', 'pm');
 // Disabling some tests on Windows as:
 // "Windows does not support sending signals"
 //  https://nodejs.org/api/process.html#process_signal_events
-const describeOrSkipOnWindows =
-  process.platform === 'win32' ? describe.skip : describe;
+const isWindows = process.platform === 'win32';
 
-describeOrSkipOnWindows('executable subcommand signals', () => {
+// eslint-disable-next-line node-test/no-skip-test
+describe('executable subcommand signals', { skip: isWindows }, () => {
   describe('signal forwarding tests', () => {
     const signals = ['SIGINT', 'SIGHUP', 'SIGTERM', 'SIGUSR1', 'SIGUSR2'];
     for (const signal of signals) {

--- a/tests/command.executableSubcommand.test.js
+++ b/tests/command.executableSubcommand.test.js
@@ -5,7 +5,6 @@ import assert from 'node:assert/strict';
 // Executable subcommand tests that didn't fit in elsewhere.
 
 // This is the default behaviour when no default command and no action handlers
-// eslint-disable-next-line node-test/require-top-level-describe
 test('when no command specified and executable subcommand then display help', (t) => {
   const program = createTestCommand();
   program.command('install', 'install description');

--- a/tests/command.nested.test.js
+++ b/tests/command.nested.test.js
@@ -2,7 +2,6 @@ import * as commander from '../index.js';
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-// eslint-disable-next-line node-test/require-top-level-describe
 test('when call nested subcommand then runs', (t) => {
   const program = new commander.Command();
   const leafAction = t.mock.fn();

--- a/tests/command.parse.test.js
+++ b/tests/command.parse.test.js
@@ -82,22 +82,26 @@ describe('Command.parse()', () => {
       }, /unexpected parse option/);
     });
 
-    describe('when node execArgv includes node flags', () => {
-      ['-e', '--eval', '-p', '--print'].forEach((flag) => {
-        test(`when node execArgv includes ${flag} then app/args`, () => {
-          const program = new commander.Command();
-          program.argument('[args...]');
-          const holdExecArgv = process.execArgv;
-          const holdArgv = process.argv;
-          process.argv = ['node', 'user-arg'];
-          process.execArgv = [flag, 'console.log("hello, world")'];
-          program.parse();
-          process.argv = holdArgv;
-          process.execArgv = holdExecArgv;
-          assert.deepEqual(program.args, ['user-arg']);
-          process.execArgv = holdExecArgv;
-        });
-      });
+    test('when node execArgv includes node flags', async (t) => {
+      const testCases = ['-e', '--eval', '-p', '--print'];
+      for (const flag of testCases) {
+        await t.test(
+          `when node execArgv includes ${flag} then app/args`,
+          () => {
+            const program = new commander.Command();
+            program.argument('[args...]');
+            const holdExecArgv = process.execArgv;
+            const holdArgv = process.argv;
+            process.argv = ['node', 'user-arg'];
+            process.execArgv = [flag, 'console.log("hello, world")'];
+            program.parse();
+            process.argv = holdArgv;
+            process.execArgv = holdExecArgv;
+            assert.deepEqual(program.args, ['user-arg']);
+            process.execArgv = holdExecArgv;
+          },
+        );
+      }
     });
   });
 

--- a/tests/command.summary.test.js
+++ b/tests/command.summary.test.js
@@ -2,7 +2,6 @@ import * as commander from '../index.js';
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-// eslint-disable-next-line node-test/require-top-level-describe
 test('Command.summary(): when set summary then get summary', () => {
   const program = new commander.Command();
   const summary = 'abcdef';

--- a/tests/help.suggestion.test.js
+++ b/tests/help.suggestion.test.js
@@ -32,7 +32,7 @@ function getSuggestion(program, arg) {
 }
 
 describe('Command.showSuggestionAfterError()', () => {
-  describe('command suggestions', () => {
+  test('command suggestions', async (t) => {
     const commandSuggestionTable = [
       ['yyy', ['zzz'], null, 'none similar'],
       ['a', ['b'], null, 'one edit away but not similar'],
@@ -59,18 +59,24 @@ describe('Command.showSuggestionAfterError()', () => {
         'only closest of different edit distances',
       ],
     ];
-    commandSuggestionTable.forEach(
-      ([arg, commandNames, expected, description]) => {
-        test(`when cli of ${arg} and commands ${JSON.stringify(commandNames)} then suggest ${expected} because ${description}`, () => {
+    for (const [
+      arg,
+      commandNames,
+      expected,
+      description,
+    ] of commandSuggestionTable) {
+      await t.test(
+        `when cli of ${arg} and commands ${JSON.stringify(commandNames)} then suggest ${expected} because ${description}`,
+        () => {
           const program = new Command();
           commandNames.forEach((name) => {
             program.command(name);
           });
           const suggestion = getSuggestion(program, arg);
           assert.equal(suggestion, expected);
-        });
-      },
-    );
+        },
+      );
+    }
   });
 
   test('when similar alias then suggest alias', () => {
@@ -141,7 +147,7 @@ describe('Command.showSuggestionAfterError()', () => {
     assert.equal(suggestion, null);
   });
 
-  describe('option suggestions', () => {
+  test('option suggestions', async (t) => {
     const optionSuggestionTable = [
       ['--yyy', ['--zzz'], null, 'none similar'],
       ['--a', ['--b'], null, 'one edit away but not similar'],
@@ -174,18 +180,24 @@ describe('Command.showSuggestionAfterError()', () => {
       ],
     ];
 
-    optionSuggestionTable.forEach(
-      ([arg, commandNames, expected, description]) => {
-        test(`when cli of ${arg} and options ${JSON.stringify(commandNames)} then suggest ${expected} because ${description}`, () => {
+    for (const [
+      arg,
+      commandNames,
+      expected,
+      description,
+    ] of optionSuggestionTable) {
+      await t.test(
+        `when cli of ${arg} and options ${JSON.stringify(commandNames)} then suggest ${expected} because ${description}`,
+        () => {
           const program = new Command();
           commandNames.forEach((name) => {
             program.option(name);
           });
           const suggestion = getSuggestion(program, arg);
           assert.equal(suggestion, expected);
-        });
-      },
-    );
+        },
+      );
+    }
   });
 
   test('when no options then no suggestion', () => {

--- a/tests/negatives.test.js
+++ b/tests/negatives.test.js
@@ -3,8 +3,8 @@ import { createTestCommand } from './testHelpers.js';
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
 
-test('negative numbers', async (t) => {
-  await t.test('negative numbers in args', async (t) => {
+describe('negative numbers', () => {
+  test('negative numbers in args', async (t) => {
     // boolean is whether is a consumable argument when negative numbers allowed
     const negativeNumbers = [
       ['-.1', true],
@@ -152,102 +152,87 @@ test('negative numbers', async (t) => {
     }
   });
 
-  await t.test(
-    'when complex example with negative numbers then all consumed',
-    () => {
-      const program = new Command();
-      program
-        .option('-o [value]', 'optional')
-        .option('-m <value>', 'required option-argument')
-        .option('-O [value...]', 'optional')
-        .option('-M <value...>', 'required option-argument')
-        .argument('[value...]', 'argument');
-      const args = [
-        '-10',
-        '-O',
-        '-40',
-        '-41',
-        '-M',
-        '-50',
-        '-51',
-        '-o',
-        '-20',
-        '-m',
-        '-30',
-        '-11',
-      ];
-      program.parse(args, { from: 'user' });
-      assert.deepEqual(program.opts(), {
-        o: '-20',
-        m: '-30',
-        O: ['-40', '-41'],
-        M: ['-50', '-51'],
-      });
-      assert.deepEqual(program.args, ['-10', '-11']);
-    },
-  );
+  test('when complex example with negative numbers then all consumed', () => {
+    const program = new Command();
+    program
+      .option('-o [value]', 'optional')
+      .option('-m <value>', 'required option-argument')
+      .option('-O [value...]', 'optional')
+      .option('-M <value...>', 'required option-argument')
+      .argument('[value...]', 'argument');
+    const args = [
+      '-10',
+      '-O',
+      '-40',
+      '-41',
+      '-M',
+      '-50',
+      '-51',
+      '-o',
+      '-20',
+      '-m',
+      '-30',
+      '-11',
+    ];
+    program.parse(args, { from: 'user' });
+    assert.deepEqual(program.opts(), {
+      o: '-20',
+      m: '-30',
+      O: ['-40', '-41'],
+      M: ['-50', '-51'],
+    });
+    assert.deepEqual(program.args, ['-10', '-11']);
+  });
 
-  await t.test(
-    'when program has digit option then negatives not allowed in leaf command',
-    () => {
-      const program = createTestCommand();
-      program.option('-2', 'double option');
-      let leafArgs;
-      program
-        .command('leaf')
-        .argument('[value...]')
-        .action((args) => {
-          leafArgs = args;
-        });
-      const args = ['leaf', '-1'];
-      assert.throws(() => program.parse(args, { from: 'user' }), {
-        code: 'commander.unknownOption',
+  test('when program has digit option then negatives not allowed in leaf command', () => {
+    const program = createTestCommand();
+    program.option('-2', 'double option');
+    let leafArgs;
+    program
+      .command('leaf')
+      .argument('[value...]')
+      .action((args) => {
+        leafArgs = args;
       });
-    },
-  );
+    const args = ['leaf', '-1'];
+    assert.throws(() => program.parse(args, { from: 'user' }), {
+      code: 'commander.unknownOption',
+    });
+  });
 
-  await t.test(
-    'when default command without digit option then negatives accepted',
-    () => {
-      const program = new Command();
-      let leafArgs;
-      program
-        .command('leaf', { isDefault: true })
-        .argument('[value...]')
-        .action((args) => {
-          leafArgs = args;
-        });
-      program.parse(['-1'], { from: 'user' });
-      assert.deepEqual(leafArgs, ['-1']);
-    },
-  );
-
-  await t.test(
-    'when default command with digit option then negative throws',
-    () => {
-      const program = createTestCommand();
-      program
-        .command('leaf', { isDefault: true })
-        .option('-2')
-        .argument('[value...]')
-        .action(() => {});
-      assert.throws(() => program.parse(['-1'], { from: 'user' }), {
-        code: 'commander.unknownOption',
+  test('when default command without digit option then negatives accepted', () => {
+    const program = new Command();
+    let leafArgs;
+    program
+      .command('leaf', { isDefault: true })
+      .argument('[value...]')
+      .action((args) => {
+        leafArgs = args;
       });
-    },
-  );
+    program.parse(['-1'], { from: 'user' });
+    assert.deepEqual(leafArgs, ['-1']);
+  });
 
-  await t.test(
-    'when program has subcommand and action handler then negative command-argument unsupported',
-    () => {
-      // Known limitation in parsing. Only allowed negative command-arguments in leaf commands
-      // to minimise changes to parsing when added support for negative numbers.
-      const program = createTestCommand();
-      program.argument('[value...]').action(() => {});
-      program.command('leaf').action(() => {});
-      assert.throws(() => program.parse(['-1'], { from: 'user' }), {
-        code: 'commander.unknownOption',
-      });
-    },
-  );
+  test('when default command with digit option then negative throws', () => {
+    const program = createTestCommand();
+    program
+      .command('leaf', { isDefault: true })
+      .option('-2')
+      .argument('[value...]')
+      .action(() => {});
+    assert.throws(() => program.parse(['-1'], { from: 'user' }), {
+      code: 'commander.unknownOption',
+    });
+  });
+
+  test('when program has subcommand and action handler then negative command-argument unsupported', () => {
+    // Known limitation in parsing. Only allowed negative command-arguments in leaf commands
+    // to minimise changes to parsing when added support for negative numbers.
+    const program = createTestCommand();
+    program.argument('[value...]').action(() => {});
+    program.command('leaf').action(() => {});
+    assert.throws(() => program.parse(['-1'], { from: 'user' }), {
+      code: 'commander.unknownOption',
+    });
+  });
 });

--- a/tests/negatives.test.js
+++ b/tests/negatives.test.js
@@ -3,8 +3,8 @@ import { createTestCommand } from './testHelpers.js';
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
 
-describe('negative numbers', () => {
-  describe('negative numbers in args', () => {
+test('negative numbers', async (t) => {
+  await t.test('negative numbers in args', async (t) => {
     // boolean is whether is a consumable argument when negative numbers allowed
     const negativeNumbers = [
       ['-.1', true],
@@ -30,13 +30,15 @@ describe('negative numbers', () => {
       ['-0x1234', false], // not a plain number
     ];
 
-    negativeNumbers.forEach(([value, consume]) => {
+    for (const [value, consume] of negativeNumbers) {
       function callProgram(program, args, consume) {
         if (consume) {
+          // eslint-disable-next-line node-test/no-conditional-assertion
           assert.doesNotThrow(() => {
             program.parse(args, { from: 'user' });
           });
         } else {
+          // eslint-disable-next-line node-test/no-conditional-assertion
           assert.throws(
             () => {
               program.parse(args, { from: 'user' });
@@ -45,165 +47,207 @@ describe('negative numbers', () => {
           );
         }
       }
-      test(`when option-argument for short optional is ${value} then consumed=${consume}`, () => {
-        const program = createTestCommand();
-        program.option('-o, --optional [value]', 'optional option');
-        const args = ['-o', value];
-        callProgram(program, args, consume);
-        // throws after setting optional to true
-        assert.equal(program.opts()['optional'], consume ? value : true);
-      });
 
-      test(`when option-argument for long optional is ${value} then consumed=${consume}`, () => {
-        const program = createTestCommand();
-        program.option('-o, --optional [value]', 'optional option');
-        const args = ['--optional', value];
-        callProgram(program, args, consume);
-        // throws after setting optional to true
-        assert.equal(program.opts()['optional'], consume ? value : true);
-      });
+      await t.test(
+        `when option-argument for short optional is ${value} then consumed=${consume}`,
+        () => {
+          const program = createTestCommand();
+          program.option('-o, --optional [value]', 'optional option');
+          const args = ['-o', value];
+          callProgram(program, args, consume);
+          // throws after setting optional to true
+          assert.equal(program.opts()['optional'], consume ? value : true);
+        },
+      );
 
-      test(`when option-argument for short optional... is ${value} then consumed=${consume}`, () => {
-        const program = createTestCommand();
-        program.option('-o, --optional [value...]', 'optional option');
-        const args = ['-o', 'first', value];
-        callProgram(program, args, consume);
-        // throws after consuming 'first'
-        assert.deepEqual(
-          program.opts()['optional'],
-          consume ? ['first', value] : ['first'],
-        );
-      });
+      await t.test(
+        `when option-argument for long optional is ${value} then consumed=${consume}`,
+        () => {
+          const program = createTestCommand();
+          program.option('-o, --optional [value]', 'optional option');
+          const args = ['--optional', value];
+          callProgram(program, args, consume);
+          // throws after setting optional to true
+          assert.equal(program.opts()['optional'], consume ? value : true);
+        },
+      );
 
-      test(`when option-argument for long optional... is ${value} then consumed=${consume}`, () => {
-        const program = createTestCommand();
-        program.option('-o, --optional [value...]', 'optional option');
-        const args = ['--optional', 'first', value];
-        callProgram(program, args, consume);
-        // throws after consuming 'first'
-        assert.deepEqual(
-          program.opts()['optional'],
-          consume ? ['first', value] : ['first'],
-        );
-      });
+      await t.test(
+        `when option-argument for short optional... is ${value} then consumed=${consume}`,
+        () => {
+          const program = createTestCommand();
+          program.option('-o, --optional [value...]', 'optional option');
+          const args = ['-o', 'first', value];
+          callProgram(program, args, consume);
+          // throws after consuming 'first'
+          assert.deepEqual(
+            program.opts()['optional'],
+            consume ? ['first', value] : ['first'],
+          );
+        },
+      );
 
-      test(`when command-argument is ${value} then consumed=${consume}`, () => {
-        const program = createTestCommand();
-        program.argument('<value>', 'argument');
-        const args = [value];
-        callProgram(program, args, consume);
-        assert.deepEqual(
-          consume ? program.args : undefined,
-          consume ? [value] : undefined,
-        );
-      });
+      await t.test(
+        `when option-argument for long optional... is ${value} then consumed=${consume}`,
+        () => {
+          const program = createTestCommand();
+          program.option('-o, --optional [value...]', 'optional option');
+          const args = ['--optional', 'first', value];
+          callProgram(program, args, consume);
+          // throws after consuming 'first'
+          assert.deepEqual(
+            program.opts()['optional'],
+            consume ? ['first', value] : ['first'],
+          );
+        },
+      );
 
-      test(`when digit option defined and option-argument is ${value} then negative not consumed`, () => {
-        const program = createTestCommand();
-        program
-          .option('-o, --optional [value]', 'optional option')
-          .option('-9', 'register option using digit');
-        const args = ['-o', value];
-        let customConsume = value[0] !== '-';
-        callProgram(program, args, customConsume);
-        assert.equal(program.opts()['optional'], customConsume ? value : true);
-      });
+      await t.test(
+        `when command-argument is ${value} then consumed=${consume}`,
+        () => {
+          const program = createTestCommand();
+          program.argument('<value>', 'argument');
+          const args = [value];
+          callProgram(program, args, consume);
+          assert.deepEqual(
+            consume ? program.args : undefined,
+            consume ? [value] : undefined,
+          );
+        },
+      );
 
-      test(`when digit option defined and command-argument is ${value} then negative not consumed`, () => {
-        const program = createTestCommand();
-        program.argument('[value]').option('-9', 'register option using digit');
-        const args = [value];
-        let customConsume = value[0] !== '-';
-        callProgram(program, args, customConsume);
-        assert.deepEqual(
-          customConsume ? program.args : undefined,
-          customConsume ? [value] : undefined,
-        );
-      });
-    });
+      await t.test(
+        `when digit option defined and option-argument is ${value} then negative not consumed`,
+        () => {
+          const program = createTestCommand();
+          program
+            .option('-o, --optional [value]', 'optional option')
+            .option('-9', 'register option using digit');
+          const args = ['-o', value];
+          let customConsume = value[0] !== '-';
+          callProgram(program, args, customConsume);
+          assert.equal(
+            program.opts()['optional'],
+            customConsume ? value : true,
+          );
+        },
+      );
+
+      await t.test(
+        `when digit option defined and command-argument is ${value} then negative not consumed`,
+        () => {
+          const program = createTestCommand();
+          program
+            .argument('[value]')
+            .option('-9', 'register option using digit');
+          const args = [value];
+          let customConsume = value[0] !== '-';
+          callProgram(program, args, customConsume);
+          assert.deepEqual(
+            customConsume ? program.args : undefined,
+            customConsume ? [value] : undefined,
+          );
+        },
+      );
+    }
   });
 
-  test('when complex example with negative numbers then all consumed', () => {
-    const program = new Command();
-    program
-      .option('-o [value]', 'optional')
-      .option('-m <value>', 'required option-argument')
-      .option('-O [value...]', 'optional')
-      .option('-M <value...>', 'required option-argument')
-      .argument('[value...]', 'argument');
-    const args = [
-      '-10',
-      '-O',
-      '-40',
-      '-41',
-      '-M',
-      '-50',
-      '-51',
-      '-o',
-      '-20',
-      '-m',
-      '-30',
-      '-11',
-    ];
-    program.parse(args, { from: 'user' });
-    assert.deepEqual(program.opts(), {
-      o: '-20',
-      m: '-30',
-      O: ['-40', '-41'],
-      M: ['-50', '-51'],
-    });
-    assert.deepEqual(program.args, ['-10', '-11']);
-  });
-
-  test('when program has digit option then negatives not allowed in leaf command', () => {
-    const program = createTestCommand();
-    program.option('-2', 'double option');
-    let leafArgs;
-    program
-      .command('leaf')
-      .argument('[value...]')
-      .action((args) => {
-        leafArgs = args;
+  await t.test(
+    'when complex example with negative numbers then all consumed',
+    () => {
+      const program = new Command();
+      program
+        .option('-o [value]', 'optional')
+        .option('-m <value>', 'required option-argument')
+        .option('-O [value...]', 'optional')
+        .option('-M <value...>', 'required option-argument')
+        .argument('[value...]', 'argument');
+      const args = [
+        '-10',
+        '-O',
+        '-40',
+        '-41',
+        '-M',
+        '-50',
+        '-51',
+        '-o',
+        '-20',
+        '-m',
+        '-30',
+        '-11',
+      ];
+      program.parse(args, { from: 'user' });
+      assert.deepEqual(program.opts(), {
+        o: '-20',
+        m: '-30',
+        O: ['-40', '-41'],
+        M: ['-50', '-51'],
       });
-    const args = ['leaf', '-1'];
-    assert.throws(() => program.parse(args, { from: 'user' }), {
-      code: 'commander.unknownOption',
-    });
-  });
+      assert.deepEqual(program.args, ['-10', '-11']);
+    },
+  );
 
-  test('when default command without digit option then negatives accepted', () => {
-    const program = new Command();
-    let leafArgs;
-    program
-      .command('leaf', { isDefault: true })
-      .argument('[value...]')
-      .action((args) => {
-        leafArgs = args;
+  await t.test(
+    'when program has digit option then negatives not allowed in leaf command',
+    () => {
+      const program = createTestCommand();
+      program.option('-2', 'double option');
+      let leafArgs;
+      program
+        .command('leaf')
+        .argument('[value...]')
+        .action((args) => {
+          leafArgs = args;
+        });
+      const args = ['leaf', '-1'];
+      assert.throws(() => program.parse(args, { from: 'user' }), {
+        code: 'commander.unknownOption',
       });
-    program.parse(['-1'], { from: 'user' });
-    assert.deepEqual(leafArgs, ['-1']);
-  });
+    },
+  );
 
-  test('when default command with digit option then negative throws', () => {
-    const program = createTestCommand();
-    program
-      .command('leaf', { isDefault: true })
-      .option('-2')
-      .argument('[value...]')
-      .action(() => {});
-    assert.throws(() => program.parse(['-1'], { from: 'user' }), {
-      code: 'commander.unknownOption',
-    });
-  });
+  await t.test(
+    'when default command without digit option then negatives accepted',
+    () => {
+      const program = new Command();
+      let leafArgs;
+      program
+        .command('leaf', { isDefault: true })
+        .argument('[value...]')
+        .action((args) => {
+          leafArgs = args;
+        });
+      program.parse(['-1'], { from: 'user' });
+      assert.deepEqual(leafArgs, ['-1']);
+    },
+  );
 
-  test('when program has subcommand and action handler then negative command-argument unsupported', () => {
-    // Known limitation in parsing. Only allowed negative command-arguments in leaf commands
-    // to minimise changes to parsing when added support for negative numbers.
-    const program = createTestCommand();
-    program.argument('[value...]').action(() => {});
-    program.command('leaf').action(() => {});
-    assert.throws(() => program.parse(['-1'], { from: 'user' }), {
-      code: 'commander.unknownOption',
-    });
-  });
+  await t.test(
+    'when default command with digit option then negative throws',
+    () => {
+      const program = createTestCommand();
+      program
+        .command('leaf', { isDefault: true })
+        .option('-2')
+        .argument('[value...]')
+        .action(() => {});
+      assert.throws(() => program.parse(['-1'], { from: 'user' }), {
+        code: 'commander.unknownOption',
+      });
+    },
+  );
+
+  await t.test(
+    'when program has subcommand and action handler then negative command-argument unsupported',
+    () => {
+      // Known limitation in parsing. Only allowed negative command-arguments in leaf commands
+      // to minimise changes to parsing when added support for negative numbers.
+      const program = createTestCommand();
+      program.argument('[value...]').action(() => {});
+      program.command('leaf').action(() => {});
+      assert.throws(() => program.parse(['-1'], { from: 'user' }), {
+        code: 'commander.unknownOption',
+      });
+    },
+  );
 });

--- a/tests/options.bool.small.combined.test.js
+++ b/tests/options.bool.small.combined.test.js
@@ -2,7 +2,6 @@ import * as commander from '../index.js';
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-// eslint-disable-next-line node-test/require-top-level-describe
 test('when when multiple short flags specified then parsed as short option group', () => {
   const program = new commander.Command();
   program


### PR DESCRIPTION
## Problem

Running fixture loops with embedded tests at top level of `describe` is running the tests at file load time instead of a test time. This is not causing any known problems at the moment, but could cause confusion in the future.

Issue picked up by `node-test/require-hook`:

- https://github.com/sindresorhus/eslint-node-test/blob/main/docs/rules/require-hook.md

## Solution

Wrap fixture loops in a test, and by convention use await for the nested test.

Couple of other tidies:
- use built-in support for conditional test/describe
- remove `node-test/require-top-level-describe` as we often use a top level `test` rather than `describe`, and don't want extra wrapper or to suppress the warning everywhere that pattern used.

The changes are a bit noisy, but a fairly pure refactor. (Turning off whitespace in the diff may help make this clearer.)