### PR TITLE
feat: allow passing custom env in parse options

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -977,6 +977,12 @@ program.parse(process.argv); // assume argv[0] is app and argv[1] is script
 program.parse(['--port', '80'], { from: 'user' }); // just user supplied arguments, nothing special about argv[0]
 ```
 
+You can also pass `env` in the parse options to use custom environment variables instead of `process.env` (useful for testing):
+
+```js
+program.parse([], { from: 'user', env: { PORT: '80' } });
+```
+
 Use `.parseAsync()` instead of `.parse()` if any of your action handlers are async.
 
 ### Parsing Configuration

--- a/Readme_zh-CN.md
+++ b/Readme_zh-CN.md
@@ -918,6 +918,7 @@ program.on('option:verbose', function () {
 program.parse(process.argv); // 指明，按 node 约定
 program.parse(); // 默认，自动识别 electron
 program.parse(['-f', 'filename'], { from: 'user' });
+program.parse([], { from: 'user', env: { PORT: '80' } }); // 使用自定义环境变量替代 process.env
 ```
 
 ### 解析配置

--- a/lib/command.js
+++ b/lib/command.js
@@ -57,6 +57,7 @@ export class Command extends EventEmitter {
     this._showHelpAfterError = false;
     this._showSuggestionAfterError = true;
     this._savedState = null; // used in save/restoreStateBeforeParse
+    this._parseEnv = undefined;
 
     // see configureOutput() for docs
     this._outputConfiguration = {
@@ -986,6 +987,10 @@ Expecting one of '${allowedValues.join("', '")}'`);
    * Get user arguments from implied or explicit arguments.
    * Side-effects: set _scriptPath if args included script. Used for default program name, and subcommand searches.
    *
+   * @param {string[]} [argv]
+   * @param {object} [parseOptions]
+   * @param {string} [parseOptions.from] - where the args are from: 'node', 'user', 'electron'
+   * @param {Record<string, string | undefined>} [parseOptions.env] - custom environment variables to use instead of process.env
    * @private
    */
 
@@ -994,6 +999,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
       throw new Error('first parameter to parse must be array or undefined');
     }
     parseOptions = parseOptions || {};
+    this._parseEnv = parseOptions.env;
 
     // auto-detect argument conventions if nothing supplied
     if (argv === undefined && parseOptions.from === undefined) {
@@ -1075,6 +1081,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
    * @param {string[]} [argv] - optional, defaults to process.argv
    * @param {object} [parseOptions] - optionally specify style of options with from: node/user/electron
    * @param {string} [parseOptions.from] - where the args are from: 'node', 'user', 'electron'
+   * @param {Record<string, string | undefined>} [parseOptions.env] - custom environment variables to use instead of process.env
    * @return {Command} `this` command for chaining
    */
 
@@ -1103,7 +1110,8 @@ Expecting one of '${allowedValues.join("', '")}'`);
    *
    * @param {string[]} [argv]
    * @param {object} [parseOptions]
-   * @param {string} parseOptions.from - where the args are from: 'node', 'user', 'electron'
+   * @param {string} [parseOptions.from] - where the args are from: 'node', 'user', 'electron'
+   * @param {Record<string, string | undefined>} [parseOptions.env] - custom environment variables to use instead of process.env
    * @return {Promise}
    */
 
@@ -1177,6 +1185,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
     this._name = this._savedState._name;
     this._scriptPath = null;
     this.rawArgs = [];
+    this._parseEnv = undefined;
     // clear state from setOptionValueWithSource
     this._optionValues = { ...this._savedState._optionValues };
     this._optionValueSources = { ...this._savedState._optionValueSources };
@@ -1970,14 +1979,29 @@ Expecting one of '${allowedValues.join("', '")}'`);
   }
 
   /**
+   * Return the environment variables to use for option lookups, either
+   * from parse options or fallback to process.env.
+   *
+   * @return {Record<string, string | undefined>}
+   * @private
+   */
+  _getParseEnv() {
+    for (const cmd of this._getCommandAndAncestors()) {
+      if (cmd._parseEnv !== undefined) return cmd._parseEnv;
+    }
+    return process.env;
+  }
+
+  /**
    * Apply any option related environment variables, if option does
    * not have a value from cli or client code.
    *
    * @private
    */
   _parseOptionsEnv() {
+    const env = this._getParseEnv();
     this.options.forEach((option) => {
-      if (option.envVar && option.envVar in process.env) {
+      if (option.envVar && option.envVar in env) {
         const optionKey = option.attributeName();
         // Priority check. Do not overwrite cli or options from unknown source (client-code).
         if (
@@ -1989,7 +2013,7 @@ Expecting one of '${allowedValues.join("', '")}'`);
           if (option.required || option.optional) {
             // option can take a value
             // keep very simple, optional always takes value
-            this.emit(`optionEnv:${option.name()}`, process.env[option.envVar]);
+            this.emit(`optionEnv:${option.name()}`, env[option.envVar]);
           } else {
             // boolean
             // keep very simple, only care that envVar defined and not the value

--- a/tests/options.env.test.js
+++ b/tests/options.env.test.js
@@ -368,4 +368,77 @@ describe('Option.env()', () => {
       delete process.env.BAR;
     });
   });
