### PR TITLE
Add `env` parse option to use instead of `process.env`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -977,6 +977,12 @@ program.parse(process.argv); // assume argv[0] is app and argv[1] is script
 program.parse(['--port', '80'], { from: 'user' }); // just user supplied arguments, nothing special about argv[0]
 ```
 
+You can also pass `env` to specify the environment variables used for options with `.env()`, instead of `process.env`. This may be useful for testing.
+
+```js
+program.parse(['--debug'], { from: 'user', env: { PORT: '80' } });
+```
+
 Use `.parseAsync()` instead of `.parse()` if any of your action handlers are async.
 
 ### Parsing Configuration

--- a/lib/command.js
+++ b/lib/command.js
@@ -57,6 +57,7 @@ export class Command extends EventEmitter {
     this._showHelpAfterError = false;
     this._showSuggestionAfterError = true;
     this._savedState = null; // used in save/restoreStateBeforeParse
+    this._parseEnv = undefined; // custom environment variables from parse option, see _getParseEnv()
 
     // see configureOutput() for docs
     this._outputConfiguration = {
@@ -994,6 +995,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
       throw new Error('first parameter to parse must be array or undefined');
     }
     parseOptions = parseOptions || {};
+    this._parseEnv = parseOptions.env;
 
     // auto-detect argument conventions if nothing supplied
     if (argv === undefined && parseOptions.from === undefined) {
@@ -1075,6 +1077,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    * @param {string[]} [argv] - optional, defaults to process.argv
    * @param {object} [parseOptions] - optionally specify style of options with from: node/user/electron
    * @param {string} [parseOptions.from] - where the args are from: 'node', 'user', 'electron'
+   * @param {Object<string, string>} [parseOptions.env] - environment variables to use for options with env(), instead of process.env
    * @return {Command} `this` command for chaining
    */
 
@@ -1104,6 +1107,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    * @param {string[]} [argv]
    * @param {object} [parseOptions]
    * @param {string} parseOptions.from - where the args are from: 'node', 'user', 'electron'
+   * @param {Object<string, string>} [parseOptions.env] - environment variables to use for options with env(), instead of process.env
    * @return {Promise}
    */
 
@@ -1976,8 +1980,9 @@ Expecting one of '${allowedValues.join("', '")}'`);
    * @private
    */
   _parseOptionsEnv() {
+    const env = this._getParseEnv();
     this.options.forEach((option) => {
-      if (option.envVar && option.envVar in process.env) {
+      if (option.envVar && option.envVar in env) {
         const optionKey = option.attributeName();
         // Priority check. Do not overwrite cli or options from unknown source (client-code).
         if (
@@ -1989,7 +1994,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
           if (option.required || option.optional) {
             // option can take a value
             // keep very simple, optional always takes value
-            this.emit(`optionEnv:${option.name()}`, process.env[option.envVar]);
+            this.emit(`optionEnv:${option.name()}`, env[option.envVar]);
           } else {
             // boolean
             // keep very simple, only care that envVar defined and not the value
@@ -1998,6 +2003,20 @@ Expecting one of '${allowedValues.join("', '")}'`);
         }
       }
     });
+  }
+
+  /**
+   * Get the environment variables to use for options with env, from the `env`
+   * parse option on this command or an ancestor, falling back to process.env.
+   *
+   * @return {Object}
+   * @private
+   */
+  _getParseEnv() {
+    const commandWithEnv = this._getCommandAndAncestors().find(
+      (cmd) => cmd._parseEnv !== undefined,
+    );
+    return commandWithEnv ? commandWithEnv._parseEnv : process.env;
   }
 
   /**

--- a/tests/options.env.test.js
+++ b/tests/options.env.test.js
@@ -369,3 +369,67 @@ describe('Option.env()', () => {
     });
   });
 });
+
+describe('parse option env', () => {
+  test('when env passed to parse then option from custom env', () => {
+    const program = new commander.Command();
+    program.addOption(new commander.Option('-f, --foo <value>').env('BAR'));
+    program.parse([], { from: 'user', env: { BAR: 'custom' } });
+    assert.equal(program.opts().foo, 'custom');
+    assert.equal(program.getOptionValueSource('foo'), 'env');
+  });
+
+  test('when env passed to parse then process.env not used', () => {
+    const program = new commander.Command();
+    process.env.BAR = 'process';
+    program.addOption(new commander.Option('-f, --foo <value>').env('BAR'));
+    program.parse([], { from: 'user', env: {} });
+    assert.equal(program.opts().foo, undefined);
+    delete process.env.BAR;
+  });
+
+  test('when env passed to parse and cli then option from cli', () => {
+    const program = new commander.Command();
+    program.addOption(new commander.Option('-f, --foo <value>').env('BAR'));
+    program.parse(['--foo', 'cli'], { from: 'user', env: { BAR: 'custom' } });
+    assert.equal(program.opts().foo, 'cli');
+  });
+
+  test('when env passed to parse for boolean option then option true', () => {
+    const program = new commander.Command();
+    program.addOption(new commander.Option('-f, --foo').env('BAR'));
+    program.parse([], { from: 'user', env: { BAR: 'anything' } });
+    assert.equal(program.opts().foo, true);
+  });
+
+  test('when env passed to parse then used for subcommand option', () => {
+    const program = new commander.Command();
+    let subOptions;
+    program
+      .command('sub')
+      .addOption(new commander.Option('-f, --foo <value>').env('BAR'))
+      .action((options) => {
+        subOptions = options;
+      });
+    program.parse(['sub'], { from: 'user', env: { BAR: 'custom' } });
+    assert.equal(subOptions.foo, 'custom');
+  });
+
+  test('when env passed to parseAsync then option from custom env', async () => {
+    const program = new commander.Command();
+    program.addOption(new commander.Option('-f, --foo <value>').env('BAR'));
+    await program.parseAsync([], { from: 'user', env: { BAR: 'custom' } });
+    assert.equal(program.opts().foo, 'custom');
+  });
+
+  test('when env not passed to subsequent parse then process.env used again', () => {
+    const program = new commander.Command();
+    process.env.BAR = 'process';
+    program.addOption(new commander.Option('-f, --foo <value>').env('BAR'));
+    program.parse([], { from: 'user', env: { BAR: 'custom' } });
+    assert.equal(program.opts().foo, 'custom');
+    program.parse([], { from: 'user' });
+    assert.equal(program.opts().foo, 'process');
+    delete process.env.BAR;
+  });
+});

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -340,6 +340,10 @@ export type HelpConfiguration = Partial<Help>;
 
 export interface ParseOptions {
   from: 'node' | 'electron' | 'user';
+  /**
+   * Environment variables to use for options with `env()`, instead of `process.env`.
+   */
+  env?: Record<string, string | undefined>;
 }
 export interface HelpContext {
   // optional parameter for .help() and .outputHelp()

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -347,6 +347,12 @@ expectType<commander.Command>(
   program.parse(['node', 'script.js'], { from: 'electron' }),
 );
 expectType<commander.Command>(program.parse(['--option'], { from: 'user' }));
+expectType<commander.Command>(
+  program.parse(['--option'], { from: 'user', env: { PORT: '80' } }),
+);
+expectType<commander.Command>(
+  program.parse(['--option'], { from: 'user', env: process.env }),
+);
 expectType<commander.Command>(program.parse(['node', 'script.js'] as const));
 
 // parseAsync, same tests as parse
@@ -360,6 +366,9 @@ expectType<Promise<commander.Command>>(
 );
 expectType<Promise<commander.Command>>(
   program.parseAsync(['--option'], { from: 'user' }),
+);
+expectType<Promise<commander.Command>>(
+  program.parseAsync(['--option'], { from: 'user', env: { PORT: '80' } }),
 );
 expectType<Promise<commander.Command>>(
   program.parseAsync(['node', 'script.js'] as const),


### PR DESCRIPTION
## Problem

Resolves #2549

There is currently no way to supply the environment used for options declared with `.env()` — Commander always reads `process.env`. When testing a CLI, that means mutating the real `process.env` (and remembering to clean up), or reaching for mocking libraries. The issue asks for an `env` override in `ParseOptions`:

```js
program.addOption(new Option('-p, --port <number>').env('PORT'));
program.parse([], { from: 'user', env: { PORT: '80' } });
// before this PR: program.opts() is {} — the env parse option is silently ignored
```

## Solution

Add an optional `env` property to the parse options for `.parse()` and `.parseAsync()`. When supplied, it is used instead of `process.env` when looking up options declared with `.env()`:

```js
program.parse([], { from: 'user', env: { PORT: '80' } });
program.opts(); // { port: '80' }, source 'env'
```

Details:

- The override is stored on the command in `_prepareUserArgs` and resolved in `_parseOptionsEnv` via a new private helper `_getParseEnv()`, which walks `_getCommandAndAncestors()` so action-handler subcommands see the `env` passed to the program's `parse()` call. Falls back to `process.env` when no override was supplied (no behaviour change for existing code).
- Passing `env` fully replaces `process.env` for option lookup (e.g. `env: {}` means no environment options are set), which makes tests deterministic.
- The override is per-parse: a subsequent `parse()` call without `env` reads `process.env` again.
- Out of scope, unchanged: color detection env vars (`NO_COLOR`/`FORCE_COLOR`/`CLICOLOR_FORCE`) and the environment of spawned stand-alone executable subcommands (the child process still inherits the real environment).
- Included: JSDoc, TypeScript typings (`ParseOptions.env?: Record<string, string | undefined>`, assignable from `process.env`), tsd tests, unit tests, and a short README note under `.parse() and .parseAsync()`.

Tested with `npm test` and `npm run check` (all passing). New tests in `tests/options.env.test.js` cover: custom env used for value and boolean options, `process.env` ignored when `env` is passed, cli still winning over env, subcommand inheritance, `parseAsync`, and reverting to `process.env` on a later `parse()` without the override.

## ChangeLog

- Added: `env` parse option for `.parse()` and `.parseAsync()` to specify environment variables to use instead of `process.env` for options with `.env()` ([#2549])
