### PR TITLE
feat: add apply() helper to batch-configure commands

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -500,6 +500,18 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   /**
+   * Apply a function to this command, useful for batch configuration
+   * of multiple commands with shared settings.
+   *
+   * @param {Function} fn - function receiving this command, return value is discarded
+   * @return {Command} `this` command for chaining
+   */
+  apply(fn) {
+    fn(this);
+    return this;
+  }
+
+  /**
    * Register callback to use as replacement for calling process.exit.
    *
    * @param {Function} [fn] optional callback which will be passed a CommanderError, defaults to throwing

--- a/tests/command.apply.test.js
+++ b/tests/command.apply.test.js
@@ -1,0 +1,59 @@
+import { Command } from '../index.js';
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+describe('Command.apply', () => {
+  test('when call .apply() with function then returns this', () => {
+    const program = new Command();
+    const result = program.apply(() => {});
+    assert.equal(result, program);
+  });
+
+  test('when call .apply() then function is called with command', () => {
+    const program = new Command();
+    let receivedCommand = null;
+    program.apply((cmd) => {
+      receivedCommand = cmd;
+    });
+    assert.equal(receivedCommand, program);
+  });
+
+  test('when call .apply() then function can configure command', () => {
+    const program = new Command();
+    program.apply((cmd) => {
+      cmd
+        .description('test description')
+        .option('-v, --verbose', 'verbose output');
+    });
+    assert.equal(program.description(), 'test description');
+    assert.ok(program.options.find((o) => o.short === '-v'));
+  });
+
+  test('when call .apply() multiple times then functions are all called', () => {
+    const program = new Command();
+    const callOrder = [];
+    program
+      .apply(() => {
+        callOrder.push(1);
+      })
+      .apply(() => {
+        callOrder.push(2);
+      })
+      .apply(() => {
+        callOrder.push(3);
+      });
+    assert.deepEqual(callOrder, [1, 2, 3]);
+  });
+
+  test('when call .apply() then can be chained with other methods', () => {
+    const program = new Command();
+    const result = program
+      .description('before')
+      .apply((cmd) => {
+        cmd.description('after');
+      })
+      .option('-f, --flag', 'a flag');
+    assert.equal(result, program);
+    assert.equal(program.description(), 'after');
+  });
+});

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -546,6 +546,11 @@ export class Command {
       actionCommand: Command,
     ) => void | Promise<void>,
   ): this;
+  /**
+   * Apply a function to this command, useful for batch configuration
+   * of multiple commands with shared settings.
+   */
+  apply(fn: (command: this) => unknown): this;
 
   /**
    * Register callback to use as replacement for calling process.exit.


### PR DESCRIPTION
## Summary

This PR adds an `apply()` method to the `Command` class, allowing users to batch-configure multiple commands with shared settings without breaking the call chain.

## Motivation

When building CLIs with many commands that share common options or hooks, it is tedious to repeat the same configuration across commands. This PR introduces `apply()` which accepts a function that receives the command instance, enabling reusable configurators:

```js
function addVerboseOption(cmd) {
  return cmd.option('-v, --verbose', 'verbose output');
}

program
  .apply(addVerboseOption)
  .apply(addOtherOptions)
  .action(() => { ... });
```

## Changes

- Added `apply(fn)` method to `Command` class in `lib/command.js`
- Added TypeScript type definition in `typings/index.d.ts`
- Added comprehensive tests in `tests/command.apply.test.js`

## Testing

- All 1378 existing tests pass
- New tests added for `apply()`: chaining, function invocation, configuration, multiple calls, and method chaining
- ESLint and Prettier checks pass