### PR TITLE
Preserve option terminator in subcommand arguments for subcommand to process

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -1789,7 +1789,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
       if (arg === '--') {
         // If going to dispatch to a subcommand...
         if (operands.length > 0 && this._findCommand(operands[0])) {
-          // ...retain the -- for the subcommand to process, as subcommand may be external.
+          // ...preserve the -- for the subcommand to process, as subcommand may be external.
           unknown.push(arg, ...args.slice(i));
           break;
         }

--- a/lib/command.js
+++ b/lib/command.js
@@ -1787,7 +1787,14 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
       // literal
       if (arg === '--') {
-        if (dest === unknown) dest.push(arg);
+        // If going to dispatch to a subcommand...
+        if (operands.length > 0 && this._findCommand(operands[0])) {
+          // ...leave the delimiter for the subcommand to remove, as subcommand may be external.
+          unknown.push(arg, ...args.slice(i));
+          break;
+        }
+
+        if (dest === unknown) dest.push(arg); // Predates above code, but keep for backwards compatibility in other cases.
         dest.push(...args.slice(i));
         break;
       }

--- a/lib/command.js
+++ b/lib/command.js
@@ -1785,16 +1785,16 @@ Expecting one of '${allowedValues.join("', '")}'`);
       const arg = activeGroup ?? args[i++];
       activeGroup = null;
 
-      // literal
+      // option terminator
       if (arg === '--') {
         // If going to dispatch to a subcommand...
         if (operands.length > 0 && this._findCommand(operands[0])) {
-          // ...leave the delimiter for the subcommand to remove, as subcommand may be external.
+          // ...retain the -- for the subcommand to process, as subcommand may be external.
           unknown.push(arg, ...args.slice(i));
           break;
         }
 
-        if (dest === unknown) dest.push(arg); // Predates above code, but keep for backwards compatibility in other cases.
+        if (dest === unknown) dest.push(arg); // `unknown` might get reprocessed, so need to preserve --
         dest.push(...args.slice(i));
         break;
       }

--- a/tests/args.literal.test.js
+++ b/tests/args.literal.test.js
@@ -1,34 +1,205 @@
-import * as commander from '../index.js';
+import { Command } from '../index.js';
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
+import { promisify } from 'node:util';
+import * as childProcess from 'child_process';
+import * as path from 'path';
 
 // Utility Conventions: http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html#tag_12_02
 //
 // 12.2 Utility Syntax Guidelines, Guideline 10:
 // The first -- argument that is not an option-argument should be accepted as a delimiter indicating the end of options. Any following arguments should be treated as operands, even if they begin with the '-' character.
 
+const execFileAsync = promisify(childProcess.execFile);
+
+function makeCmdWithOptions(name) {
+  return new Command(name)
+    .option('-f, --foo', 'add some foo')
+    .option('-b, --bar', 'add some bar')
+    .argument('[args...]')
+    .exitOverride()
+    .action(() => {});
+}
+
 describe('end of options delimiter "--"', () => {
-  test('when arguments includes -- then stop processing options', () => {
-    const program = new commander.Command();
-    program
-      .option('-f, --foo', 'add some foo')
-      .option('-b, --bar', 'add some bar')
-      .argument('[args...]');
-    program.parse(['node', 'test', '--foo', '--', '--bar', 'baz']);
-    // More than one assert, ported from legacy test
+  test('when arguments include -- then stop processing options', () => {
+    const program = makeCmdWithOptions('program');
+    program.parse(['--foo', '--', '--bar', '--unknown', 'ARG'], {
+      from: 'user',
+    });
+
     const opts = program.opts();
     assert.equal(opts.foo, true);
     assert.equal(opts.bar, undefined);
-    assert.deepEqual(program.args, ['--bar', 'baz']);
+    assert.deepEqual(program.args, ['--bar', '--unknown', 'ARG']);
   });
 
-  test('when arguments include -- then more -- are passed-through as args', () => {
-    const program = new commander.Command();
-    program
-      .option('-f, --foo', 'add some foo')
-      .option('-b, --bar', 'add some bar')
-      .argument('[args...]');
-    program.parse(['node', 'test', '--', 'cmd', '--', '--arg']);
-    assert.deepEqual(program.args, ['cmd', '--', '--arg']);
+  test('when arguments include multiple -- then extras are passed-through as args', () => {
+    const program = makeCmdWithOptions('program');
+    program.parse(['--foo', '--', '--bar', '--', '--unknown', 'ARG'], {
+      from: 'user',
+    });
+
+    const opts = program.opts();
+    assert.equal(opts.foo, true);
+    assert.equal(opts.bar, undefined);
+    assert.deepEqual(program.args, ['--bar', '--', '--unknown', 'ARG']);
+  });
+
+  test('when arguments end with -- then -- still stripped', () => {
+    const program = makeCmdWithOptions('program');
+    program.parse(['--foo', 'ARG', '--'], {
+      from: 'user',
+    });
+
+    const opts = program.opts();
+    assert.equal(opts.foo, true);
+    assert.equal(opts.bar, undefined);
+    assert.deepEqual(program.args, ['ARG']);
+  });
+
+  test('when -- after arg then options stripped', () => {
+    const program = makeCmdWithOptions('program');
+    program.parse(['ARG', '--', '--unknown'], {
+      from: 'user',
+    });
+
+    assert.deepEqual(program.args, ['ARG', '--unknown']);
+  });
+
+  test('when arguments include -- before sub then option processing stops', () => {
+    const program = new Command().exitOverride();
+    const sub = makeCmdWithOptions('sub');
+    program.addCommand(sub);
+    program.parse(['--', 'sub', '--foo', 'ARG'], { from: 'user' });
+
+    assert.deepEqual(sub.args, ['--foo', 'ARG']);
+  });
+
+  test('when arguments include -- directly after sub then option processing stops', () => {
+    const program = new Command().exitOverride();
+    const sub = makeCmdWithOptions('sub');
+    program.addCommand(sub);
+    program.parse(['sub', '--', '--foo', 'ARG'], { from: 'user' });
+
+    assert.deepEqual(sub.args, ['--foo', 'ARG']);
+  });
+
+  test('when arguments include -- in sub args then option processing stops', () => {
+    const program = new Command().exitOverride();
+    const sub = makeCmdWithOptions('sub');
+    program.addCommand(sub);
+    program.parse(['sub', '--foo', '--', '--bar', '--unknown', 'ARG'], {
+      from: 'user',
+    });
+
+    const opts = sub.opts();
+    assert.equal(opts.foo, true);
+    assert.equal(opts.bar, undefined);
+    assert.deepEqual(sub.args, ['--bar', '--unknown', 'ARG']);
+  });
+
+  test('when arguments include -- and default command then options processing', () => {
+    const program = new Command().exitOverride();
+    const sub = makeCmdWithOptions('sub');
+    program.addCommand(sub, { isDefault: true });
+    program.parse(['--foo', '--', '--bar', '--unknown', 'ARG'], {
+      from: 'user',
+    });
+    const opts = sub.opts();
+    assert.equal(opts.foo, true);
+    assert.equal(opts.bar, undefined);
+    assert.deepEqual(sub.args, ['--bar', '--unknown', 'ARG']);
+  });
+
+  // action handler
+  test('when arguments include -- after non-matching command then options processing stops for action handler', () => {
+    // Fairly exotic to have an action handler and subcommands, but run a test.
+    let actionArgs;
+    const program = makeCmdWithOptions('program');
+    program.action((args) => {
+      actionArgs = args;
+    });
+    program.command('sub');
+    program.parse(
+      ['--foo', 'non-matching', '--', '--bar', '--unknown', 'ARG'],
+      {
+        from: 'user',
+      },
+    );
+    console.error('AFTER');
+    const opts = program.opts();
+    assert.equal(opts.foo, true);
+    assert.equal(opts.bar, undefined);
+    assert.deepEqual(actionArgs, ['non-matching', '--bar', '--unknown', 'ARG']);
+  });
+
+  // action handler
+  test('when arguments include -- after non-matching command and argument then -- stripped', () => {
+    // Fairly exotic to have an action handler and subcommands, but run a test.
+    // (Spotted problem with -- .)
+    let actionArgs;
+    const program = makeCmdWithOptions('program');
+    program.action((args) => {
+      actionArgs = args;
+    });
+    program.command('sub');
+    program.parse(['non-matching', '--', '--unknown'], {
+      from: 'user',
+    });
+    assert.deepEqual(actionArgs, ['non-matching', '--unknown']);
+  });
+
+  test('when arguments include -- after (allowed) unknown option then -- preserved', () => {
+    // This is more of a historical behaviour than a design behaviour, but reasonable for options
+    // that are likely to be passed through to another command of some sort.
+    const program = makeCmdWithOptions('program');
+    program.allowUnknownOption();
+    program.parse(['--unknown', '--', '--foo'], {
+      from: 'user',
+    });
+    assert.deepEqual(program.args, ['--unknown', '--', '--foo']);
+  });
+
+  test('when arguments include -- before external subcommand then not passed to subcommand', async () => {
+    // The behaviour for action handler and external subcommands is different here.
+    // The `--` came before the subcommand and not injecting it into external subcommand arguments.
+    // (When the -- comes among the subcommand arguments, it is preserved. See other tests.)
+    const pm = path.join(import.meta.dirname, 'fixtures/pm');
+    const { stdout } = await execFileAsync('node', [
+      pm,
+      '--',
+      'echo',
+      '--foo',
+      'ARG',
+    ]);
+
+    assert.equal(stdout, '["--foo","ARG"]\n');
+  });
+
+  test('when arguments include -- after external subcommand then passed to subcommand', async () => {
+    const pm = path.join(import.meta.dirname, 'fixtures/pm');
+    const { stdout } = await execFileAsync('node', [
+      pm,
+      'echo',
+      '--',
+      '--foo',
+      'ARG',
+    ]);
+
+    assert.equal(stdout, '["--","--foo","ARG"]\n');
+  });
+
+  test('when arguments include -- after external subcommand argument then passed to subcommand', async () => {
+    const pm = path.join(import.meta.dirname, 'fixtures/pm');
+    const { stdout } = await execFileAsync('node', [
+      pm,
+      'echo',
+      'ARG',
+      '--',
+      '--foo',
+    ]);
+
+    assert.equal(stdout, '["ARG","--","--foo"]\n');
   });
 });

--- a/tests/args.literal.test.js
+++ b/tests/args.literal.test.js
@@ -127,7 +127,6 @@ describe('end of options delimiter "--"', () => {
         from: 'user',
       },
     );
-    console.error('AFTER');
     const opts = program.opts();
     assert.equal(opts.foo, true);
     assert.equal(opts.bar, undefined);


### PR DESCRIPTION
## Problem

The option delimiter is stripped during top level pass of arguments by root command before the subcommand sees the arguments. This works for internal subcommands (action handler) because the following arguments are marked as having been processed. This does not work for external subcommands which just get the arguments without the option terminator and following options get processed as normal.

Issue: #2530

## Solution

Leave the option terminator and the remaining arguments as "unknown" for the subcommand to reprocess. This works for both internal and external commands.

The option terminator tests were weak. Beefed them up to cover the external case and more besides.

This is a change in core behaviour, so marking PR as semver-major.

## ChangeLog

- Breaking: preserve option terminator in subcommand arguments until subcommand parsing, so passed to external subcommand (#2577)