+
+  describe('custom env in parseOptions', () => {
+    test('when custom env specified with option value then option from custom env', () => {
+      const program = new commander.Command();
+      program.addOption(new commander.Option('-f, --foo <value>').env('BAR'));
+      program.parse([], { from: 'user', env: { BAR: 'custom_env' } });
+      assert.equal(program.opts().foo, 'custom_env');
+    });
+
+    test('when custom env specified with boolean flag then option true', () => {
+      const program = new commander.Command();
+      program.addOption(new commander.Option('-f, --foo').env('BAR'));
+      program.parse([], { from: 'user', env: { BAR: '1' } });
+      assert.equal(program.opts().foo, true);
+    });
+
+    test('when custom env specified and process.env set then option from custom env', () => {
+      const program = new commander.Command();
+      process.env.BAR = 'process_env';
+      program.addOption(new commander.Option('-f, --foo <value>').env('BAR'));
+      program.parse([], { from: 'user', env: { BAR: 'custom_env' } });
+      assert.equal(program.opts().foo, 'custom_env');
+      delete process.env.BAR;
+    });
+
+    test('when custom env is empty object and process.env is set then option undefined', () => {
+      const program = new commander.Command();
+      process.env.BAR = 'process_env';
+      program.addOption(new commander.Option('-f, --foo <value>').env('BAR'));
+      program.parse([], { from: 'user', env: {} });
+      assert.equal(program.opts().foo, undefined);
+      delete process.env.BAR;
+    });
+
+    test('when custom env and cli defined then option from cli', () => {
+      const program = new commander.Command();
+      program.addOption(new commander.Option('-f, --foo <value>').env('BAR'));
+      program.parse(['--foo', 'cli'], {
+        from: 'user',
+        env: { BAR: 'custom_env' },
+      });
+      assert.equal(program.opts().foo, 'cli');
+    });
+
+    test('when custom env on parent command then subcommand inherits custom env', () => {
+      const program = new commander.Command();
+      const sub = program.command('sub');
+      sub.addOption(new commander.Option('-f, --foo <value>').env('BAR'));
+      program.parse(['sub'], { from: 'user', env: { BAR: 'sub_env' } });
+      assert.equal(sub.opts().foo, 'sub_env');
+    });
+
+    test('when custom env passed to parseAsync then option from custom env', async () => {
+      const program = new commander.Command();
+      program.addOption(new commander.Option('-f, --foo <value>').env('BAR'));
+      await program.parseAsync([], { from: 'user', env: { BAR: 'async_env' } });
+      assert.equal(program.opts().foo, 'async_env');
+    });
+
+    test('when custom env in first parse then subsequent parse without env uses process.env', () => {
+      const program = new commander.Command();
+      process.env.BAR = 'real_env';
+      program.addOption(new commander.Option('-f, --foo <value>').env('BAR'));
+
+      program.parse([], { from: 'user', env: { BAR: 'custom_env' } });
+      assert.equal(program.opts().foo, 'custom_env');
+
+      program.parse([], { from: 'user' });
+      assert.equal(program.opts().foo, 'real_env');
+
+      delete process.env.BAR;
+    });
+  });
 });

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -339,7 +339,8 @@ export class Help {
 export type HelpConfiguration = Partial<Help>;
 
 export interface ParseOptions {
-  from: 'node' | 'electron' | 'user';
+  from?: 'node' | 'electron' | 'user';
+  env?: Record<string, string | undefined>;
 }
 export interface HelpContext {
   // optional parameter for .help() and .outputHelp()

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -347,6 +347,12 @@ expectType<commander.Command>(
   program.parse(['node', 'script.js'], { from: 'electron' }),
 );
 expectType<commander.Command>(program.parse(['--option'], { from: 'user' }));
+expectType<commander.Command>(
+  program.parse(['--option'], { from: 'user', env: { FOO: 'bar' } }),
+);
+expectType<commander.Command>(
+  program.parse(['--option'], { env: process.env }),
+);
 expectType<commander.Command>(program.parse(['node', 'script.js'] as const));
 
 // parseAsync, same tests as parse
@@ -360,6 +366,12 @@ expectType<Promise<commander.Command>>(
 );
 expectType<Promise<commander.Command>>(
   program.parseAsync(['--option'], { from: 'user' }),
+);
+expectType<Promise<commander.Command>>(
+  program.parseAsync(['--option'], { from: 'user', env: { FOO: 'bar' } }),
+);
+expectType<Promise<commander.Command>>(
+  program.parseAsync(['--option'], { env: process.env }),
 );
 expectType<Promise<commander.Command>>(
   program.parseAsync(['node', 'script.js'] as const),

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -351,7 +351,7 @@ expectType<commander.Command>(
   program.parse(['--option'], { from: 'user', env: { FOO: 'bar' } }),
 );
 expectType<commander.Command>(
-  program.parse(['--option'], { env: process.env }),
+  program.parse(['node', 'script.js', '--option'], { env: process.env }),
 );
 expectType<commander.Command>(program.parse(['node', 'script.js'] as const));
 
@@ -371,7 +371,7 @@ expectType<Promise<commander.Command>>(
   program.parseAsync(['--option'], { from: 'user', env: { FOO: 'bar' } }),
 );
 expectType<Promise<commander.Command>>(
-  program.parseAsync(['--option'], { env: process.env }),
+  program.parseAsync(['node', 'script.js', '--option'], { env: process.env }),
 );
 expectType<Promise<commander.Command>>(
   program.parseAsync(['node', 'script.js'] as const),


### PR DESCRIPTION
## Problem

Resolves #2549

Currently, options configured with \.env()\ always read values directly from \process.env\. In testing scenarios or when wrapping Commander in custom application contexts, modifying \process.env\ globally requires manual setup and cleanup. Allowing a custom \env\ dictionary to be passed via \parseOptions\ provides a clean and predictable way to supply environment variables.

## Solution

- Added optional \env\ property to \ParseOptions\ for \.parse()\ and \.parseAsync()\.
- When \env\ is provided, options declared with \.env()\ read from the supplied object instead of \process.env\.
- Subcommands inherit \env\ configured on parent commands.
- State is properly saved and restored across multiple \.parse()\ calls.
- Updated TypeScript typings (\ParseOptions.env?: Record<string, string | undefined>\), \	sd\ tests, JSDoc documentation, and \Readme.md\ / \Readme_zh-CN.md\.
- Added unit tests in \	ests/options.env.test.js\ covering custom env lookup, priority over \process.env\, CLI precedence, subcommand inheritance, \parseAsync\, and state restoration.

## Testing

- \
pm test\ passed (100% tests pass).
- \
pm run check\ passed (\check:type\, \check:lint\, \check:format\).

## Suggested Changelog

- Added: \env\ property in \ParseOptions\ to specify custom environment variables for \.parse()\ and \.parseAsync()\ (#2549)