### PR TITLE
Mark InvalidOptionArgumentError as deprecated for editors

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,5 +18,4 @@ export const createArgument = (name, description) =>
 
 export { Command, Option, Argument, Help };
 export { CommanderError, InvalidArgumentError };
-/** @deprecated use {@linkcode InvalidArgumentError} instead */
-export const InvalidOptionArgumentError = InvalidArgumentError;
+export { InvalidArgumentError as InvalidOptionArgumentError }; // Deprecated

--- a/index.js
+++ b/index.js
@@ -18,4 +18,5 @@ export const createArgument = (name, description) =>
 
 export { Command, Option, Argument, Help };
 export { CommanderError, InvalidArgumentError };
-export { InvalidArgumentError as InvalidOptionArgumentError }; // Deprecated
+/** @deprecated use {@linkcode InvalidArgumentError} instead */
+export const InvalidOptionArgumentError = InvalidArgumentError;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -34,7 +34,11 @@ export class InvalidArgumentError extends CommanderError {
    */
   constructor(message: string);
 }
-export { InvalidArgumentError as InvalidOptionArgumentError }; // deprecated old name
+
+/** @deprecated use {@linkcode InvalidArgumentError} instead */
+export const InvalidOptionArgumentError: typeof InvalidArgumentError;
+/** @deprecated use {@linkcode InvalidArgumentError} instead */
+export type InvalidOptionArgumentError = InvalidArgumentError;
 
 export interface ErrorOptions {
   // optional parameter for error()

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -35,9 +35,9 @@ export class InvalidArgumentError extends CommanderError {
   constructor(message: string);
 }
 
-/** @deprecated use {@linkcode InvalidArgumentError} instead */
+/** @deprecated since v8, instead use InvalidArgumentError */
 export const InvalidOptionArgumentError: typeof InvalidArgumentError;
-/** @deprecated use {@linkcode InvalidArgumentError} instead */
+/** @deprecated since v8, instead use InvalidArgumentError */
 export type InvalidOptionArgumentError = InvalidArgumentError;
 
 export interface ErrorOptions {


### PR DESCRIPTION
## Problem

`InvalidOptionArgumentError` has been deprecated since Commander v8 and is documented as such in `docs/deprecated.md`, but nothing tells you that at the use site. It is declared in the typings as a re-export:

```ts
export { InvalidArgumentError as InvalidOptionArgumentError }; // deprecated old name
```

A re-export statement cannot carry a JSDoc comment, so TypeScript and editors have no `@deprecated` tag to act on. Users get no strikethrough and no hover hint — the `// deprecated old name` comment is only visible to somebody reading Commander's own source.

## Solution

Replace the re-export in `typings/index.d.ts` with declarations that can be annotated:

```ts
/** @deprecated since v8, instead use InvalidArgumentError */
export const InvalidOptionArgumentError: typeof InvalidArgumentError;
/** @deprecated since v8, instead use InvalidArgumentError */
export type InvalidOptionArgumentError = InvalidArgumentError;
```

Editors now strike through the identifier and point at `InvalidArgumentError`.

Both halves are needed to stay backwards compatible, because the old re-export put the name in **both** value space and type space:

- Without the `const`, the existing `typings/index.test-d.ts` case `new commander.InvalidOptionArgumentError('message')` fails.
- Without the `type` alias, `let e: InvalidOptionArgumentError` fails with `TS2749: 'InvalidOptionArgumentError' refers to a value, but is being used as a type here`.

The runtime export in `index.js` is unchanged. No runtime or type behaviour changes — this is purely about surfacing the existing deprecation in editors.

`npm run test` and `npm run check` both pass.

## ChangeLog

- add `@deprecated` JSDoc tag to `InvalidOptionArgumentError` typings so editors show the deprecation
