### PR TITLE
fix: do not use electron argv parsing with ELECTRON_RUN_AS_NODE

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -997,7 +997,10 @@ Expecting one of '${allowedValues.join("', '")}'`);
 
     // auto-detect argument conventions if nothing supplied
     if (argv === undefined && parseOptions.from === undefined) {
-      if (process.versions?.electron) {
+      // ELECTRON_RUN_AS_NODE makes Electron behave as plain Node (script.js is
+      // argv[1]), even though process.versions.electron is still truthy. Only
+      // use Electron argument handling when it is running as an Electron app.
+      if (process.versions?.electron && !process.env.ELECTRON_RUN_AS_NODE) {
         parseOptions.from = 'electron';
       }
       // check node specific options for scenarios where user CLI args follow executable without scriptname

--- a/tests/command.parse.test.js
+++ b/tests/command.parse.test.js
@@ -33,6 +33,25 @@ describe('Command.parse()', () => {
       assert.deepEqual(program.args, ['user']);
     });
 
+    test('when no args and electron properties but ELECTRON_RUN_AS_NODE then use process.argv and app/script/args', () => {
+      const program = new commander.Command();
+      program.argument('[args...]');
+      const holdArgv = process.argv;
+      const holdRunAsNode = process.env.ELECTRON_RUN_AS_NODE;
+      process.versions.electron = '1.2.3';
+      process.env.ELECTRON_RUN_AS_NODE = '1';
+      process.argv = 'node script.js user'.split(' ');
+      program.parse();
+      delete process.versions.electron;
+      if (holdRunAsNode === undefined) {
+        delete process.env.ELECTRON_RUN_AS_NODE;
+      } else {
+        process.env.ELECTRON_RUN_AS_NODE = holdRunAsNode;
+      }
+      process.argv = holdArgv;
+      assert.deepEqual(program.args, ['user']);
+    });
+
     test('when args then app/script/args', () => {
       const program = new commander.Command();
       program.argument('[args...]');


### PR DESCRIPTION
## Summary

`Command.parse()` mis-parses `argv` when `ELECTRON_RUN_AS_NODE` is set (#2603).

When an Electron main process spawns a JS child with `ELECTRON_RUN_AS_NODE=1`, the child runs as plain Node — the argv layout is `Electron script.js [...args]`, exactly like `node script.js [...args]`, so `script.js` is the script path, not a user argument. But `process.versions.electron` is still truthy, so auto-detection picked `from: 'electron'`; and because `process.defaultApp` is `undefined`, the script path was kept as a user argument (`argv.slice(1)`).

## Fix

Only auto-select the `electron` convention when the process is actually running as an Electron app, i.e. when `ELECTRON_RUN_AS_NODE` is **not** set:

```js
if (process.versions?.electron && !process.env.ELECTRON_RUN_AS_NODE) {
  parseOptions.from = 'electron';
}
```

This is intentionally minimal and only touches auto-detection; passing `{ from: 'electron' }` explicitly is unchanged.

## On the fragility

I saw @shadowspawn's note that this heuristic is inherently fragile — we can't know at parse time whether the executable was launched with the env var or it was set afterwards. Agreed. This guard doesn't try to solve that general case; it aligns auto-detection with the documented meaning of `ELECTRON_RUN_AS_NODE` ("run as a normal Node.js process"), which covers the common case in the report (env var set as part of the `spawn`). It's a small, spec-consistent improvement over unconditionally trusting `process.versions.electron`, and explicit `from` remains available for anything more exotic.

## Test

Added a case to `tests/command.parse.test.js` alongside the existing electron auto-detection test: with `process.versions.electron` and `ELECTRON_RUN_AS_NODE` set and `argv = 'node script.js user'`, the script path is excluded and `program.args` is `['user']`. Confirmed it fails before the fix and passes after.

`npm test` (node --test) green — 1373 passing.

Fixes #2603
