### PR TITLE
docs: point inspector debugging link at current Node.js guide

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1054,7 +1054,7 @@ You can enable `--harmony` option in two ways:
 
 An executable subcommand is launched as a separate child process.
 
-If you are using the node inspector for [debugging](https://nodejs.org/en/docs/guides/debugging-getting-started/) executable subcommands using `node --inspect` et al.,
+If you are using the node inspector for [debugging](https://nodejs.org/en/learn/getting-started/debugging) executable subcommands using `node --inspect` et al.,
 the inspector port is incremented by 1 for the spawned subcommand.
 
 If you are using VSCode to debug executable subcommands you need to set the `"autoAttachChildProcesses": true` flag in your `launch.json` configuration.

--- a/Readme_zh-CN.md
+++ b/Readme_zh-CN.md
@@ -981,7 +981,7 @@ const program = createCommand();
 
 一个可执行的子命令会作为单独的子进程执行。
 
-如果使用 node inspector 的`node -inspect`等命令来[调试](https://nodejs.org/en/docs/guides/debugging-getting-started/)可执行命令，对于生成的子命令，inspector 端口会递增 1。
+如果使用 node inspector 的`node -inspect`等命令来[调试](https://nodejs.org/en/learn/getting-started/debugging)可执行命令，对于生成的子命令，inspector 端口会递增 1。
 
 如果想使用 VSCode 调试，则需要在`launch.json`配置文件里设置`"autoAttachChildProcesses": true`。
 


### PR DESCRIPTION
## Problem

The README debugging section links to the retired Node.js guide:

https://nodejs.org/en/docs/guides/debugging-getting-started/

A curl -L GET of that URL returns 404. The same dead URL is also used in `Readme_zh-CN.md`.

## Solution

Point both READMEs at the current Node.js debugging guide, which returns 200:

https://nodejs.org/en/learn/getting-started/debugging

## Verification

```
curl -sL -o /dev/null -w "%{http_code}\n" https://nodejs.org/en/docs/guides/debugging-getting-started/
# 404

curl -sL -o /dev/null -w "%{http_code}\n" https://nodejs.org/en/learn/getting-started/debugging
# 200
```
