### PR TITLE
fix: show arguments with choices or default in help even without description

### DIFF
--- a/lib/help.js
+++ b/lib/help.js
@@ -131,7 +131,7 @@ export class Help {
   }
 
   /**
-   * Get an array of the arguments if any have a description.
+   * Get an array of the arguments if any have a description, default value, or choices.
    *
    * @param {Command} cmd
    * @returns {Argument[]}

--- a/lib/help.js
+++ b/lib/help.js
@@ -146,8 +146,15 @@ export class Help {
       });
     }
 
-    // If there are any arguments with a description then return all the arguments.
-    if (cmd.registeredArguments.find((argument) => argument.description)) {
+    // If there are any arguments with a description, default value, or choices then return all the arguments.
+    if (
+      cmd.registeredArguments.find(
+        (argument) =>
+          argument.description ||
+          argument.defaultValue !== undefined ||
+          argument.argChoices,
+      )
+    ) {
       return cmd.registeredArguments;
     }
     return [];

--- a/tests/help.visibleArguments.test.js
+++ b/tests/help.visibleArguments.test.js
@@ -12,11 +12,29 @@ describe('Help.visibleArguments()', () => {
     assert.deepEqual(helper.visibleArguments(program), []);
   });
 
-  test('when argument but no argument description then empty array', () => {
+  test('when argument but no description and no default and no choices then empty array', () => {
     const program = new commander.Command();
     program.argument('<file>');
     const helper = new commander.Help();
     assert.deepEqual(helper.visibleArguments(program), []);
+  });
+
+  test('when argument has choices but no description then returned', () => {
+    const program = new commander.Command();
+    program.addArgument(program.createArgument('<color>').choices(['red', 'green', 'blue']));
+    const helper = new commander.Help();
+    const visibleArguments = helper.visibleArguments(program);
+    assert.equal(visibleArguments.length, 1);
+    assert.deepEqual(visibleArguments[0].argChoices, ['red', 'green', 'blue']);
+  });
+
+  test('when argument has default value but no description then returned', () => {
+    const program = new commander.Command();
+    program.addArgument(program.createArgument('[file]').default('fallback'));
+    const helper = new commander.Help();
+    const visibleArguments = helper.visibleArguments(program);
+    assert.equal(visibleArguments.length, 1);
+    assert.deepEqual(visibleArguments[0].defaultValue, 'fallback');
   });
 
   test('when argument and argument description then returned', () => {


### PR DESCRIPTION
## Summary

Ensures commands whose arguments have `choices` or a `defaultValue` (but no description string) display their `Arguments:` section in the help output, resolving an asymmetry with how options already display.

## Problem & Context

`Help.visibleArguments()` previously filtered registered arguments solely with `Boolean(argument.description)`. If a command registered arguments that defined choices or default values but left the description empty, the `Arguments:` section was omitted from `--help` entirely:

```js
const program = new Command();
program.addArgument(new Argument('<color>').choices(['red', 'green', 'blue']));
program.parse(['--help'], { from: 'user' });
```

Options with choices already display `(choices: "red", "green", "blue")` in the Options section regardless of whether a description was provided.

## Changes

- Broaden `Help.visibleArguments()` condition to include arguments where `argument.defaultValue !== undefined` or `argument.argChoices` is set (`lib/help.js`).
- Update JSDoc documentation for `visibleArguments()` (`lib/help.js`).
- Add regression test suite covering arguments with choices/defaults but empty descriptions (`tests/help.visibleArguments.test.js`).

## Verification

- `npm test`: **1,374/1,374 tests pass** (1,372 existing + 2 regression cases).
- `npm run check:type:ts` (`tsd && tsc`): Clean.
