### PR TITLE
Preserve -- delimiter for executable subcommands

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -1788,6 +1788,13 @@ Expecting one of '${allowedValues.join("', '")}'`);
       // literal
       if (arg === '--') {
         if (dest === unknown) dest.push(arg);
+        if (
+          dest === operands &&
+          operands.length > 0 &&
+          this._findCommand(operands[0])
+        ) {
+          dest.push(arg);
+        }
         dest.push(...args.slice(i));
         break;
       }

--- a/tests/command.parseOptions.test.js
+++ b/tests/command.parseOptions.test.js
@@ -52,6 +52,18 @@ describe('parsing regression tests', () => {
     ]);
     assert.equal(stdout, '["1","2","--dry-run","3","4","5","6"]\n');
   });
+
+  // https://github.com/tj/commander.js/issues/2530
+  test('when arguments to executable include end-of-options delimiter then delimiter preserved', async () => {
+    const pm = path.join(import.meta.dirname, 'fixtures/pm');
+    const { stdout } = await execFileAsync('node', [
+      pm,
+      'echo',
+      '--',
+      '--not-an-option',
+    ]);
+    assert.equal(stdout, '["--","--not-an-option"]\n');
+  });
 });
 
 describe('Command.parseOptions()', () => {


### PR DESCRIPTION
Fixes #2530

## Problem / reproduction

A stand-alone executable subcommand drops the first end-of-options delimiter before spawning the child process. Reproduced on `develop` with:

```sh
node scratch-parent.js child -- --not-an-option
```

where the parent dispatches an executable `child` and the child uses Commander with `.argument('[input]')`. Before the fix, the child saw `--not-an-option` as an option and exited with `error: unknown option '--not-an-option'`.

## Root cause

`parseOptions()` removed `--` as soon as the parent command parsed it. For in-process subcommands that is ok because the leaf command reparses the remaining operands, but executable subcommands are spawned directly with the already-processed operands, so the original option boundary was lost.

## Fix

When `parseOptions()` reaches `--` after a recognised subcommand operand, keep the delimiter in the operands passed down to that subcommand. In-process leaf commands still consume and remove the delimiter during their own parse, while executable subcommands receive the original boundary in `argv`.

## Backward compatibility

This intentionally changes executable-subcommand argv to include the user-supplied `--` delimiter. In-process subcommand action arguments remain unchanged. Direct callers of `parseOptions()` on a command with subcommands may now observe the delimiter retained when it is being passed on to a recognised subcommand, matching the delayed-removal model discussed in #2530.

## Validation

- Minimal repro before fix: failed with `error: unknown option '--not-an-option'` and exit 1.
- Minimal repro after fix: printed `{ "input": "--not-an-option" }` and exited 0.
- Regression check without fix: `node --test tests\command.parseOptions.test.js` failed 1/34 tests, with actual `['--not-an-option']` vs expected `['--', '--not-an-option']`.
- Targeted test with fix: `node --test tests\command.parseOptions.test.js` passed 34 tests, 4 suites.
- Full tests: `npm test` passed 1405 tests, 189 suites, 4 skipped, 0 failed; TypeScript definition tests (`tsd && tsc -p tsconfig.ts.json`) passed as part of `npm test`.
- Checks: `npm run check` passed (`tsc -p tsconfig.js.json`, `tsd`, `tsc -p tsconfig.ts.json`, `eslint .`, `prettier --check .`).

Prepared with AI/LLM assistance; I reviewed the change and validation results.