### PR TITLE
test: isolate color environment in configureOutput tests

### DIFF
--- a/tests/command.configureOutput.test.js
+++ b/tests/command.configureOutput.test.js
@@ -342,18 +342,30 @@ describe('Command.configureOutput()', () => {
       ['FORCE_COLOR', true],
       ['CLICOLOR_FORCE', true],
     ];
+    const originalEnv = testCases.map(([envvar]) => [
+      envvar,
+      process.env[envvar],
+    ]);
+    t.beforeEach(() => {
+      for (const [envvar] of originalEnv) {
+        delete process.env[envvar];
+      }
+    });
+    t.afterEach(() => {
+      for (const [envvar, value] of originalEnv) {
+        if (value === undefined) delete process.env[envvar];
+        else process.env[envvar] = value;
+      }
+    });
     for (const [envvar, expected] of testCases) {
       await t.test(
         `when ${envvar} then getFooHasColors returns ${expected}`,
         () => {
           // Would like to vary process.istty too, but too hard, so tests here provide only partial cover.
-          const holdEnv = process.env[envvar];
           process.env[envvar] = '1';
           const config = new commander.Command().configureOutput();
           assert.equal(config.getOutHasColors(), expected);
           assert.equal(config.getErrHasColors(), expected);
-          if (holdEnv === undefined) delete process.env[envvar];
-          else process.env[envvar] = holdEnv;
         },
       );
     }

--- a/tests/command.configureOutput.test.js
+++ b/tests/command.configureOutput.test.js
@@ -351,7 +351,7 @@ describe('Command.configureOutput()', () => {
         delete process.env[envvar];
       }
     });
-    t.afterEach(() => {
+    t.after(() => {
       for (const [envvar, value] of originalEnv) {
         if (value === undefined) delete process.env[envvar];
         else process.env[envvar] = value;


### PR DESCRIPTION
Running the tests from a shell with `NO_COLOR=1` makes the two configureOutput force-color cases fail, even though Commander correctly gives `NO_COLOR` precedence. With `FORCE_COLOR=0`, the CLICOLOR_FORCE case also inherits a conflicting setting. The tests currently save and replace only the variable they are testing.

Clear all three color variables before each subtest and restore their original values once in `after` when the group finishes, so inherited settings cannot change the assertions and a failed assertion still restores the environment. This changes only test setup and cleanup.

Validation on develop `97411c6`:

- Reproduced two failures with `NO_COLOR=1 node --test tests/command.configureOutput.test.js` before the change.
- The focused file passes with no color variables, each of `NO_COLOR=1`, `FORCE_COLOR=0`, `FORCE_COLOR=1`, `CLICOLOR_FORCE=1`, and all three conflicting settings together.
- `npm test`: 1,420 passing with the original `NO_COLOR=1` environment.
- `npm run check`: types, lint and formatting pass.
- The focused file also passes on the minimum supported Node 22.12.0.

Suggested changelog summary: isolate configureOutput tests from inherited color environment variables.

Implemented and validated with Codex.
